### PR TITLE
Refactor GC queue management and metrics

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -531,7 +531,7 @@ Drains the `gc_queue` table. Each item has a type; the worker dispatches accordi
 - **DLQ requeue identity preservation**: Failed items are requeued with their original `queued_at` and stable `identity_at` so cascade stale checks and semantic dedupe keep the same deletion identity when an operator retries a failed item.
 - **Cascade error propagation**: If enqueueing child items fails, the parent item is NOT deleted — the worker returns an error and the item stays in queue for retry.
 - Dry-run mode for testing (toggle at runtime via admin API); the worker logs simulated actions without consuming queued items.
-- Prometheus metrics: `gc_worker_duration`, `gc_scanner_duration`, `gc_queue_size`, `gc_blocks_deleted_total`, `gc_worker_consecutive_errors`, `gc_queue_growth_rate`, `gc_worker_last_success_timestamp_seconds`, `gc_failed_items_total`, `gc_dirty_orgs_total`, `gc_snapshot_age_seconds`, `gc_reconcile_duration_seconds`, `gc_snapshot_drift_corrected_total`, `gc_queue_counter_update_failures_total`
+- Prometheus metrics: `gc_worker_duration`, `gc_scanner_duration`, `gc_queue_size`, `gc_blocks_deleted_total`, `gc_worker_consecutive_errors`, `gc_queue_growth_rate`, `gc_worker_last_success_timestamp_seconds`, `gc_failed_items_total`, `gc_dirty_orgs_total`, `gc_snapshot_age_seconds`, `gc_reconcile_duration_seconds`, `gc_snapshot_drift_corrected_total`
 - Scanner runs immediately on startup to catch anything missed during downtime
 - Health alerting: `gc_worker_consecutive_errors` tracks sequential failures (alert if > 5), `gc_queue_growth_rate` tracks net queue growth (positive = queue growing faster than worker can drain)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -177,8 +177,9 @@ Schema is now baked into `internal/db/migrations/001_initial_schema.cql`:
   (32 hash buckets, no full-table `SELECT DISTINCT`).
 - `gc_dirty_orgs (bucket, org_id, marked_at)` — orgs needing snapshot
   reconciliation.
-- `gc_org_stats (org_id, queue_depth, failed_depth, oldest_queued_at)` —
-  per-org snapshot maintained by the reconciler.
+- `gc_org_stats (org_id, queue_depth, failed_depth, oldest_queued_at,
+  recalculated_at)` — per-org snapshot maintained by background exact
+  recalculation from canonical queue / DLQ rows.
 - `gc_failed_items (org_id, failed_at, ...)` — durable DLQ with explicit
   30-day retention via `gc_failed_items_by_expiry` and a `resolution_status`
   column for operator workflow.
@@ -188,8 +189,8 @@ Schema is now baked into `internal/db/migrations/001_initial_schema.cql`:
 ### Fix — reconciler (`internal/gc/gc.go`)
 
 - Snapshot is read by `Status()` from `gc_stats` (single-key reads, no live
-  count). Snapshot is maintained by a `reconcileDirtyQueueStats` pass that
-  runs at the end of every worker tick and every scanner tick.
+  count). Snapshot is maintained by a serialized dirty-org refresh pass; exact
+  recounts happen off the write path and are throttled by `recalculated_at`.
 - The reconciler is serialized via `reconcileMu` so concurrent worker /
   scanner / admin paths cannot corrupt the global totals via interleaved
   read-modify-write cycles.

--- a/docs/GC-SERVICE-ANALYSIS.md
+++ b/docs/GC-SERVICE-ANALYSIS.md
@@ -209,13 +209,11 @@ the read executes, the count could be back at 1.
 So this is a false-positive enqueue (block enqueued for deletion but LWT skips it),
 not a data loss scenario. The cost is a wasted queue entry that gets cleaned up.
 
-### PARTIAL: Counter drift hot path removed; repair still required
+### RESOLVED: Hot exact recounts removed without Cassandra COUNTER
 
 **Status:** Hot `COUNT(*)` reads are removed from normal status/reconcile paths,
-the baseline now includes `gc_queue_counter_reconciliation`: queue/DLQ mutations
-write a per-org repair marker in the same logged batch, and the scanner
-recomputes queue/failed depths from canonical rows for
-production multi-node operation.
+and the baseline schema no longer depends on Cassandra `COUNTER` tables for
+GC queue/DLQ depth snapshots.
 
 **Original problem:** the `gc_queue_stats` Cassandra counter table was updated
 in a separate batch from queue mutations. Drift accumulated whenever (a) the
@@ -227,21 +225,21 @@ held 0 rows.
 
 **New design:**
 - `gc_queue_stats` is dropped. Snapshots live in `gc_stats` (per-key) and
-  `gc_org_stats` (per-org). The baseline schema also keeps approximate
-  per-org/per-bucket write-path counters in `gc_org_queue_counters` so status
-  reconciliation does not need hot `COUNT(*)` reads over `gc_queue` or
-  `gc_failed_items`.
+  `gc_org_stats` (per-org, with `recalculated_at` for throttling).
 - `gc_failed_items` no longer relies on Cassandra TTL. Failed items carry
   `expires_at` and are discovered through `gc_failed_items_by_expiry`; the
-  scanner deletes expired rows through the GC store so `failed_depth` counters
-  and `gc_pending_items` markers are decremented together.
-- Mutations write to `gc_dirty_orgs`. A serialized reconciler iterates dirty
-  orgs each worker/scanner tick, loads queue/DLQ depth from
-  `gc_org_queue_counters`, saves the per-org row, and applies the delta to the
-  global `gc_stats` totals.
+  scanner deletes expired rows through the GC store so DLQ rows and
+  `gc_pending_items` markers move together.
+- Mutations write only canonical rows plus `gc_active_orgs` / `gc_dirty_orgs`.
+  A serialized refresh pass exact-recalculates a limited dirty-org batch from
+  canonical `gc_queue` / `gc_failed_items` rows, saves the per-org snapshot,
+  and applies the delta to the global `gc_stats` totals.
+- Worker drain decisions do not trust snapshots destructively. The worker uses
+  `GetOldestQueuedAt` as the real confirmation before removing an org from
+  `gc_active_orgs`.
 - Every 10 reconciler passes a full `SUM(queue_depth) FROM gc_org_stats` runs
   as a snapshot safety net; mismatches overwrite the totals and bump
-  `gc_snapshot_drift_corrected_total`. This does not compare counters against
+  `gc_snapshot_drift_corrected_total`. This does not compare snapshots against
   live queue/DLQ rows.
 - Admin DLQ mutations require leadership and serialize through `dlqOpsMu` so
   the non-atomic `RequeueFailedItem` cannot duplicate queue rows under
@@ -249,7 +247,7 @@ held 0 rows.
 
 **New Prometheus metrics:** `gc_failed_items_total`, `gc_dirty_orgs_total`,
 `gc_snapshot_age_seconds`, `gc_snapshot_drift_corrected_total`,
-`gc_queue_counter_update_failures_total`, `gc_reconcile_duration_seconds`.
+`gc_reconcile_duration_seconds`.
 
 `/api/v2.1/admin/gc/status/` now exposes `queue_size`, `failed_items_total`,
 `dirty_orgs_total`, `snapshot_age_seconds` (-1 when no reconcile has run yet),

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1340,7 +1340,7 @@ The GC (worker + scanner) has no coordination mechanism between instances. If mu
 
 1. **DequeueBatch without locking**: `SELECT ... LIMIT ?` returns the same items to all instances. Both process the same items simultaneously.
 2. **Scanner without leader election**: Multiple scanners enqueue the same orphans as duplicates (the PK includes `queued_at = time.Now()`, so each INSERT creates a distinct row).
-3. **Snapshot drift** (substantially resolved): the original `gc_queue_stats` counter table was retired from the baseline schema. Queue/DLQ totals now live in `gc_stats` and are reconciled per dirty org by a serialized reconciler. Hot `COUNT(*)` reads are gone, DLQ expiry is explicit, and `gc_queue_counter_reconciliation` gives the scanner a durable counter-vs-row repair path before refreshed snapshots are trusted. See ARCHITECTURE.md / GC-SERVICE-ANALYSIS.md.
+3. **Snapshot drift** (substantially resolved): the original `gc_queue_stats` counter table was retired from the baseline schema. Queue/DLQ totals now live in `gc_stats` and `gc_org_stats`, dirty orgs are exact-recalculated from canonical rows off the write path, hot `COUNT(*)` reads are gone, and DLQ expiry is explicit. Snapshots remain approximate until the background/admin refresh runs. See ARCHITECTURE.md / GC-SERVICE-ANALYSIS.md.
 
 **Is there data loss?** No. Destructive operations are protected:
 - `DeleteBlock` uses a claim-then-verify delete fence: only one instance can win the claim, and the winner re-checks live `block_references` before touching S3
@@ -2705,10 +2705,10 @@ Even when the application query does not literally contain `ALLOW FILTERING`, Ca
 - Counter-backed status must stay explicitly approximate unless paired with a scrub/repair path: the retired counter design drifted because drift was structural, not incidental
 
 **Safe direction for a future fix:**
-1. Remove exact `gc_queue` recounts from the hot reconcile/status path - done in the baseline schema by loading `gc_org_queue_counters`.
-2. Maintain `queue_depth`/`failed_depth` counters on the write path where queue rows are inserted/deleted/moved - done for normal Cassandra GC store mutations.
+1. Remove exact `gc_queue` recounts from the hot reconcile/status path - done.
+2. Keep queue/DLQ writes focused on canonical rows plus dirty/active markers - done.
 3. Avoid invisible DLQ expiry - done by replacing Cassandra TTL with `gc_failed_items_by_expiry` and scanner-driven deletes.
-4. Keep a separate, infrequent scrub/reconciliation path to repair any counter drift explicitly - done in the baseline schema via `gc_queue_counter_reconciliation`.
+4. Keep exact recounts in background/admin refresh, throttled by snapshot recency - done.
 
 **Related worker note:**
 The worker behavior in `internal/gc/worker.go` that removes an org from `gc_active_orgs` when `len(items) < batchSize` should remain in place.
@@ -2716,8 +2716,7 @@ The worker behavior in `internal/gc/worker.go` that removes an org from `gc_acti
 That change addresses a different problem: stale active-org entries causing repeated empty dequeues. It does **not** introduce the `COUNT(*)` issue and remains safe because removal is guarded by the `last_enqueued_at` timestamp semantics.
 
 **Current recommendation:**
-- Treat the hot-path `COUNT(*)` removal and explicit DLQ expiry as implemented, then validate under multi-instance/multinode load
-- Monitor `gc_queue_counter_reconciliation` backlog and `gc_queue_counter_update_failures_total` before relying on counters as the only recovery mechanism
+- Treat the hot-path `COUNT(*)` removal and explicit DLQ expiry as implemented, then validate dirty-org backlog drain and snapshot staleness under multi-instance/multinode load
 - Do not revert the current worker short-batch active-set removal
 - Do not add new hot-path exact recounts over `gc_queue`
 

--- a/docs/PENDING-ISSUES-AUDIT-2026-05-14.md
+++ b/docs/PENDING-ISSUES-AUDIT-2026-05-14.md
@@ -120,17 +120,17 @@ Evidence:
 
 Recommendation: either implement real batch move or return 501 for all batch moves until it is real. Returning false success is the dangerous part.
 
-### 5. GC queue exact recounts replaced by write-path counters
+### 5. GC queue exact recounts moved out of the hot path
 
-Resolved in the baseline schema hardening branch for the hot path. GC now has leadership, the hot/status/reconcile paths no longer exact-count every queue bucket, DLQ retention is explicit instead of Cassandra TTL-driven, and `gc_queue_counter_reconciliation` gives the scanner a durable counter-vs-row repair path.
+Resolved in the baseline schema hardening branch without Cassandra counters. GC now has leadership, the hot/status/reconcile paths no longer exact-count every queue bucket, DLQ retention is explicit instead of Cassandra TTL-driven, and exact queue/DLQ snapshot refresh happens from dirty-org markers plus `recalculated_at` throttling.
 
 Evidence:
-- `internal/gc/gc.go` reads queue and failed depths through the explicit counter-snapshot API backed by `gc_org_queue_counters`.
+- `internal/gc/gc.go` serves cheap snapshots from `gc_stats` / `gc_org_stats` and exact-recalculates dirty orgs off the write path.
 - `internal/gc/store_cassandra.go` no longer executes `SELECT COUNT(*) FROM gc_queue` or `SELECT COUNT(*) FROM gc_failed_items` in the GC status/reconcile path.
-- `internal/db/migrations/001_initial_schema.cql` defines `gc_org_queue_counters` with `(org_id, bucket)` partitions and `COUNTER` columns for queue and failed depth.
-- `internal/db/migrations/001_initial_schema.cql` keeps `gc_failed_items` durable and adds `gc_failed_items_by_expiry`; the scanner expires DLQ rows through the store so counters are decremented.
+- `internal/db/migrations/001_initial_schema.cql` keeps `gc_org_stats` as the per-org snapshot row and adds `recalculated_at`; there is no `gc_org_queue_counters` table in the baseline schema.
+- `internal/db/migrations/001_initial_schema.cql` keeps `gc_failed_items` durable and adds `gc_failed_items_by_expiry`; the scanner expires DLQ rows through the store.
 
-Recommendation: validate counter drift behavior and repair backlog drain under multi-instance/multinode load before treating snapshots as authoritative SLO inputs.
+Recommendation: validate dirty-org backlog drain and snapshot staleness under multi-instance/multinode load before treating snapshots as authoritative SLO inputs.
 
 ### 6. Public/upload-link resume semantics remain fragile
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -99,7 +99,7 @@ cross-process races by default.
 Keep background GC isolated to the primary `sesamefs` service in that profile.
 `sesamefs-node-2` and `sesamefs-node-3` must keep `GC_ENABLED=false`, or GC-
 sensitive integration tests become nondeterministic because secondary nodes can
-reconcile queue counters, requeue failed items, or purge expired share links in
+refresh dirty GC snapshots, requeue failed items, or purge expired share links in
 parallel.
 
 ### Current Multi-Instance Coverage Gaps

--- a/internal/db/migrations/001_initial_schema.cql
+++ b/internal/db/migrations/001_initial_schema.cql
@@ -1113,31 +1113,8 @@ CREATE TABLE IF NOT EXISTS gc_org_stats (
     queue_depth      INT,
     failed_depth     INT,
     oldest_queued_at TIMESTAMP,
-    updated_at       TIMESTAMP
-);
-
--- Approximate queue-depth counters maintained on the GC write path. These keep
--- admin/status snapshots off expensive COUNT(*) reads over tombstone-heavy
--- gc_queue/gc_failed_items partitions. Queue correctness still lives in
--- gc_queue, gc_failed_items, and gc_pending_items.
-CREATE TABLE IF NOT EXISTS gc_org_queue_counters (
-    org_id       UUID,
-    bucket       INT,
-    queue_depth  COUNTER,
-    failed_depth COUNTER,
-    PRIMARY KEY ((org_id, bucket))
-);
-
--- Durable repair queue for best-effort GC counters. Queue/DLQ mutations add a
--- per-org marker in the same logged batch, then the scanner periodically
--- recomputes exact queue/failed depths from canonical rows and applies counter
--- deltas. This closes the crash window between row mutation and counter write.
-CREATE TABLE IF NOT EXISTS gc_queue_counter_reconciliation (
-    bucket       INT,
-    org_id       UUID,
-    requested_at TIMESTAMP,
-    reason       TEXT,
-    PRIMARY KEY ((bucket), org_id)
+    updated_at       TIMESTAMP,
+    recalculated_at TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS gc_failed_items (

--- a/internal/db/migrator_test.go
+++ b/internal/db/migrator_test.go
@@ -145,8 +145,6 @@ func TestInitialSchemaContainsLookupNameAndStarredIndex(t *testing.T) {
 	assert.Contains(t, content, "CREATE TABLE IF NOT EXISTS gc_active_orgs")
 	assert.Contains(t, content, "CREATE TABLE IF NOT EXISTS gc_dirty_orgs")
 	assert.Contains(t, content, "CREATE TABLE IF NOT EXISTS gc_org_stats")
-	assert.Contains(t, content, "CREATE TABLE IF NOT EXISTS gc_org_queue_counters")
-	assert.Contains(t, content, "CREATE TABLE IF NOT EXISTS gc_queue_counter_reconciliation")
 	assert.Contains(t, content, "CREATE TABLE IF NOT EXISTS gc_failed_items")
 	assert.Contains(t, content, "CREATE TABLE IF NOT EXISTS gc_failed_items_by_expiry")
 	assert.Contains(t, content, "CREATE TABLE IF NOT EXISTS gc_pending_items")
@@ -155,8 +153,7 @@ func TestInitialSchemaContainsLookupNameAndStarredIndex(t *testing.T) {
 	assert.Contains(t, content, "CREATE TABLE IF NOT EXISTS gc_s3_orphans_by_day")
 	assert.Contains(t, content, "CREATE TABLE IF NOT EXISTS gc_leases")
 	assert.Contains(t, content, "gc_claim_id   TEXT")
-	assert.Contains(t, normalizedContent, "CREATE TABLE IF NOT EXISTS gc_org_queue_counters (\n    org_id       UUID,\n    bucket       INT,\n    queue_depth  COUNTER,\n    failed_depth COUNTER,\n    PRIMARY KEY ((org_id, bucket))\n);")
-	assert.Contains(t, normalizedContent, "CREATE TABLE IF NOT EXISTS gc_queue_counter_reconciliation (\n    bucket       INT,\n    org_id       UUID,\n    requested_at TIMESTAMP,\n    reason       TEXT,\n    PRIMARY KEY ((bucket), org_id)\n);")
+	assert.Contains(t, normalizedContent, "CREATE TABLE IF NOT EXISTS gc_org_stats (\n    org_id           UUID PRIMARY KEY,\n    queue_depth      INT,\n    failed_depth     INT,\n    oldest_queued_at TIMESTAMP,\n    updated_at       TIMESTAMP,\n    recalculated_at TIMESTAMP\n);")
 	assert.Contains(t, normalizedContent, "CREATE TABLE IF NOT EXISTS gc_failed_items_by_expiry (\n    expiry_day DATE,\n    bucket     INT,\n    expires_at TIMESTAMP,\n    org_id     UUID,\n    failed_at  TIMESTAMP,\n    item_type  TEXT,\n    item_id    TEXT,\n    PRIMARY KEY ((expiry_day, bucket), expires_at, org_id, failed_at, item_type, item_id)\n) WITH CLUSTERING ORDER BY (expires_at ASC, org_id ASC, failed_at ASC, item_type ASC, item_id ASC)\n  AND default_time_to_live = 0;")
 	assert.Contains(t, normalizedContent, "CREATE TABLE IF NOT EXISTS gc_pending_items (\n    org_id      UUID,\n    bucket      INT,\n    item_type   TEXT,\n    library_id  UUID,\n    item_id     TEXT,\n    identity_at TIMESTAMP,\n    PRIMARY KEY ((org_id, bucket), item_type, library_id, item_id, identity_at)\n) WITH default_time_to_live = 0;")
 	// `blocks` and related tables must use per-block partitioning to avoid

--- a/internal/gc/gc.go
+++ b/internal/gc/gc.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"sort"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -117,6 +116,7 @@ const (
 	gcAutoRetryFailedItemLimit   = 100
 	gcSnapshotDriftCheckEvery    = 10
 	gcActiveOrgRecoveryEvery     = 10
+	gcMinSnapshotRecalcInterval  = time.Minute
 )
 
 var ErrNotLeader = errors.New("gc leadership required")
@@ -385,9 +385,9 @@ func (s *Service) loadStatString(key string) string {
 	return val
 }
 
-// RefreshFailedItemSnapshot repairs stale failed-item counters derived from
-// gc_org_stats/gc_stats. This is needed because gc_failed_items rows expire via
-// TTL and those expirations do not mark orgs dirty on their own.
+// RefreshFailedItemSnapshot forces an exact refresh of failed-item-related
+// queue snapshots before admin/status views read them. This is intentionally
+// heavier than GetOrgQueueStats and should stay off the mutation hot path.
 func (s *Service) RefreshFailedItemSnapshot() {
 	s.reconcileMu.Lock()
 	defer s.reconcileMu.Unlock()
@@ -501,7 +501,7 @@ func (s *Service) runWorkerOnce(ctx context.Context) {
 	}
 	s.persistStats()
 
-	s.reconcileDirtyQueueStats(s.reconcileLimit())
+	s.reconcileDirtyQueueStats(s.reconcileLimit(), s.queueSnapshotRecalcMinInterval())
 
 	queueAfter := s.loadStatInt(gcStatKeyTotalQueue)
 	metrics.GCQueueSize.Set(float64(queueAfter))
@@ -513,8 +513,17 @@ func (s *Service) runWorkerOnce(ctx context.Context) {
 }
 
 func (s *Service) shouldRecoverMissingActiveQueueOrgs(queueBefore int) (string, bool) {
+	dirtyHint := false
 	if queueBefore <= 0 {
-		return "", false
+		dirtyOrgs, err := s.store.ListDirtyOrgs(1)
+		if err != nil {
+			log.Printf("[GC] Failed to list dirty orgs for recovery trigger: %v", err)
+			return "", false
+		}
+		if len(dirtyOrgs) == 0 {
+			return "", false
+		}
+		dirtyHint = true
 	}
 
 	activeOrgs, err := s.store.ListOrgsWithQueuedItems()
@@ -523,8 +532,12 @@ func (s *Service) shouldRecoverMissingActiveQueueOrgs(queueBefore int) (string, 
 		return "", false
 	}
 	if len(activeOrgs) == 0 {
-		metrics.GCActiveOrgRecoveryTriggersTotal.WithLabelValues("no_active_orgs").Inc()
-		return "no_active_orgs", true
+		reason := "no_active_orgs"
+		if dirtyHint {
+			reason = "dirty_orgs"
+		}
+		metrics.GCActiveOrgRecoveryTriggersTotal.WithLabelValues(reason).Inc()
+		return reason, true
 	}
 	if s.workerPasses%gcActiveOrgRecoveryEvery == 0 {
 		metrics.GCActiveOrgRecoveryTriggersTotal.WithLabelValues("periodic").Inc()
@@ -539,7 +552,12 @@ func (s *Service) recoverMissingActiveQueueOrgs(reason string) {
 		log.Printf("[GC] Failed to list queued snapshots for active-set recovery: %v", err)
 		return
 	}
-	if len(snapshotOrgs) == 0 {
+	dirtyOrgs, err := s.store.ListDirtyOrgs(0)
+	if err != nil {
+		log.Printf("[GC] Failed to list dirty orgs for active-set recovery: %v", err)
+		return
+	}
+	if len(snapshotOrgs) == 0 && len(dirtyOrgs) == 0 {
 		return
 	}
 
@@ -552,15 +570,30 @@ func (s *Service) recoverMissingActiveQueueOrgs(reason string) {
 	for _, orgID := range activeOrgs {
 		activeSet[orgID] = struct{}{}
 	}
+	candidateSet := make(map[uuid.UUID]struct{}, len(snapshotOrgs)+len(dirtyOrgs))
+	for _, orgID := range snapshotOrgs {
+		candidateSet[orgID] = struct{}{}
+	}
+	for _, dirtyOrg := range dirtyOrgs {
+		candidateSet[dirtyOrg.OrgID] = struct{}{}
+	}
 
 	now := time.Now().UTC()
 	recovered := 0
-	for _, orgID := range snapshotOrgs {
+	for orgID := range candidateSet {
 		if _, ok := activeSet[orgID]; ok {
 			continue
 		}
+		oldestQueuedAt, oldestErr := s.store.GetOldestQueuedAt(orgID)
+		if oldestErr != nil {
+			log.Printf("[GC] Failed to probe queued rows for active-set recovery org %s: %v", orgID, oldestErr)
+			continue
+		}
+		if oldestQueuedAt == nil {
+			continue
+		}
 		if err := s.store.MarkOrgActive(orgID, now); err != nil {
-			log.Printf("[GC] Failed to re-mark org %s active from queued snapshot: %v", orgID, err)
+			log.Printf("[GC] Failed to re-mark org %s active during recovery: %v", orgID, err)
 			continue
 		}
 		if err := s.store.MarkOrgDirty(orgID, now); err != nil {
@@ -570,7 +603,7 @@ func (s *Service) recoverMissingActiveQueueOrgs(reason string) {
 	}
 	if recovered > 0 {
 		metrics.GCActiveOrgRecoveriesTotal.WithLabelValues(reason).Add(float64(recovered))
-		log.Printf("[GC] Recovered %d queued org(s) into active set from gc_org_stats (reason=%s)", recovered, reason)
+		log.Printf("[GC] Recovered %d queued org(s) into active set from GC snapshots/dirty markers (reason=%s)", recovered, reason)
 	}
 }
 
@@ -612,7 +645,7 @@ func (s *Service) runScannerOnce(ctx context.Context) {
 		log.Printf("[GC Scanner] Auto-requeued %d recoverable failed items", retried)
 		s.TriggerWorker()
 	}
-	s.reconcileDirtyQueueStats(s.reconcileLimit())
+	s.reconcileDirtyQueueStats(s.reconcileLimit(), s.queueSnapshotRecalcMinInterval())
 	metrics.GCScannerDuration.Observe(time.Since(start).Seconds())
 	metrics.GCLastScannerRun.Set(float64(time.Now().Unix()))
 }
@@ -724,101 +757,71 @@ func (s *Service) saveStatInt(key string, value int) {
 	}
 }
 
-func (s *Service) reconcileDirtyQueueStats(limit int) {
-	s.reconcileMu.Lock()
-	defer s.reconcileMu.Unlock()
+type gcSnapshotCandidate struct {
+	OrgID          uuid.UUID
+	DirtyBefore    time.Time
+	HasDirtyMarker bool
+	ForceRefresh   bool
+}
 
+func (s *Service) queueSnapshotRecalcMinInterval() time.Duration {
+	interval := 2 * s.config.WorkerInterval
+	if interval < gcMinSnapshotRecalcInterval {
+		return gcMinSnapshotRecalcInterval
+	}
+	return interval
+}
+
+func (s *Service) reconcileSnapshotCandidatesLocked(candidates []gcSnapshotCandidate, minInterval time.Duration) {
 	start := time.Now()
 	defer func() {
 		metrics.GCReconcileDuration.Observe(time.Since(start).Seconds())
 	}()
 
-	dirtyOrgs, err := s.store.ListDirtyOrgs(limit)
-	if err != nil {
-		log.Printf("[GC] Failed to list dirty orgs: %v", err)
-		return
-	}
-	metrics.GCDirtyOrgsTotal.Set(float64(len(dirtyOrgs)))
-
 	totalQueue := s.loadStatInt(gcStatKeyTotalQueue)
 	totalFailed := s.loadStatInt(gcStatKeyTotalFailed)
-	remainingDirtyCount := len(dirtyOrgs)
 
-	if len(dirtyOrgs) > 0 {
-		for _, dirtyOrg := range dirtyOrgs {
-			snapshotAt := time.Now().UTC()
-			prevStats, err := s.store.GetOrgQueueStats(dirtyOrg.OrgID)
-			if err != nil {
-				log.Printf("[GC] Failed to load org queue stats for %s: %v", dirtyOrg.OrgID, err)
-				continue
+	for _, candidate := range candidates {
+		prevStats, err := s.store.GetOrgQueueStats(candidate.OrgID)
+		if err != nil {
+			log.Printf("[GC] Failed to load org queue stats for %s: %v", candidate.OrgID, err)
+			continue
+		}
+		if candidate.HasDirtyMarker && !candidate.ForceRefresh && !prevStats.RecalculatedAt.IsZero() && !prevStats.RecalculatedAt.Before(candidate.DirtyBefore) {
+			if err := s.store.ClearDirtyOrg(candidate.OrgID, candidate.DirtyBefore); err != nil {
+				log.Printf("[GC] Failed to clear already-refreshed dirty org %s: %v", candidate.OrgID, err)
 			}
-			queueDepth, err := s.store.ReadOrgQueueDepth(dirtyOrg.OrgID)
-			if err != nil {
-				log.Printf("[GC] Failed to read queue depth counters for %s: %v", dirtyOrg.OrgID, err)
-				continue
-			}
-			failedDepth, err := s.store.ReadOrgFailedDepth(dirtyOrg.OrgID)
-			if err != nil {
-				log.Printf("[GC] Failed to read failed depth counters for %s: %v", dirtyOrg.OrgID, err)
-				continue
-			}
-			oldestQueuedAt := prevStats.OldestQueuedAt
-			if queueDepth == 0 {
-				liveOldestQueuedAt, err := s.store.GetOldestQueuedAt(dirtyOrg.OrgID)
-				if err != nil {
-					log.Printf("[GC] Failed to probe live queue rows for %s before drain decision: %v", dirtyOrg.OrgID, err)
-					continue
-				}
-				if liveOldestQueuedAt != nil {
-					log.Printf("[GC] Queue counter false-zero detected for %s; preserving active state and requesting repair", dirtyOrg.OrgID)
-					if err := s.store.RequestQueueCounterReconciliation(dirtyOrg.OrgID, "reconcile_false_zero"); err != nil {
-						log.Printf("[GC] Failed to request queue counter repair for %s after false-zero: %v", dirtyOrg.OrgID, err)
-					}
-					if err := s.store.MarkOrgActive(dirtyOrg.OrgID, snapshotAt); err != nil {
-						log.Printf("[GC] Failed to preserve active org %s after false-zero: %v", dirtyOrg.OrgID, err)
-					}
-					if err := s.store.MarkOrgDirty(dirtyOrg.OrgID, snapshotAt); err != nil {
-						log.Printf("[GC] Failed to keep org %s dirty after false-zero: %v", dirtyOrg.OrgID, err)
-					}
-					continue
-				}
-				oldestQueuedAt = nil
-			}
+			continue
+		}
+		if !candidate.ForceRefresh && minInterval > 0 && !prevStats.RecalculatedAt.IsZero() && time.Since(prevStats.RecalculatedAt) < minInterval {
+			continue
+		}
 
-			nextStats := GCOrgStats{
-				OrgID:          dirtyOrg.OrgID,
-				QueueDepth:     queueDepth,
-				FailedDepth:    failedDepth,
-				OldestQueuedAt: oldestQueuedAt,
-				UpdatedAt:      snapshotAt,
-			}
-			if err := s.store.SaveOrgQueueStats(nextStats); err != nil {
-				log.Printf("[GC] Failed to save org queue stats for %s: %v", dirtyOrg.OrgID, err)
-				continue
-			}
+		nextStats, err := s.store.RecalculateOrgQueueStats(candidate.OrgID)
+		if err != nil {
+			log.Printf("[GC] Failed to recalculate org queue stats for %s: %v", candidate.OrgID, err)
+			continue
+		}
 
-			totalQueue += queueDepth - prevStats.QueueDepth
-			if totalQueue < 0 {
-				totalQueue = 0
-			}
-			totalFailed += failedDepth - prevStats.FailedDepth
-			if totalFailed < 0 {
-				totalFailed = 0
-			}
+		totalQueue += nextStats.QueueDepth - prevStats.QueueDepth
+		if totalQueue < 0 {
+			totalQueue = 0
+		}
+		totalFailed += nextStats.FailedDepth - prevStats.FailedDepth
+		if totalFailed < 0 {
+			totalFailed = 0
+		}
 
-			if err := s.store.ClearDirtyOrg(dirtyOrg.OrgID, dirtyOrg.MarkedAt); err != nil {
-				log.Printf("[GC] Failed to clear dirty org %s: %v", dirtyOrg.OrgID, err)
-			}
-			if queueDepth == 0 {
-				if err := s.store.RemoveOrgFromActiveSet(dirtyOrg.OrgID, snapshotAt); err != nil {
-					log.Printf("[GC] Failed to remove drained org %s from active set: %v", dirtyOrg.OrgID, err)
-				}
+		if nextStats.QueueDepth > 0 {
+			if err := s.store.MarkOrgActive(candidate.OrgID, nextStats.RecalculatedAt); err != nil {
+				log.Printf("[GC] Failed to preserve active org %s after snapshot refresh: %v", candidate.OrgID, err)
 			}
 		}
-	}
-
-	if err := s.refreshFailedItemSnapshotLocked(); err != nil {
-		log.Printf("[GC] Failed to repair stale failed-item snapshot: %v", err)
+		if candidate.HasDirtyMarker {
+			if err := s.store.ClearDirtyOrg(candidate.OrgID, candidate.DirtyBefore); err != nil {
+				log.Printf("[GC] Failed to clear dirty org %s: %v", candidate.OrgID, err)
+			}
+		}
 	}
 
 	s.reconcilePasses++
@@ -834,10 +837,13 @@ func (s *Service) reconcileDirtyQueueStats(limit int) {
 		}
 	}
 
-	lastRun := time.Now().UTC()
+	remainingDirtyCount := 0
 	if remainingDirty, err := s.store.ListDirtyOrgs(0); err == nil {
 		remainingDirtyCount = len(remainingDirty)
+	} else {
+		log.Printf("[GC] Failed to list dirty orgs after snapshot refresh: %v", err)
 	}
+	lastRun := time.Now().UTC()
 	s.saveStatInt(gcStatKeyTotalQueue, totalQueue)
 	s.saveStatInt(gcStatKeyTotalFailed, totalFailed)
 	s.saveStatInt(gcStatKeyTotalDirtyOrgs, remainingDirtyCount)
@@ -850,57 +856,58 @@ func (s *Service) reconcileDirtyQueueStats(limit int) {
 	metrics.GCSnapshotAgeSeconds.Set(0)
 }
 
+func (s *Service) reconcileDirtyQueueStats(limit int, minInterval time.Duration) {
+	s.reconcileMu.Lock()
+	defer s.reconcileMu.Unlock()
+
+	dirtyOrgs, err := s.store.ListDirtyOrgs(limit)
+	if err != nil {
+		log.Printf("[GC] Failed to list dirty orgs: %v", err)
+		return
+	}
+	candidates := make([]gcSnapshotCandidate, 0, len(dirtyOrgs))
+	for _, dirtyOrg := range dirtyOrgs {
+		candidates = append(candidates, gcSnapshotCandidate{
+			OrgID:          dirtyOrg.OrgID,
+			DirtyBefore:    dirtyOrg.MarkedAt,
+			HasDirtyMarker: true,
+		})
+	}
+	s.reconcileSnapshotCandidatesLocked(candidates, minInterval)
+}
+
 func (s *Service) refreshFailedItemSnapshotLocked() error {
 	snapshotOrgs, err := s.store.ListOrgsWithFailedItems(0)
 	if err != nil {
 		return err
 	}
 
-	if len(snapshotOrgs) == 0 {
-		if s.loadStatInt(gcStatKeyTotalFailed) != 0 {
-			s.saveStatInt(gcStatKeyTotalFailed, 0)
-			metrics.GCFailedItemsTotal.Set(0)
-		}
-		return nil
-	}
-
-	repaired := 0
-	now := time.Now().UTC()
-	for _, org := range snapshotOrgs {
-		failedDepth, err := s.store.ReadOrgFailedDepth(org.OrgID)
-		if err != nil {
-			log.Printf("[GC] Failed to read stale failed depth counters for %s: %v", org.OrgID, err)
-			continue
-		}
-		if failedDepth == org.FailedItemsTotal {
-			continue
-		}
-
-		stats, err := s.store.GetOrgQueueStats(org.OrgID)
-		if err != nil {
-			log.Printf("[GC] Failed to load stale failed stats for %s: %v", org.OrgID, err)
-			continue
-		}
-		stats.FailedDepth = failedDepth
-		stats.UpdatedAt = now
-		if err := s.store.SaveOrgQueueStats(stats); err != nil {
-			log.Printf("[GC] Failed to save repaired failed stats for %s: %v", org.OrgID, err)
-			continue
-		}
-		repaired++
-	}
-
-	if repaired == 0 {
-		return nil
-	}
-
-	_, summedFailed, err := s.store.SumOrgQueueStats()
+	dirtyOrgs, err := s.store.ListDirtyOrgs(0)
 	if err != nil {
 		return err
 	}
-	s.saveStatInt(gcStatKeyTotalFailed, summedFailed)
-	metrics.GCFailedItemsTotal.Set(float64(summedFailed))
-	log.Printf("[GC] Repaired stale failed-item snapshot for %d org(s); total_failed=%d", repaired, summedFailed)
+
+	candidateByOrg := make(map[uuid.UUID]gcSnapshotCandidate, len(snapshotOrgs)+len(dirtyOrgs))
+	for _, org := range snapshotOrgs {
+		candidateByOrg[org.OrgID] = gcSnapshotCandidate{OrgID: org.OrgID}
+	}
+	for _, dirtyOrg := range dirtyOrgs {
+		candidateByOrg[dirtyOrg.OrgID] = gcSnapshotCandidate{
+			OrgID:          dirtyOrg.OrgID,
+			DirtyBefore:    dirtyOrg.MarkedAt,
+			HasDirtyMarker: true,
+		}
+	}
+	if len(candidateByOrg) == 0 {
+		s.reconcileSnapshotCandidatesLocked(nil, 0)
+		return nil
+	}
+
+	candidates := make([]gcSnapshotCandidate, 0, len(candidateByOrg))
+	for _, candidate := range candidateByOrg {
+		candidates = append(candidates, candidate)
+	}
+	s.reconcileSnapshotCandidatesLocked(candidates, 0)
 	return nil
 }
 
@@ -929,67 +936,28 @@ func (s *Service) ListFailedItemOrgs(limit int) ([]GCFailedItemOrgInfo, error) {
 	if limit <= 0 {
 		limit = gcDefaultFailedOrgPageSize
 	}
-	snapshotOrgs, err := s.store.ListOrgsWithFailedItems(0)
-	if err != nil {
-		return nil, err
-	}
+	return s.store.ListOrgsWithFailedItems(limit)
+}
+
+func (s *Service) refreshOrgQueueStatsNow(orgID uuid.UUID) error {
+	s.reconcileMu.Lock()
+	defer s.reconcileMu.Unlock()
+
+	candidate := gcSnapshotCandidate{OrgID: orgID, ForceRefresh: true}
 	dirtyOrgs, err := s.store.ListDirtyOrgs(0)
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	candidateOrgIDs := make(map[uuid.UUID]struct{}, len(snapshotOrgs)+len(dirtyOrgs))
-	for _, org := range snapshotOrgs {
-		candidateOrgIDs[org.OrgID] = struct{}{}
-	}
-	for _, org := range dirtyOrgs {
-		candidateOrgIDs[org.OrgID] = struct{}{}
-	}
-
-	orgs := make([]GCFailedItemOrgInfo, 0, len(candidateOrgIDs))
-	for orgID := range candidateOrgIDs {
-		failedDepth, err := s.store.ReadOrgFailedDepth(orgID)
-		if err != nil {
-			return nil, err
-		}
-		if failedDepth <= 0 {
+	for _, dirtyOrg := range dirtyOrgs {
+		if dirtyOrg.OrgID != orgID {
 			continue
 		}
-
-		latestItems, err := s.store.ListFailedItems(orgID, 1)
-		if err != nil {
-			return nil, err
-		}
-		if len(latestItems) == 0 {
-			continue
-		}
-
-		orgName, err := s.store.GetOrgName(orgID)
-		if err != nil {
-			orgName = ""
-		}
-
-		orgs = append(orgs, GCFailedItemOrgInfo{
-			OrgID:            orgID,
-			OrgName:          orgName,
-			FailedItemsTotal: failedDepth,
-			UpdatedAt:        latestItems[0].FailedAt,
-		})
+		candidate.DirtyBefore = dirtyOrg.MarkedAt
+		candidate.HasDirtyMarker = true
+		break
 	}
-
-	sort.Slice(orgs, func(i, j int) bool {
-		if orgs[i].FailedItemsTotal != orgs[j].FailedItemsTotal {
-			return orgs[i].FailedItemsTotal > orgs[j].FailedItemsTotal
-		}
-		if !orgs[i].UpdatedAt.Equal(orgs[j].UpdatedAt) {
-			return orgs[i].UpdatedAt.After(orgs[j].UpdatedAt)
-		}
-		return orgs[i].OrgID.String() < orgs[j].OrgID.String()
-	})
-	if len(orgs) > limit {
-		orgs = orgs[:limit]
-	}
-	return orgs, nil
+	s.reconcileSnapshotCandidatesLocked([]gcSnapshotCandidate{candidate}, 0)
+	return nil
 }
 
 func (s *Service) DeleteFailedItem(orgID uuid.UUID, failedAt time.Time, itemType ItemType, itemID string) error {
@@ -1002,7 +970,9 @@ func (s *Service) DeleteFailedItem(orgID uuid.UUID, failedAt time.Time, itemType
 	if err != nil {
 		return err
 	}
-	s.reconcileDirtyQueueStats(s.reconcileLimit())
+	if err := s.refreshOrgQueueStatsNow(orgID); err != nil {
+		log.Printf("[GC] WARNING: failed to refresh GC snapshot after admin delete for org %s: %v", orgID, err)
+	}
 	return nil
 }
 
@@ -1022,7 +992,9 @@ func (s *Service) RequeueFailedItem(orgID uuid.UUID, failedAt time.Time, itemTyp
 	if err != nil {
 		return err
 	}
-	s.reconcileDirtyQueueStats(s.reconcileLimit())
+	if err := s.refreshOrgQueueStatsNow(orgID); err != nil {
+		log.Printf("[GC] WARNING: failed to refresh GC snapshot after admin requeue for org %s: %v", orgID, err)
+	}
 	return nil
 }
 

--- a/internal/gc/gc_test.go
+++ b/internal/gc/gc_test.go
@@ -555,7 +555,7 @@ func TestService_ReconcileDirtyQueueStats_SerializesRuns(t *testing.T) {
 	var inFlight atomic.Int32
 	var maxInFlight atomic.Int32
 	release := make(chan struct{})
-	store.readQueueDepthHook = func(orgID uuid.UUID, depth int) {
+	store.recalculateStatsHook = func(orgID uuid.UUID) {
 		current := inFlight.Add(1)
 		for {
 			max := maxInFlight.Load()
@@ -571,11 +571,11 @@ func TestService_ReconcileDirtyQueueStats_SerializesRuns(t *testing.T) {
 
 	done := make(chan struct{}, 2)
 	go func() {
-		svc.reconcileDirtyQueueStats(1)
+		svc.reconcileDirtyQueueStats(1, 0)
 		done <- struct{}{}
 	}()
 	go func() {
-		svc.reconcileDirtyQueueStats(1)
+		svc.reconcileDirtyQueueStats(1, 0)
 		done <- struct{}{}
 	}()
 
@@ -591,44 +591,28 @@ func TestService_ReconcileDirtyQueueStats_SerializesRuns(t *testing.T) {
 	}
 }
 
-func TestService_ReconcileDirtyQueueStats_FalseZeroDoesNotDrainActiveOrg(t *testing.T) {
+func TestService_ReconcileDirtyQueueStats_ThrottlesRecentlyRecalculatedOrg(t *testing.T) {
 	store := NewMockStore()
 	orgID := uuid.New()
-	queuedAt := time.Now().UTC().Add(-2 * time.Hour)
-	store.activeQueueOrgs[orgID] = queuedAt
-	store.dirtyQueueOrgs[orgID] = queuedAt
-	store.queue[orgID] = []QueueItem{{
-		OrgID:        orgID,
-		QueuedAt:     queuedAt,
-		IdentityAt:   queuedAt,
-		ItemType:     ItemBlock,
-		ItemID:       "block-false-zero",
-		LibraryID:    uuid.Nil,
-		StorageClass: "hot",
-	}}
+	now := time.Now().UTC()
+	store.dirtyQueueOrgs[orgID] = now
 	store.orgQueueStats[orgID] = GCOrgStats{
 		OrgID:          orgID,
-		QueueDepth:     1,
-		OldestQueuedAt: &queuedAt,
-		UpdatedAt:      queuedAt,
+		QueueDepth:     7,
+		FailedDepth:    2,
+		UpdatedAt:      now.Add(-30 * time.Second),
+		RecalculatedAt: now.Add(-30 * time.Second),
 	}
-	store.forcedQueueDepth[orgID] = 0
 
 	svc := &Service{store: store, config: config.GCConfig{Enabled: true}}
-	svc.reconcileDirtyQueueStats(1)
+	svc.reconcileDirtyQueueStats(1, time.Hour)
 
-	if _, ok := store.activeQueueOrgs[orgID]; !ok {
-		t.Fatal("expected false-zero reconcile to preserve active org")
-	}
 	if _, ok := store.dirtyQueueOrgs[orgID]; !ok {
-		t.Fatal("expected false-zero reconcile to keep org dirty")
-	}
-	if _, ok := store.queueCounterReconciliations[orgID]; !ok {
-		t.Fatal("expected false-zero reconcile to request queue counter repair")
+		t.Fatal("expected recently recalculated org to remain dirty until throttle window elapses")
 	}
 	stats := store.orgQueueStats[orgID]
-	if stats.QueueDepth != 1 {
-		t.Fatalf("expected false-zero reconcile to leave prior queue stats intact, got %d", stats.QueueDepth)
+	if stats.QueueDepth != 7 || stats.FailedDepth != 2 {
+		t.Fatalf("expected throttled reconcile to leave prior stats intact, got queue=%d failed=%d", stats.QueueDepth, stats.FailedDepth)
 	}
 }
 
@@ -791,6 +775,7 @@ func TestService_ListFailedItemOrgs_FiltersStaleSnapshotAndIncludesDirtyActualFa
 	}}
 
 	svc := NewService(store, nil, config.GCConfig{Enabled: true}, nil)
+	svc.RefreshFailedItemSnapshot()
 
 	orgs, err := svc.ListFailedItemOrgs(10)
 	if err != nil {
@@ -969,6 +954,71 @@ func TestService_RequeueFailedCascade_PreservesIdentityAt(t *testing.T) {
 	}
 }
 
+func TestService_AdminFailedItemOps_RefreshSnapshotImmediately(t *testing.T) {
+	store := NewMockStore()
+	orgID := uuid.New()
+	failedAtA := time.Now().UTC().Truncate(time.Millisecond)
+	failedAtB := failedAtA.Add(time.Second)
+	queuedAtA := failedAtA.Add(-time.Minute)
+	queuedAtB := failedAtB.Add(-time.Minute)
+
+	store.failedItems[orgID] = []GCFailedItemInfo{
+		{
+			OrgID:        orgID,
+			FailedAt:     failedAtA,
+			QueuedAt:     queuedAtA,
+			IdentityAt:   queuedAtA,
+			ItemType:     ItemBlock,
+			ItemID:       "admin-requeue",
+			LibraryID:    uuid.Nil,
+			StorageClass: "hot",
+			RetryCount:   5,
+		},
+		{
+			OrgID:        orgID,
+			FailedAt:     failedAtB,
+			QueuedAt:     queuedAtB,
+			IdentityAt:   queuedAtB,
+			ItemType:     ItemBlock,
+			ItemID:       "admin-delete",
+			LibraryID:    uuid.Nil,
+			StorageClass: "hot",
+			RetryCount:   5,
+		},
+	}
+	store.orgQueueStats[orgID] = GCOrgStats{
+		OrgID:          orgID,
+		QueueDepth:     0,
+		FailedDepth:    2,
+		UpdatedAt:      failedAtB,
+		RecalculatedAt: failedAtB,
+	}
+
+	svc := &Service{
+		store:  store,
+		config: config.GCConfig{Enabled: true},
+		lease:  &fakeLeaderLease{allowed: true},
+	}
+
+	if err := svc.RequeueFailedItem(orgID, failedAtA, ItemBlock, "admin-requeue"); err != nil {
+		t.Fatalf("RequeueFailedItem failed: %v", err)
+	}
+	if err := svc.DeleteFailedItem(orgID, failedAtB, ItemBlock, "admin-delete"); err != nil {
+		t.Fatalf("DeleteFailedItem failed: %v", err)
+	}
+
+	stats := store.orgQueueStats[orgID]
+	if stats.QueueDepth != 1 {
+		t.Fatalf("QueueDepth after admin DLQ ops = %d, want 1", stats.QueueDepth)
+	}
+	if stats.FailedDepth != 0 {
+		t.Fatalf("FailedDepth after admin DLQ ops = %d, want 0", stats.FailedDepth)
+	}
+	if stats.RecalculatedAt.IsZero() {
+		t.Fatal("expected admin DLQ ops to refresh org snapshot immediately")
+	}
+}
+
 func TestService_RetryAutoRecoverableFailedItems_RequeuesMissingLibraryChildren(t *testing.T) {
 	store := NewMockStore()
 	orgID := uuid.New()
@@ -992,6 +1042,12 @@ func TestService_RetryAutoRecoverableFailedItems_RequeuesMissingLibraryChildren(
 		FailureCode:                 GCFailureCodeLibraryHardDeleteInProgress,
 		ResolvedState:               "open",
 	}}
+	store.orgQueueStats[orgID] = GCOrgStats{
+		OrgID:          orgID,
+		FailedDepth:    1,
+		UpdatedAt:      failedAt,
+		RecalculatedAt: failedAt,
+	}
 
 	svc := &Service{
 		store:  store,
@@ -1046,7 +1102,7 @@ func TestService_ReconcileDirtyQueueStats_CorrectsSnapshotDrift(t *testing.T) {
 	store.gcStats[gcStatKeyTotalDirtyOrgs] = "9"
 
 	svc := &Service{store: store, config: config.GCConfig{Enabled: true}, reconcilePasses: gcSnapshotDriftCheckEvery - 1}
-	svc.reconcileDirtyQueueStats(0)
+	svc.reconcileDirtyQueueStats(0, 0)
 
 	queueSnapshot, _ := store.LoadGCStats(gcStatKeyTotalQueue)
 	failedSnapshot, _ := store.LoadGCStats(gcStatKeyTotalFailed)

--- a/internal/gc/scanner.go
+++ b/internal/gc/scanner.go
@@ -121,7 +121,6 @@ func (s *Scanner) ScanOnce(ctx context.Context) error {
 		{"expired_deleted_orgs", s.scanExpiredDeletedOrgs},
 		{"onlyoffice_pending_blocks", s.scanOnlyOfficePendingBlocks},
 		{"s3_orphan_recovery", s.scanS3OrphanRecovery},
-		{"queue_counter_reconciliation", s.scanQueueCounterReconciliation},
 	}
 
 	for _, phase := range phases {
@@ -158,25 +157,6 @@ func (s *Scanner) ScanOnce(ctx context.Context) error {
 		s.stats.SetLastScanSuccess(completedAt)
 	}
 	return scanErr
-}
-
-func (s *Scanner) scanQueueCounterReconciliation(ctx context.Context) (int, error) {
-	select {
-	case <-ctx.Done():
-		return 0, ctx.Err()
-	default:
-	}
-
-	const limit = 32
-	log.Println("[GC Scanner] Phase 17: Reconciling GC queue counters...")
-	reconciled, err := s.store.ReconcilePendingQueueCounters(limit)
-	if err != nil {
-		log.Printf("[GC Scanner] Phase 17: queue counter reconciliation error: %v", err)
-	}
-	log.Printf("[GC Scanner] Phase 17 complete: reconciled %d GC queue counter orgs", reconciled)
-	metrics.GCScannerLastPhaseRun.WithLabelValues("queue_counter_reconciliation").SetToCurrentTime()
-	recordScannerAction("queue_counter_reconciliation", "reconciled", reconciled)
-	return 0, err
 }
 
 func (s *Scanner) scanPendingStorageCounterReconciliation(ctx context.Context) (int, error) {

--- a/internal/gc/scanner_test.go
+++ b/internal/gc/scanner_test.go
@@ -63,36 +63,6 @@ func TestScanner_LoadFailedItemsExpiryStartDay_ColdStartUsesFailedItemLookback(t
 	}
 }
 
-func TestScanner_ScanQueueCounterReconciliation_ReactivatesOrgWithLiveQueue(t *testing.T) {
-	store := NewMockStore()
-	stats := &Stats{}
-	q := NewQueue(store)
-	s := NewScanner(store, q, stats, config.GCConfig{})
-
-	orgID := uuid.New()
-	queuedAt := time.Now().UTC().Add(-2 * time.Hour)
-	if err := store.EnqueueItem(orgID, queuedAt, ItemBlock, "block-repair", uuid.Nil, "hot", 0); err != nil {
-		t.Fatalf("enqueue failed: %v", err)
-	}
-	delete(store.activeQueueOrgs, orgID)
-	if err := store.RequestQueueCounterReconciliation(orgID, "test_repair"); err != nil {
-		t.Fatalf("RequestQueueCounterReconciliation failed: %v", err)
-	}
-
-	if n, err := s.scanQueueCounterReconciliation(context.Background()); err != nil || n != 0 {
-		t.Fatalf("scanQueueCounterReconciliation = (%d, %v), want (0, nil)", n, err)
-	}
-	if _, ok := store.activeQueueOrgs[orgID]; !ok {
-		t.Fatal("expected queue counter repair to reactivate org with live queue")
-	}
-	if _, ok := store.dirtyQueueOrgs[orgID]; !ok {
-		t.Fatal("expected queue counter repair to leave org dirty for snapshot refresh")
-	}
-	if _, ok := store.queueCounterReconciliations[orgID]; ok {
-		t.Fatal("expected queue counter repair request to be cleared")
-	}
-}
-
 func TestScanner_ScanOnce_ExpiredProvisionalRefEnqueuesZeroRefBlock(t *testing.T) {
 	store := NewMockStore()
 	stats := &Stats{}
@@ -410,7 +380,7 @@ func TestScanner_ScanOnce_ReturnsAccumulatedPhaseErrorWhenCanceledBetweenPhases(
 	store.deleteExpiredShareLinkErr = fmt.Errorf("delete failed")
 
 	ctx, cancel := context.WithCancel(context.Background())
-	store.readQueueDepthHook = func(_ uuid.UUID, _ int) {
+	store.reconcileStorageCountersHook = func() {
 		cancel()
 	}
 

--- a/internal/gc/store.go
+++ b/internal/gc/store.go
@@ -46,10 +46,7 @@ type GCStore interface {
 	ClearDirtyOrg(orgID uuid.UUID, dirtyBefore time.Time) error
 	GetOrgQueueStats(orgID uuid.UUID) (GCOrgStats, error)
 	SaveOrgQueueStats(stats GCOrgStats) error
-	ReadOrgQueueDepth(orgID uuid.UUID) (int, error)
-	ReadOrgFailedDepth(orgID uuid.UUID) (int, error)
-	RequestQueueCounterReconciliation(orgID uuid.UUID, reason string) error
-	ReconcilePendingQueueCounters(limit int) (int, error)
+	RecalculateOrgQueueStats(orgID uuid.UUID) (GCOrgStats, error)
 	GetOldestQueuedAt(orgID uuid.UUID) (*time.Time, error)
 	SumOrgQueueStats() (int, int, error)
 	GetUserDeletedAt(orgID, userID uuid.UUID) (*time.Time, error)
@@ -318,6 +315,7 @@ type GCOrgStats struct {
 	FailedDepth    int
 	OldestQueuedAt *time.Time
 	UpdatedAt      time.Time
+	RecalculatedAt time.Time
 }
 
 // GCFailedItemOrgInfo summarizes one organization with items in the GC DLQ.

--- a/internal/gc/store_cassandra.go
+++ b/internal/gc/store_cassandra.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/Sesame-Disk/sesamefs/internal/db"
-	"github.com/Sesame-Disk/sesamefs/internal/metrics"
 	"github.com/Sesame-Disk/sesamefs/internal/storage"
 	"github.com/Sesame-Disk/sesamefs/internal/traffic"
 	gocql "github.com/apache/cassandra-gocql-driver/v2"
@@ -233,96 +232,44 @@ func (s *CassandraStore) loadGCStatInt(key string) (int, bool, error) {
 	return parsed, true, nil
 }
 
-func (s *CassandraStore) recordQueueCounterDelta(orgID uuid.UUID, bucket int, queueDelta, failedDelta int) {
-	if queueDelta == 0 && failedDelta == 0 {
-		return
-	}
-	if err := s.adjustQueueCounter(orgID, bucket, queueDelta, failedDelta); err != nil {
-		counter := "queue"
-		if queueDelta != 0 && failedDelta != 0 {
-			counter = "queue_failed"
-		} else if failedDelta != 0 {
-			counter = "failed"
-		}
-		metrics.GCQueueCounterUpdateFailuresTotal.WithLabelValues(counter).Inc()
-		log.Printf("[GC] WARNING: failed to update queue-depth counter org=%s bucket=%d queue_delta=%d failed_delta=%d: %v", orgID, bucket, queueDelta, failedDelta, err)
-		if repairErr := s.RequestQueueCounterReconciliation(orgID, "counter_update_failed"); repairErr != nil {
-			log.Printf("[GC] WARNING: failed to request queue counter repair org=%s: %v", orgID, repairErr)
-		}
-		if markErr := s.MarkOrgDirty(orgID, time.Now().UTC()); markErr != nil {
-			log.Printf("[GC] WARNING: failed to mark org dirty after counter update failure org=%s: %v", orgID, markErr)
-		}
-	}
-}
+func (s *CassandraStore) scanOrgQueueStats(orgID uuid.UUID) (GCOrgStats, error) {
+	stats := GCOrgStats{OrgID: orgID}
+	var oldestQueuedAt *time.Time
 
-func (s *CassandraStore) adjustQueueCounter(orgID uuid.UUID, bucket int, queueDelta, failedDelta int) error {
-	switch {
-	case queueDelta != 0 && failedDelta != 0:
-		return s.db.Session().Query(`
-			UPDATE gc_org_queue_counters
-			SET queue_depth = queue_depth + ?, failed_depth = failed_depth + ?
-			WHERE org_id = ? AND bucket = ?
-		`, int64(queueDelta), int64(failedDelta), orgID.String(), bucket).Exec()
-	case queueDelta != 0:
-		return s.db.Session().Query(`
-			UPDATE gc_org_queue_counters
-			SET queue_depth = queue_depth + ?
-			WHERE org_id = ? AND bucket = ?
-		`, int64(queueDelta), orgID.String(), bucket).Exec()
-	case failedDelta != 0:
-		return s.db.Session().Query(`
-			UPDATE gc_org_queue_counters
-			SET failed_depth = failed_depth + ?
-			WHERE org_id = ? AND bucket = ?
-		`, int64(failedDelta), orgID.String(), bucket).Exec()
-	default:
-		return nil
-	}
-}
-
-func (s *CassandraStore) loadOrgQueueCounterTotals(orgID uuid.UUID) (int, int, error) {
-	var totalQueue, totalFailed int64
 	for bucket := 0; bucket < gcDefaultQueueBucketCount; bucket++ {
-		var queueDepth, failedDepth int64
-		err := s.db.Session().Query(`
-			SELECT queue_depth, failed_depth
-			FROM gc_org_queue_counters
+		iter := s.db.Session().Query(`
+			SELECT queued_at
+			FROM gc_queue
 			WHERE org_id = ? AND bucket = ?
-		`, orgID.String(), bucket).Scan(&queueDepth, &failedDepth)
-		if err != nil {
-			if errors.Is(err, gocql.ErrNotFound) {
-				continue
+		`, orgID.String(), bucket).Iter()
+		var queuedAt time.Time
+		for iter.Scan(&queuedAt) {
+			stats.QueueDepth++
+			queuedAtCopy := queuedAt.UTC()
+			if oldestQueuedAt == nil || queuedAtCopy.Before(*oldestQueuedAt) {
+				oldestQueuedAt = &queuedAtCopy
 			}
-			return 0, 0, fmt.Errorf("load gc queue counters for %s bucket %d: %w", orgID, bucket, err)
 		}
-		totalQueue += queueDepth
-		totalFailed += failedDepth
+		if err := iter.Close(); err != nil {
+			return GCOrgStats{}, fmt.Errorf("scan queue depth org=%s bucket=%d: %w", orgID, bucket, err)
+		}
 	}
-	if totalQueue < 0 {
-		totalQueue = 0
+
+	iter := s.db.Session().Query(`
+		SELECT failed_at
+		FROM gc_failed_items
+		WHERE org_id = ?
+	`, orgID.String()).Iter()
+	var failedAt time.Time
+	for iter.Scan(&failedAt) {
+		stats.FailedDepth++
 	}
-	if totalFailed < 0 {
-		totalFailed = 0
+	if err := iter.Close(); err != nil {
+		return GCOrgStats{}, fmt.Errorf("scan failed depth org=%s: %w", orgID, err)
 	}
-	return int(totalQueue), int(totalFailed), nil
-}
 
-func addQueueCounterReconciliationBatchQuery(batch *gocql.Batch, orgID uuid.UUID, requestedAt time.Time, reason string) {
-	batch.Query(`
-		INSERT INTO gc_queue_counter_reconciliation (bucket, org_id, requested_at, reason)
-		VALUES (?, ?, ?, ?)
-	`, gcOrgBucket(orgID), orgID.String(), requestedAt.UTC(), reason)
-}
-
-func (s *CassandraStore) requestQueueCounterReconciliation(orgID uuid.UUID, reason string) error {
-	return s.db.Session().Query(`
-		INSERT INTO gc_queue_counter_reconciliation (bucket, org_id, requested_at, reason)
-		VALUES (?, ?, ?, ?)
-	`, gcOrgBucket(orgID), orgID.String(), time.Now().UTC(), reason).Exec()
-}
-
-func (s *CassandraStore) RequestQueueCounterReconciliation(orgID uuid.UUID, reason string) error {
-	return s.requestQueueCounterReconciliation(orgID, reason)
+	stats.OldestQueuedAt = oldestQueuedAt
+	return stats, nil
 }
 
 // --- Queue operations ---
@@ -344,12 +291,7 @@ func (s *CassandraStore) EnqueueItem(orgID uuid.UUID, queuedAt time.Time, itemTy
 		INSERT INTO gc_dirty_orgs (bucket, org_id, marked_at)
 		VALUES (?, ?, ?)
 	`, gcOrgBucket(orgID), orgID.String(), now)
-	addQueueCounterReconciliationBatchQuery(batch, orgID, now, "queue_mutation")
-	if err := batch.Exec(); err != nil {
-		return err
-	}
-	s.recordQueueCounterDelta(orgID, queueBucket, 1, 0)
-	return nil
+	return batch.Exec()
 }
 
 func (s *CassandraStore) EnqueueBatch(items []QueueItem) error {
@@ -367,11 +309,6 @@ func (s *CassandraStore) EnqueueBatch(items []QueueItem) error {
 
 		batch := s.db.Session().Batch(gocql.LoggedBatch)
 		activeAtByOrg := make(map[string]time.Time)
-		queueDeltas := make(map[string]struct {
-			orgID  uuid.UUID
-			bucket int
-			delta  int
-		})
 		for _, item := range chunk {
 			identityAt := effectiveIdentityAt(item.QueuedAt, item.IdentityAt)
 			queueBucket := gcQueueBucket(item.OrgID, item.ItemType, item.ItemID)
@@ -381,30 +318,19 @@ func (s *CassandraStore) EnqueueBatch(items []QueueItem) error {
 			`, item.OrgID.String(), queueBucket, item.QueuedAt, identityAt, item.RequiresLibraryDeletedCheck, string(item.ItemType), item.ItemID, item.LibraryID.String(), item.StorageClass, item.RetryCount)
 			addPendingItemBatchQuery(batch, item.OrgID, item.LibraryID, item.ItemType, item.ItemID, identityAt)
 			activeAtByOrg[item.OrgID.String()] = time.Now().UTC()
-			deltaKey := fmt.Sprintf("%s:%d", item.OrgID, queueBucket)
-			delta := queueDeltas[deltaKey]
-			delta.orgID = item.OrgID
-			delta.bucket = queueBucket
-			delta.delta++
-			queueDeltas[deltaKey] = delta
 		}
 		for orgIDStr, activeAt := range activeAtByOrg {
-			orgID := parseUUID(orgIDStr)
 			batch.Query(`
 				INSERT INTO gc_active_orgs (bucket, org_id, last_enqueued_at)
 				VALUES (?, ?, ?)
-			`, gcOrgBucket(orgID), orgIDStr, activeAt)
+			`, gcOrgBucket(parseUUID(orgIDStr)), orgIDStr, activeAt)
 			batch.Query(`
 				INSERT INTO gc_dirty_orgs (bucket, org_id, marked_at)
 				VALUES (?, ?, ?)
-			`, gcOrgBucket(orgID), orgIDStr, activeAt)
-			addQueueCounterReconciliationBatchQuery(batch, orgID, activeAt, "queue_batch_mutation")
+			`, gcOrgBucket(parseUUID(orgIDStr)), orgIDStr, activeAt)
 		}
 		if err := batch.Exec(); err != nil {
 			return fmt.Errorf("failed to enqueue batch chunk at offset %d: %w", i, err)
-		}
-		for _, delta := range queueDeltas {
-			s.recordQueueCounterDelta(delta.orgID, delta.bucket, delta.delta, 0)
 		}
 	}
 	return nil
@@ -567,12 +493,11 @@ func (s *CassandraStore) CompleteItem(orgID uuid.UUID, queuedAt time.Time, itemT
 		INSERT INTO gc_dirty_orgs (bucket, org_id, marked_at)
 		VALUES (?, ?, ?)
 	`, gcOrgBucket(orgID), orgID.String(), now)
-	addQueueCounterReconciliationBatchQuery(batch, orgID, now, "queue_complete")
 	if err := batch.Exec(); err != nil {
 		return err
 	}
-	if hadQueueRow {
-		s.recordQueueCounterDelta(orgID, gcQueueBucket(orgID, itemType, itemID), -1, 0)
+	if !hadQueueRow {
+		return nil
 	}
 	return nil
 }
@@ -603,7 +528,6 @@ func (s *CassandraStore) RequeueItem(orgID uuid.UUID, oldQueuedAt, newQueuedAt t
 		INSERT INTO gc_dirty_orgs (bucket, org_id, marked_at)
 		VALUES (?, ?, ?)
 	`, gcOrgBucket(orgID), orgID.String(), now)
-	addQueueCounterReconciliationBatchQuery(batch, orgID, now, "queue_requeue")
 
 	return batch.Exec()
 }
@@ -638,20 +562,15 @@ func (s *CassandraStore) FailItem(item QueueItem, failedAt time.Time, lastError,
 		INSERT INTO gc_dirty_orgs (bucket, org_id, marked_at)
 		VALUES (?, ?, ?)
 	`, gcOrgBucket(item.OrgID), item.OrgID.String(), now)
-	addQueueCounterReconciliationBatchQuery(batch, item.OrgID, now, "queue_fail")
-	if err := batch.Exec(); err != nil {
-		return err
-	}
-	s.recordQueueCounterDelta(item.OrgID, queueBucket, -1, 1)
-	return nil
+	return batch.Exec()
 }
 
 func (s *CassandraStore) GetQueueSize(orgID uuid.UUID) (int, error) {
-	queueDepth, _, err := s.loadOrgQueueCounterTotals(orgID)
+	stats, err := s.GetOrgQueueStats(orgID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get queue size for %s: %w", orgID, err)
 	}
-	return queueDepth, nil
+	return stats.QueueDepth, nil
 }
 
 func (s *CassandraStore) GetTotalQueueSize() (int, error) {
@@ -823,12 +742,7 @@ func (s *CassandraStore) DeleteFailedItem(orgID uuid.UUID, failedAt time.Time, i
 		INSERT INTO gc_dirty_orgs (bucket, org_id, marked_at)
 		VALUES (?, ?, ?)
 	`, gcOrgBucket(orgID), orgID.String(), now)
-	addQueueCounterReconciliationBatchQuery(batch, orgID, now, "failed_delete")
-	if err := batch.Exec(); err != nil {
-		return err
-	}
-	s.recordQueueCounterDelta(orgID, gcQueueBucket(orgID, itemType, itemID), 0, -1)
-	return nil
+	return batch.Exec()
 }
 
 func (s *CassandraStore) DeleteExpiredFailedItem(expiry GCFailedItemExpiryInfo, now time.Time) (bool, error) {
@@ -839,9 +753,6 @@ func (s *CassandraStore) DeleteExpiredFailedItem(expiry GCFailedItemExpiryInfo, 
 			WHERE expiry_day = ? AND bucket = ? AND expires_at = ? AND org_id = ? AND failed_at = ? AND item_type = ? AND item_id = ?
 		`, db.GCProjectionUTCDate(expiry.ExpiresAt), db.GCDiscoveryBucket(expiry.OrgID.String(), string(expiry.ItemType), expiry.ItemID, expiry.FailedAt.UTC().Format(time.RFC3339Nano)), expiry.ExpiresAt.UTC(), expiry.OrgID.String(), expiry.FailedAt.UTC(), string(expiry.ItemType), expiry.ItemID).Exec(); err != nil {
 			return false, fmt.Errorf("delete orphaned failed-item expiry projection org=%s item=%s: %w", expiry.OrgID, expiry.ItemID, err)
-		}
-		if repairErr := s.RequestQueueCounterReconciliation(expiry.OrgID, "failed_expiry_projection_orphaned"); repairErr != nil {
-			log.Printf("[GC] WARNING: failed to request queue counter repair for orphaned failed-item expiry org=%s item=%s: %v", expiry.OrgID, expiry.ItemID, repairErr)
 		}
 		if markErr := s.MarkOrgDirty(expiry.OrgID, time.Now().UTC()); markErr != nil {
 			log.Printf("[GC] WARNING: failed to mark org dirty for orphaned failed-item expiry org=%s item=%s: %v", expiry.OrgID, expiry.ItemID, markErr)
@@ -860,9 +771,6 @@ func (s *CassandraStore) DeleteExpiredFailedItem(expiry GCFailedItemExpiryInfo, 
 			WHERE expiry_day = ? AND bucket = ? AND expires_at = ? AND org_id = ? AND failed_at = ? AND item_type = ? AND item_id = ?
 		`, db.GCProjectionUTCDate(expiry.ExpiresAt), db.GCDiscoveryBucket(expiry.OrgID.String(), string(expiry.ItemType), expiry.ItemID, expiry.FailedAt.UTC().Format(time.RFC3339Nano)), expiry.ExpiresAt.UTC(), expiry.OrgID.String(), expiry.FailedAt.UTC(), string(expiry.ItemType), expiry.ItemID).Exec(); err != nil {
 			return false, fmt.Errorf("delete stale failed-item expiry projection org=%s item=%s: %w", expiry.OrgID, expiry.ItemID, err)
-		}
-		if repairErr := s.RequestQueueCounterReconciliation(expiry.OrgID, "failed_expiry_projection_stale"); repairErr != nil {
-			log.Printf("[GC] WARNING: failed to request queue counter repair for stale failed-item expiry org=%s item=%s: %v", expiry.OrgID, expiry.ItemID, repairErr)
 		}
 		if markErr := s.MarkOrgDirty(expiry.OrgID, time.Now().UTC()); markErr != nil {
 			log.Printf("[GC] WARNING: failed to mark org dirty for stale failed-item expiry org=%s item=%s: %v", expiry.OrgID, expiry.ItemID, markErr)
@@ -885,11 +793,9 @@ func (s *CassandraStore) DeleteExpiredFailedItem(expiry GCFailedItemExpiryInfo, 
 		INSERT INTO gc_dirty_orgs (bucket, org_id, marked_at)
 		VALUES (?, ?, ?)
 	`, gcOrgBucket(expiry.OrgID), expiry.OrgID.String(), mutationAt)
-	addQueueCounterReconciliationBatchQuery(batch, expiry.OrgID, mutationAt, "failed_expire")
 	if err := batch.Exec(); err != nil {
 		return false, err
 	}
-	s.recordQueueCounterDelta(expiry.OrgID, gcQueueBucket(expiry.OrgID, expiry.ItemType, expiry.ItemID), 0, -1)
 	return true, nil
 }
 
@@ -929,170 +835,7 @@ func (s *CassandraStore) RequeueFailedItem(orgID uuid.UUID, failedAt time.Time, 
 		INSERT INTO gc_dirty_orgs (bucket, org_id, marked_at)
 		VALUES (?, ?, ?)
 	`, gcOrgBucket(orgID), orgID.String(), queuedAt)
-	addQueueCounterReconciliationBatchQuery(batch, orgID, queuedAt, "failed_requeue")
-	if err := batch.Exec(); err != nil {
-		return err
-	}
-	s.recordQueueCounterDelta(orgID, gcQueueBucket(orgID, itemType, itemID), 1, -1)
-	return nil
-}
-
-type queueCounterRepairRequest struct {
-	OrgID       uuid.UUID
-	Bucket      int
-	RequestedAt time.Time
-	Reason      string
-}
-
-func (s *CassandraStore) listQueueCounterRepairRequests(limit int) ([]queueCounterRepairRequest, error) {
-	requests := make([]queueCounterRepairRequest, 0)
-	for bucket := 0; bucket < gcDefaultOrgBucketCount; bucket++ {
-		iter := s.db.Session().Query(`
-			SELECT org_id, requested_at, reason
-			FROM gc_queue_counter_reconciliation
-			WHERE bucket = ?
-		`, bucket).Iter()
-		var (
-			orgIDStr    string
-			requestedAt time.Time
-			reason      string
-		)
-		for iter.Scan(&orgIDStr, &requestedAt, &reason) {
-			requests = append(requests, queueCounterRepairRequest{
-				OrgID:       parseUUID(orgIDStr),
-				Bucket:      bucket,
-				RequestedAt: requestedAt,
-				Reason:      reason,
-			})
-			if limit > 0 && len(requests) >= limit {
-				break
-			}
-		}
-		if err := iter.Close(); err != nil {
-			return nil, fmt.Errorf("list queue counter repair requests bucket=%d: %w", bucket, err)
-		}
-		if limit > 0 && len(requests) >= limit {
-			break
-		}
-	}
-	return requests, nil
-}
-
-func (s *CassandraStore) recomputeOrgQueueCounterDepths(orgID uuid.UUID) ([]int64, []int64, error) {
-	queueDepths := make([]int64, gcDefaultQueueBucketCount)
-	failedDepths := make([]int64, gcDefaultQueueBucketCount)
-
-	for bucket := 0; bucket < gcDefaultQueueBucketCount; bucket++ {
-		iter := s.db.Session().Query(`
-			SELECT queued_at
-			FROM gc_queue
-			WHERE org_id = ? AND bucket = ?
-		`, orgID.String(), bucket).Iter()
-		var queuedAt time.Time
-		for iter.Scan(&queuedAt) {
-			queueDepths[bucket]++
-		}
-		if err := iter.Close(); err != nil {
-			return nil, nil, fmt.Errorf("recompute queue depth org=%s bucket=%d: %w", orgID, bucket, err)
-		}
-	}
-
-	iter := s.db.Session().Query(`
-		SELECT item_type, item_id
-		FROM gc_failed_items
-		WHERE org_id = ?
-	`, orgID.String()).Iter()
-	var itemType, itemID string
-	for iter.Scan(&itemType, &itemID) {
-		bucket := gcQueueBucket(orgID, ItemType(itemType), itemID)
-		failedDepths[bucket]++
-	}
-	if err := iter.Close(); err != nil {
-		return nil, nil, fmt.Errorf("recompute failed depth org=%s: %w", orgID, err)
-	}
-	return queueDepths, failedDepths, nil
-}
-
-func (s *CassandraStore) loadOrgQueueCounterBucket(orgID uuid.UUID, bucket int) (int64, int64, error) {
-	var queueDepth, failedDepth int64
-	err := s.db.Session().Query(`
-		SELECT queue_depth, failed_depth
-		FROM gc_org_queue_counters
-		WHERE org_id = ? AND bucket = ?
-	`, orgID.String(), bucket).Scan(&queueDepth, &failedDepth)
-	if err != nil {
-		if errors.Is(err, gocql.ErrNotFound) {
-			return 0, 0, nil
-		}
-		return 0, 0, err
-	}
-	return queueDepth, failedDepth, nil
-}
-
-func (s *CassandraStore) reconcileQueueCounterRequest(request queueCounterRepairRequest) error {
-	queueDepths, failedDepths, err := s.recomputeOrgQueueCounterDepths(request.OrgID)
-	if err != nil {
-		return err
-	}
-
-	var totalQueue int64
-
-	for bucket := 0; bucket < gcDefaultQueueBucketCount; bucket++ {
-		totalQueue += queueDepths[bucket]
-		currentQueue, currentFailed, err := s.loadOrgQueueCounterBucket(request.OrgID, bucket)
-		if err != nil {
-			return fmt.Errorf("load queue counter org=%s bucket=%d: %w", request.OrgID, bucket, err)
-		}
-		queueDelta := queueDepths[bucket] - currentQueue
-		failedDelta := failedDepths[bucket] - currentFailed
-		if queueDelta == 0 && failedDelta == 0 {
-			continue
-		}
-		if err := s.adjustQueueCounter(request.OrgID, bucket, int(queueDelta), int(failedDelta)); err != nil {
-			metrics.GCQueueCounterUpdateFailuresTotal.WithLabelValues("repair").Inc()
-			return fmt.Errorf("repair queue counter org=%s bucket=%d queue_delta=%d failed_delta=%d: %w", request.OrgID, bucket, queueDelta, failedDelta, err)
-		}
-	}
-
-	if err := s.MarkOrgDirty(request.OrgID, time.Now().UTC()); err != nil {
-		return fmt.Errorf("mark org dirty after queue counter repair org=%s: %w", request.OrgID, err)
-	}
-	if totalQueue > 0 {
-		if err := s.MarkOrgActive(request.OrgID, time.Now().UTC()); err != nil {
-			return fmt.Errorf("mark org active after queue counter repair org=%s: %w", request.OrgID, err)
-		}
-	}
-	if err := s.db.Session().Query(`
-		DELETE FROM gc_queue_counter_reconciliation
-		WHERE bucket = ? AND org_id = ?
-	`, request.Bucket, request.OrgID.String()).Exec(); err != nil {
-		return fmt.Errorf("delete queue counter repair request org=%s: %w", request.OrgID, err)
-	}
-	return nil
-}
-
-func (s *CassandraStore) ReconcilePendingQueueCounters(limit int) (int, error) {
-	requests, err := s.listQueueCounterRepairRequests(limit)
-	if err != nil {
-		return 0, err
-	}
-	if len(requests) == 0 {
-		return 0, nil
-	}
-
-	reconciled := 0
-	var firstErr error
-	for _, request := range requests {
-		if err := s.reconcileQueueCounterRequest(request); err != nil {
-			if firstErr == nil {
-				firstErr = err
-			}
-			log.Printf("[GC] WARNING: queue counter repair failed org=%s reason=%s requested_at=%s: %v", request.OrgID, request.Reason, request.RequestedAt.Format(time.RFC3339Nano), err)
-			continue
-		}
-		reconciled++
-	}
-	return reconciled, firstErr
+	return batch.Exec()
 }
 
 func (s *CassandraStore) ListOrgsWithQueuedItems() ([]uuid.UUID, error) {
@@ -1212,9 +955,9 @@ func (s *CassandraStore) GetOrgQueueStats(orgID uuid.UUID) (GCOrgStats, error) {
 	stats := GCOrgStats{OrgID: orgID}
 	var oldestQueuedAt *time.Time
 	err := s.db.Session().Query(`
-		SELECT queue_depth, failed_depth, oldest_queued_at, updated_at
+		SELECT queue_depth, failed_depth, oldest_queued_at, updated_at, recalculated_at
 		FROM gc_org_stats WHERE org_id = ?
-	`, orgID.String()).Scan(&stats.QueueDepth, &stats.FailedDepth, &oldestQueuedAt, &stats.UpdatedAt)
+	`, orgID.String()).Scan(&stats.QueueDepth, &stats.FailedDepth, &oldestQueuedAt, &stats.UpdatedAt, &stats.RecalculatedAt)
 	if err != nil {
 		if errors.Is(err, gocql.ErrNotFound) {
 			return stats, nil
@@ -1227,25 +970,23 @@ func (s *CassandraStore) GetOrgQueueStats(orgID uuid.UUID) (GCOrgStats, error) {
 
 func (s *CassandraStore) SaveOrgQueueStats(stats GCOrgStats) error {
 	return s.db.Session().Query(`
-		INSERT INTO gc_org_stats (org_id, queue_depth, failed_depth, oldest_queued_at, updated_at)
-		VALUES (?, ?, ?, ?, ?)
-	`, stats.OrgID.String(), stats.QueueDepth, stats.FailedDepth, stats.OldestQueuedAt, stats.UpdatedAt).Exec()
+		INSERT INTO gc_org_stats (org_id, queue_depth, failed_depth, oldest_queued_at, updated_at, recalculated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, stats.OrgID.String(), stats.QueueDepth, stats.FailedDepth, stats.OldestQueuedAt, stats.UpdatedAt, stats.RecalculatedAt).Exec()
 }
 
-func (s *CassandraStore) ReadOrgQueueDepth(orgID uuid.UUID) (int, error) {
-	queueDepth, _, err := s.loadOrgQueueCounterTotals(orgID)
+func (s *CassandraStore) RecalculateOrgQueueStats(orgID uuid.UUID) (GCOrgStats, error) {
+	stats, err := s.scanOrgQueueStats(orgID)
 	if err != nil {
-		return 0, fmt.Errorf("load queue depth counters for %s: %w", orgID, err)
+		return GCOrgStats{}, err
 	}
-	return queueDepth, nil
-}
-
-func (s *CassandraStore) ReadOrgFailedDepth(orgID uuid.UUID) (int, error) {
-	_, failedDepth, err := s.loadOrgQueueCounterTotals(orgID)
-	if err != nil {
-		return 0, fmt.Errorf("load failed depth counters for %s: %w", orgID, err)
+	now := time.Now().UTC()
+	stats.UpdatedAt = now
+	stats.RecalculatedAt = now
+	if err := s.SaveOrgQueueStats(stats); err != nil {
+		return GCOrgStats{}, fmt.Errorf("save recalculated org queue stats for %s: %w", orgID, err)
 	}
-	return failedDepth, nil
+	return stats, nil
 }
 
 func (s *CassandraStore) GetOldestQueuedAt(orgID uuid.UUID) (*time.Time, error) {

--- a/internal/gc/store_mock.go
+++ b/internal/gc/store_mock.go
@@ -125,8 +125,6 @@ type MockStore struct {
 
 	// gc_stats keyed by stat_key
 	gcStats map[string]string
-	// pending GC queue counter repairs keyed by orgID.
-	queueCounterReconciliations map[uuid.UUID]mockQueueCounterRepairRequest
 
 	// test hooks for scanner and worker failure paths.
 	enqueueBatchErr                error
@@ -153,16 +151,16 @@ type MockStore struct {
 	listLibrariesForOrgErr         error
 	deleteLibraryStorageCounterErr error
 	deleteGroupFullErr             error
+	reconcileStorageCountersHook   func()
 	acquireOrgHardDeleteLockHook   func(orgID uuid.UUID)
 	beginOrgPurgeHook              func(orgID uuid.UUID)
 	getBlockRefCountErr            error
 	blockHasReferencesHook         func(orgID uuid.UUID, blockID string, current bool) (bool, error)
 
 	// optional test hooks for reproducing concurrency windows deterministically.
-	getQueueSizeHook    func(orgID uuid.UUID, size int)
-	removeActiveOrgHook func(orgID uuid.UUID, activeBefore time.Time)
-	readQueueDepthHook  func(orgID uuid.UUID, depth int)
-	forcedQueueDepth    map[uuid.UUID]int
+	getQueueSizeHook     func(orgID uuid.UUID, size int)
+	removeActiveOrgHook  func(orgID uuid.UUID, activeBefore time.Time)
+	recalculateStatsHook func(orgID uuid.UUID)
 	// requeueItemErr, when non-nil, forces RequeueItem to return this error
 	// without mutating state. Used to exercise IncrementRetry failure paths
 	// where the LoggedBatch never applied.
@@ -347,12 +345,6 @@ type mockStorageCounterReconciliation struct {
 	RequestedAt time.Time
 }
 
-type mockQueueCounterRepairRequest struct {
-	OrgID       uuid.UUID
-	Reason      string
-	RequestedAt time.Time
-}
-
 type mockHardDeleteLock struct {
 	LeaseToken uuid.UUID
 	StartedAt  time.Time
@@ -412,8 +404,6 @@ func NewMockStore() *MockStore {
 		starredFiles:                         make(map[uuid.UUID]bool),
 		monitoredRepos:                       make(map[uuid.UUID]bool),
 		gcStats:                              make(map[string]string),
-		queueCounterReconciliations:          make(map[uuid.UUID]mockQueueCounterRepairRequest),
-		forcedQueueDepth:                     make(map[uuid.UUID]int),
 		organizations:                        nil,
 		s3Orphans:                            make(map[string]*S3OrphanInfo),
 		s3OrphanProjections:                  make(map[mockS3OrphanProjectionKey]S3OrphanInfo),
@@ -1305,7 +1295,6 @@ func (m *MockStore) ListOrgsWithFailedItems(limit int) ([]GCFailedItemOrgInfo, e
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	results := make([]GCFailedItemOrgInfo, 0)
-	seen := make(map[uuid.UUID]struct{})
 	for orgID, stats := range m.orgQueueStats {
 		if stats.FailedDepth <= 0 {
 			continue
@@ -1315,24 +1304,6 @@ func (m *MockStore) ListOrgsWithFailedItems(limit int) ([]GCFailedItemOrgInfo, e
 			OrgName:          m.orgNames[orgID],
 			FailedItemsTotal: stats.FailedDepth,
 			UpdatedAt:        stats.UpdatedAt,
-		})
-		seen[orgID] = struct{}{}
-	}
-	for orgID, items := range m.failedItems {
-		if _, ok := seen[orgID]; ok || len(items) == 0 {
-			continue
-		}
-		updatedAt := time.Time{}
-		for _, item := range items {
-			if item.FailedAt.After(updatedAt) {
-				updatedAt = item.FailedAt
-			}
-		}
-		results = append(results, GCFailedItemOrgInfo{
-			OrgID:            orgID,
-			OrgName:          m.orgNames[orgID],
-			FailedItemsTotal: len(items),
-			UpdatedAt:        updatedAt,
 		})
 	}
 	sort.Slice(results, func(i, j int) bool {
@@ -1389,11 +1360,6 @@ func (m *MockStore) DeleteExpiredFailedItem(expiry GCFailedItemExpiryInfo, now t
 			m.dirtyQueueOrgs[expiry.OrgID] = time.Now().UTC()
 			return true, nil
 		}
-	}
-	m.queueCounterReconciliations[expiry.OrgID] = mockQueueCounterRepairRequest{
-		OrgID:       expiry.OrgID,
-		Reason:      "failed_expiry_projection_orphaned",
-		RequestedAt: time.Now().UTC(),
 	}
 	m.dirtyQueueOrgs[expiry.OrgID] = time.Now().UTC()
 	return false, nil
@@ -1541,35 +1507,31 @@ func (m *MockStore) SaveOrgQueueStats(stats GCOrgStats) error {
 	return nil
 }
 
-func (m *MockStore) ReadOrgQueueDepth(orgID uuid.UUID) (int, error) {
+func (m *MockStore) RecalculateOrgQueueStats(orgID uuid.UUID) (GCOrgStats, error) {
 	m.mu.RLock()
-	depth := len(m.queue[orgID])
-	if forcedDepth, ok := m.forcedQueueDepth[orgID]; ok {
-		depth = forcedDepth
-	}
-	hook := m.readQueueDepthHook
+	hook := m.recalculateStatsHook
 	m.mu.RUnlock()
 	if hook != nil {
-		hook(orgID, depth)
+		hook(orgID)
 	}
-	return depth, nil
-}
 
-func (m *MockStore) ReadOrgFailedDepth(orgID uuid.UUID) (int, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return len(m.failedItems[orgID]), nil
-}
-
-func (m *MockStore) RequestQueueCounterReconciliation(orgID uuid.UUID, reason string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.queueCounterReconciliations[orgID] = mockQueueCounterRepairRequest{
-		OrgID:       orgID,
-		Reason:      reason,
-		RequestedAt: time.Now().UTC(),
+
+	stats := GCOrgStats{OrgID: orgID}
+	for _, item := range m.queue[orgID] {
+		stats.QueueDepth++
+		queuedAtCopy := item.QueuedAt
+		if stats.OldestQueuedAt == nil || queuedAtCopy.Before(*stats.OldestQueuedAt) {
+			stats.OldestQueuedAt = &queuedAtCopy
+		}
 	}
-	return nil
+	stats.FailedDepth = len(m.failedItems[orgID])
+	now := time.Now().UTC()
+	stats.UpdatedAt = now
+	stats.RecalculatedAt = now
+	m.orgQueueStats[orgID] = stats
+	return stats, nil
 }
 
 func (m *MockStore) GetOldestQueuedAt(orgID uuid.UUID) (*time.Time, error) {
@@ -2135,39 +2097,13 @@ func (m *MockStore) ListFSObjectIDsForLibrary(libraryID uuid.UUID) ([]string, er
 	return ids, nil
 }
 
-func (m *MockStore) ReconcilePendingQueueCounters(limit int) (int, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if len(m.queueCounterReconciliations) == 0 {
-		return 0, nil
-	}
-
-	orgIDs := make([]uuid.UUID, 0, len(m.queueCounterReconciliations))
-	for orgID := range m.queueCounterReconciliations {
-		orgIDs = append(orgIDs, orgID)
-	}
-	sort.Slice(orgIDs, func(i, j int) bool {
-		return strings.Compare(orgIDs[i].String(), orgIDs[j].String()) < 0
-	})
-	if limit > 0 && len(orgIDs) > limit {
-		orgIDs = orgIDs[:limit]
-	}
-
-	now := time.Now().UTC()
-	for _, orgID := range orgIDs {
-		if len(m.queue[orgID]) > 0 {
-			m.activeQueueOrgs[orgID] = now
-		}
-		m.dirtyQueueOrgs[orgID] = now
-		delete(m.queueCounterReconciliations, orgID)
-	}
-	return len(orgIDs), nil
-}
-
 func (m *MockStore) ReconcilePendingStorageCounters() (int, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if m.reconcileStorageCountersHook != nil {
+		m.reconcileStorageCountersHook()
+	}
 
 	if len(m.storageCounterReconciliations) == 0 {
 		return 0, nil

--- a/internal/integration/gc_integration_test.go
+++ b/internal/integration/gc_integration_test.go
@@ -347,61 +347,6 @@ func gcFailedItemExpiryBucketForTest(orgID string, itemType string, itemID strin
 	return db.GCDiscoveryBucket(orgID, itemType, itemID, failedAt.UTC().Format(time.RFC3339Nano))
 }
 
-func adjustGCQueueCountersForTest(t *testing.T, orgID uuid.UUID, bucket int, queueDelta, failedDelta int) {
-	t.Helper()
-	if queueDelta == 0 && failedDelta == 0 {
-		return
-	}
-	session := shareProjectionDBForTest(t).Session()
-	switch {
-	case queueDelta != 0 && failedDelta != 0:
-		if err := session.Query(`
-			UPDATE gc_org_queue_counters
-			SET queue_depth = queue_depth + ?, failed_depth = failed_depth + ?
-			WHERE org_id = ? AND bucket = ?
-		`, int64(queueDelta), int64(failedDelta), orgID.String(), bucket).Exec(); err != nil {
-			t.Fatalf("failed to adjust GC queue counters for %s bucket %d: %v", orgID, bucket, err)
-		}
-	case queueDelta != 0:
-		if err := session.Query(`
-			UPDATE gc_org_queue_counters
-			SET queue_depth = queue_depth + ?
-			WHERE org_id = ? AND bucket = ?
-		`, int64(queueDelta), orgID.String(), bucket).Exec(); err != nil {
-			t.Fatalf("failed to adjust GC queue counter for %s bucket %d: %v", orgID, bucket, err)
-		}
-	case failedDelta != 0:
-		if err := session.Query(`
-			UPDATE gc_org_queue_counters
-			SET failed_depth = failed_depth + ?
-			WHERE org_id = ? AND bucket = ?
-		`, int64(failedDelta), orgID.String(), bucket).Exec(); err != nil {
-			t.Fatalf("failed to adjust GC failed counter for %s bucket %d: %v", orgID, bucket, err)
-		}
-	}
-}
-
-func resetGCQueueCountersForTest(t *testing.T, orgID uuid.UUID) {
-	t.Helper()
-	session := shareProjectionDBForTest(t).Session()
-	for bucket := 0; bucket < 32; bucket++ {
-		var queueDepth int64
-		var failedDepth int64
-		err := session.Query(`
-			SELECT queue_depth, failed_depth
-			FROM gc_org_queue_counters
-			WHERE org_id = ? AND bucket = ?
-		`, orgID.String(), bucket).Scan(&queueDepth, &failedDepth)
-		if errors.Is(err, gocql.ErrNotFound) {
-			continue
-		}
-		if err != nil {
-			t.Fatalf("failed to read GC queue counters for %s bucket %d: %v", orgID, bucket, err)
-		}
-		adjustGCQueueCountersForTest(t, orgID, bucket, -int(queueDepth), -int(failedDepth))
-	}
-}
-
 func deleteGCQueueItemsByIdentity(t *testing.T, orgID string, itemType string, itemID string) {
 	deleteGCQueueItemsByIdentitySince(t, orgID, itemType, itemID, time.Time{})
 }
@@ -503,51 +448,15 @@ func deleteGCPendingBlockItems(t *testing.T, orgID uuid.UUID, blockID string) {
 func repairGCSnapshotsForTest(t *testing.T, orgID uuid.UUID) {
 	t.Helper()
 	database := shareProjectionDBForTest(t)
-	session := database.Session()
 	store := gcpkg.NewCassandraStore(database)
 
-	queueDepth, err := store.ReadOrgQueueDepth(orgID)
-	if err != nil {
-		t.Fatalf("failed to read GC queue depth counters for %s: %v", orgID, err)
-	}
-	failedDepth, err := store.ReadOrgFailedDepth(orgID)
-	if err != nil {
-		t.Fatalf("failed to read GC failed depth counters for %s: %v", orgID, err)
+	if _, err := store.RecalculateOrgQueueStats(orgID); err != nil {
+		t.Fatalf("failed to recalculate gc_org_stats for %s: %v", orgID, err)
 	}
 
-	if queueDepth == 0 && failedDepth == 0 {
-		if err := session.Query(`DELETE FROM gc_org_stats WHERE org_id = ?`, orgID.String()).Exec(); err != nil {
-			t.Fatalf("failed to delete gc_org_stats for %s: %v", orgID, err)
-		}
-		if err := session.Query(`DELETE FROM gc_active_orgs WHERE bucket = ? AND org_id = ?`, gcpkg.OrgBucket(orgID), orgID.String()).Exec(); err != nil {
-			t.Fatalf("failed to delete gc_active_orgs for %s: %v", orgID, err)
-		}
-		if err := session.Query(`DELETE FROM gc_dirty_orgs WHERE bucket = ? AND org_id = ?`, gcpkg.OrgBucket(orgID), orgID.String()).Exec(); err != nil {
-			t.Fatalf("failed to delete gc_dirty_orgs for %s: %v", orgID, err)
-		}
-	} else {
-		oldestQueuedAt, err := store.GetOldestQueuedAt(orgID)
-		if err != nil {
-			t.Fatalf("failed to read oldest queued item for %s: %v", orgID, err)
-		}
-		if err := store.SaveOrgQueueStats(gcpkg.GCOrgStats{
-			OrgID:          orgID,
-			QueueDepth:     queueDepth,
-			FailedDepth:    failedDepth,
-			OldestQueuedAt: oldestQueuedAt,
-			UpdatedAt:      time.Now().UTC(),
-		}); err != nil {
-			t.Fatalf("failed to save gc_org_stats for %s: %v", orgID, err)
-		}
-	}
-
-	totalQueue, err := store.GetTotalQueueSize()
+	totalQueue, totalFailed, err := store.SumOrgQueueStats()
 	if err != nil {
-		t.Fatalf("failed to read total GC queue size: %v", err)
-	}
-	totalFailed, err := store.GetTotalFailedItems()
-	if err != nil {
-		t.Fatalf("failed to read total GC failed size: %v", err)
+		t.Fatalf("failed to sum gc_org_stats: %v", err)
 	}
 	dirtyOrgs, err := store.ListDirtyOrgs(0)
 	if err != nil {
@@ -569,7 +478,6 @@ func cleanupGCBlockFixturesForTest(t *testing.T, orgID uuid.UUID, blockID string
 	deleteGCQueueItemsByIdentity(t, orgID.String(), "block", blockID)
 	deleteGCFailedItemsByIdentity(t, orgID.String(), "block", blockID)
 	deleteGCPendingBlockItems(t, orgID, blockID)
-	resetGCQueueCountersForTest(t, orgID)
 	store := gcpkg.NewCassandraStore(shareProjectionDBForTest(t))
 	if err := store.DeleteBlockGCCandidate(orgID, blockID, time.Time{}); err != nil {
 		t.Fatalf("failed to delete gc_block_candidate for %s/%s: %v", orgID, blockID, err)
@@ -1234,10 +1142,10 @@ func TestGC_QueueSizeTracking(t *testing.T) {
 	}
 }
 
-// TestGC_StatusSnapshotReconcilesQueueCounters verifies that the scanner can
-// reconcile the queue-depth snapshot from write-path counters without relying
-// on hot COUNT(*) reads over gc_queue.
-func TestGC_StatusSnapshotReconcilesQueueCounters(t *testing.T) {
+// TestGC_StatusSnapshotReconcilesDirtyQueueRows verifies that background GC
+// snapshot refresh picks up canonical queue rows from dirty markers without
+// relying on Cassandra COUNTER state.
+func TestGC_StatusSnapshotReconcilesDirtyQueueRows(t *testing.T) {
 	requireGCEnabled(t)
 	requireCassandra(t)
 
@@ -1254,7 +1162,6 @@ func TestGC_StatusSnapshotReconcilesQueueCounters(t *testing.T) {
 	`, orgID.String(), queueBucket, queuedAt, "block", itemID, libraryID.String(), "hot", 0).Exec(); err != nil {
 		t.Fatalf("failed to insert synthetic gc_queue row: %v", err)
 	}
-	adjustGCQueueCountersForTest(t, orgID, queueBucket, 1, 0)
 	if err := session.Query(`
 		INSERT INTO gc_active_orgs (bucket, org_id, last_enqueued_at)
 		VALUES (?, ?, ?)
@@ -1274,7 +1181,6 @@ func TestGC_StatusSnapshotReconcilesQueueCounters(t *testing.T) {
 		`, orgID.String(), queueBucket, queuedAt, "block", itemID).Exec()
 		_ = session.Query(`DELETE FROM gc_active_orgs WHERE bucket = ? AND org_id = ?`, bucket, orgID.String()).Exec()
 		_ = session.Query(`DELETE FROM gc_dirty_orgs WHERE bucket = ? AND org_id = ?`, bucket, orgID.String()).Exec()
-		resetGCQueueCountersForTest(t, orgID)
 		repairGCSnapshotsForTest(t, orgID)
 	})
 	snapshotBefore := readGCQueueSnapshotTotal(t)
@@ -1402,7 +1308,6 @@ func TestGC_MaxRetryItemMovesToFailedQueue(t *testing.T) {
 	`, orgID.String(), queueBucket, queuedAt, "unknown_type", itemID, libraryID.String(), "hot", 5).Exec(); err != nil {
 		t.Fatalf("failed to insert max-retry queue row: %v", err)
 	}
-	adjustGCQueueCountersForTest(t, orgID, queueBucket, 1, 0)
 	if err := session.Query(`
 		INSERT INTO gc_active_orgs (bucket, org_id, last_enqueued_at)
 		VALUES (?, ?, ?)
@@ -1462,7 +1367,6 @@ func TestGC_MaxRetryItemMovesToFailedQueue(t *testing.T) {
 		`, orgID.String(), failedAt, "unknown_type", itemID).Exec()
 		_ = session.Query(`DELETE FROM gc_active_orgs WHERE bucket = ? AND org_id = ?`, bucket, orgID.String()).Exec()
 		_ = session.Query(`DELETE FROM gc_dirty_orgs WHERE bucket = ? AND org_id = ?`, bucket, orgID.String()).Exec()
-		resetGCQueueCountersForTest(t, orgID)
 		repairGCSnapshotsForTest(t, orgID)
 	})
 
@@ -1521,7 +1425,6 @@ func TestGC_FailedItemsAdminEndpoints(t *testing.T) {
 		`, bucket, orgID.String(), time.Now().UTC()).Exec(); err != nil {
 			t.Fatalf("failed to insert dirty org row: %v", err)
 		}
-		adjustGCQueueCountersForTest(t, orgID, gcpkg.QueueBucket(orgID, gcpkg.ItemType("unknown_type"), itemID), 0, 1)
 	}
 
 	insertFailed(failedAtA, itemIDA)
@@ -1540,7 +1443,6 @@ func TestGC_FailedItemsAdminEndpoints(t *testing.T) {
 		_ = session.Query(`DELETE FROM gc_active_orgs WHERE bucket = ? AND org_id = ?`, bucket, orgID.String()).Exec()
 		_ = session.Query(`DELETE FROM gc_dirty_orgs WHERE bucket = ? AND org_id = ?`, bucket, orgID.String()).Exec()
 		_ = session.Query(`DELETE FROM gc_org_stats WHERE org_id = ?`, orgID.String()).Exec()
-		resetGCQueueCountersForTest(t, orgID)
 		repairGCSnapshotsForTest(t, orgID)
 	})
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -218,17 +218,6 @@ var (
 		},
 	)
 
-	// GCQueueCounterUpdateFailuresTotal counts failed writes to approximate GC
-	// queue/DLQ depth counters. Any sustained increase means status snapshots
-	// can drift until an explicit repair pass corrects the counters.
-	GCQueueCounterUpdateFailuresTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "gc_queue_counter_update_failures_total",
-			Help: "Total number of failed GC queue/DLQ depth counter updates.",
-		},
-		[]string{"counter"},
-	)
-
 	// GCActiveOrgRecoveryTriggersTotal counts how often the worker attempts to
 	// rebuild gc_active_orgs from gc_org_stats. Labelled by trigger source.
 	GCActiveOrgRecoveryTriggersTotal = prometheus.NewCounterVec(
@@ -359,7 +348,6 @@ func Register() {
 		GCSnapshotAgeSeconds,
 		GCReconcileDuration,
 		GCSnapshotDriftCorrectedTotal,
-		GCQueueCounterUpdateFailuresTotal,
 		GCActiveOrgRecoveryTriggersTotal,
 		GCActiveOrgRecoveriesTotal,
 		GCWorkerLastSuccessTimestamp,


### PR DESCRIPTION
- Removed deprecated methods for reading and adjusting queue depths in GCStore interface.
- Introduced RecalculateOrgQueueStats method to compute and save organization queue statistics.
- Updated CassandraStore to implement new queue statistics calculation logic.
- Simplified mock store by removing queue counter reconciliation logic.
- Adjusted integration tests to reflect changes in queue management and removed unnecessary counter adjustments.
- Cleaned up metrics by removing unused GCQueueCounterUpdateFailuresTotal counter.