### PR TITLE
fix(web-block-upload): global static block concurrency limiter

### DIFF
--- a/docs/WEB-BLOCK-UPLOAD.md
+++ b/docs/WEB-BLOCK-UPLOAD.md
@@ -398,10 +398,13 @@ is mapped onto the *legacy* resumable.js progress UI, which only understands
 - **No dedup/throughput observability.** The UI does not surface bytes already
   existing vs actually uploaded vs pending, nor the deduplicated percentage, so a
   fast repeat upload or an oddly-moving bar is unexplained to the user.
-- **Aggregated concurrency of multiple large files is unbounded across files.**
-  Each large file spawns its own orchestrator with internal block concurrency, so
-  `N` large files in one batch run `N × M` concurrent block operations
-  (hashing/network/backend). There is no cross-file ceiling yet.
+- **~~Aggregated concurrency of multiple large files is unbounded across files.~~ —
+  FIXED (PR2, global block-upload limiter).** Previously each large file spawned its
+  own orchestrator with its own pool, so `N` files ran `N × M` concurrent block
+  operations with no cross-file ceiling. A single shared `createBlockLimiter` now caps
+  the total blocks on the wire to the configured `simultaneous_uploads` ceiling; see
+  the "Frontend re-implementation from main → PR2" section below. (Hashing is still
+  per-file off-thread; the limiter bounds the network/backend block operations.)
 - **Cancel during `Saving…`/commit is undefined.** Cancel aborts the in-flight
   client requests, but its effect once the commit has started is not specified
   (whether the commit is interrupted, whether provisional refs linger until TTL,
@@ -450,9 +453,34 @@ must **not** reintroduce any target clearing.
   "preserves block entries when a legacy upload is added later".
 - Cancel-All now cancels every `!isSaved` entry (incl. a block at 100% in commit). Test:
   "cancel all still aborts a block upload that is already in saving at 100%".
-- Pending (next PRs): global adaptive block concurrency (static ceiling from
-  `simultaneous_uploads` first, then adaptive ramp); single-source upload list +
-  duplicate-name prompt for batch/large; broader browser E2E with the flag on.
+
+**PR2 — global STATIC block concurrency limiter (done; behind flag).**
+- Closed: CAS ignored global concurrency — each file ran its own pool of `3`, so N
+  files opened N×3 requests. New `frontend/src/utils/block-upload-limiter.js`
+  (`createBlockLimiter`) is a SINGLE semaphore shared by every block upload; the
+  ceiling is the config value `simultaneous_uploads` (via
+  `getBaselineSimultaneousUploads(props.simultaneousUploads || resumableSimultaneousUploads)`,
+  built once in `componentDidMount`) — the hardcoded `concurrency = 3` is removed from
+  the orchestrator (now `concurrency` is only a no-limiter test fallback, default 1).
+  Every block `acquire`s a slot before its network upload and releases after, so the
+  TOTAL blocks on the wire across ALL files never exceed the ceiling. Test:
+  `block-upload-orchestrator.test.js` "never exceeds the shared ceiling across multiple
+  files (no N×max)".
+- `acquire({ signal })` is signal-aware: an already-aborted signal rejects without
+  taking a slot; a waiter whose signal aborts is removed from the FIFO and never
+  uploads (no "ghost" upload after cancel). Tests: `block-upload-limiter.test.js`
+  "a waiter whose signal aborts…" + orchestrator "a block waiting for a slot is NOT
+  uploaded after its file is cancelled".
+- Anti-starvation: a file spawns at most `maxConcurrency` workers (NOT one waiter per
+  block) and each worker re-acquires at the back of the FIFO after every block, so
+  files interleave instead of the first one monopolising the queue. Test: orchestrator
+  "does not starve later files…".
+- STATIC ceiling here (`effective === max`); `setMax`/the adaptive ramp land in PR3.
+  The limiter is `reset()` on dialog close / cancel-all. Legacy resumable concurrency
+  (`upload-finalization.js` adaptive engine) is untouched — block-only.
+- Pending (next PRs): PR3 adaptive ramp (1→max by bandwidth, →1 on degrade); PR4
+  single-source upload list + duplicate-name prompt for batch/large; broader browser
+  E2E with the flag on.
 
 ## Known issues / deferred debts (tracked — gated by the flag being OFF in prod)
 

--- a/frontend/src/components/file-uploader/__tests__/block-upload-orchestrator.test.js
+++ b/frontend/src/components/file-uploader/__tests__/block-upload-orchestrator.test.js
@@ -1,4 +1,5 @@
 import { isStallError, uploadFileViaBlocks } from '../block-upload-orchestrator';
+import { createBlockLimiter } from '../../../utils/block-upload-limiter';
 
 jest.mock('../../../utils/seafile-api', () => ({ seafileAPI: {} }));
 jest.mock('../../../utils/constants', () => ({ enableBlockUpload: true, blockUploadThresholdMB: 64 }));
@@ -253,6 +254,105 @@ describe('stall watchdog', () => {
     expect(isStallError(stall)).toBe(true);
     expect(isStallError(abort)).toBe(false);
     expect(isStallError(null)).toBe(false);
+  });
+});
+
+describe('global concurrency limiter (shared across files)', () => {
+  // hashOf returns N blocks tagged by file (sha256 = `${tag}${i}` so the first char
+  // identifies the file in the upload-order trace).
+  const hashOf = (tag, n) => jest.fn().mockResolvedValue({
+    blocks: Array.from({ length: n }, (_, i) => ({ index: i, sha1: `${tag}sha1-${i}`, sha256: `${tag}${i}`, size: 1 })),
+    size: n,
+  });
+
+  test('never exceeds the shared ceiling across multiple files (no N×max)', async () => {
+    const track = { active: 0, peak: 0 };
+    const api = {
+      createBlockUploadSession: jest.fn().mockResolvedValue({ data: { session_id: 's' } }),
+      checkBlocks: jest.fn((batch) => Promise.resolve({ data: { missing: batch.slice() } })),
+      uploadBlock: jest.fn(() => {
+        track.active += 1;
+        track.peak = Math.max(track.peak, track.active);
+        return new Promise((resolve) => setTimeout(() => { track.active -= 1; resolve({ data: {} }); }, 0));
+      }),
+      createFileFromBlocks: jest.fn().mockResolvedValue({ data: [{ name: 'f', id: 'i', size: '1' }] }),
+    };
+    const limiter = createBlockLimiter({ maxConcurrency: 2 });
+
+    await Promise.all([
+      uploadFileViaBlocks(makeFile(4), { repoID: 'r', api, hashFn: hashOf('A', 4), blockSize: 1, limiter }),
+      uploadFileViaBlocks(makeFile(4), { repoID: 'r', api, hashFn: hashOf('B', 4), blockSize: 1, limiter }),
+      uploadFileViaBlocks(makeFile(4), { repoID: 'r', api, hashFn: hashOf('C', 4), blockSize: 1, limiter }),
+    ]);
+
+    // 3 files × 4 blocks were uploaded, but never more than 2 at once globally.
+    expect(api.uploadBlock).toHaveBeenCalledTimes(12);
+    expect(track.peak).toBeLessThanOrEqual(2);
+    expect(track.peak).toBeGreaterThan(0);
+    expect(limiter.getInFlight()).toBe(0);
+  });
+
+  test('does not starve later files: another file starts before the first finishes all its blocks', async () => {
+    const starts = [];
+    const api = {
+      createBlockUploadSession: jest.fn().mockResolvedValue({ data: { session_id: 's' } }),
+      checkBlocks: jest.fn((batch) => Promise.resolve({ data: { missing: batch.slice() } })),
+      uploadBlock: jest.fn((session, hash) => {
+        starts.push(hash[0]); // file tag
+        return new Promise((resolve) => setTimeout(() => resolve({ data: {} }), 0));
+      }),
+      createFileFromBlocks: jest.fn().mockResolvedValue({ data: [{ name: 'f', id: 'i', size: '1' }] }),
+    };
+    const limiter = createBlockLimiter({ maxConcurrency: 2 });
+
+    await Promise.all([
+      uploadFileViaBlocks(makeFile(6), { repoID: 'r', api, hashFn: hashOf('A', 6), blockSize: 1, limiter }),
+      uploadFileViaBlocks(makeFile(6), { repoID: 'r', api, hashFn: hashOf('B', 6), blockSize: 1, limiter }),
+      uploadFileViaBlocks(makeFile(6), { repoID: 'r', api, hashFn: hashOf('C', 6), blockSize: 1, limiter }),
+    ]);
+
+    // A worker re-queues at the back after each block, so a later file gets a turn
+    // before the first file drains all of its blocks (no FIFO monopoly).
+    const lastA = starts.lastIndexOf('A');
+    const firstNonA = starts.findIndex((t) => t !== 'A');
+    expect(firstNonA).toBeGreaterThanOrEqual(0);
+    expect(firstNonA).toBeLessThan(lastA);
+  });
+
+  test('a block waiting for a slot is NOT uploaded after its file is cancelled', async () => {
+    const calls = [];
+    let releaseA;
+    const api = {
+      createBlockUploadSession: jest.fn().mockResolvedValue({ data: { session_id: 's' } }),
+      checkBlocks: jest.fn((batch) => Promise.resolve({ data: { missing: batch.slice() } })),
+      uploadBlock: jest.fn((session, hash) => {
+        calls.push(hash);
+        return new Promise((resolve) => {
+          if (hash[0] === 'A') {
+            releaseA = () => resolve({ data: {} }); // A holds the only slot until we let go
+          }
+        });
+      }),
+      createFileFromBlocks: jest.fn().mockResolvedValue({ data: [{ name: 'f', id: 'i', size: '1' }] }),
+    };
+    const limiter = createBlockLimiter({ maxConcurrency: 1 });
+    const ctrlB = new AbortController();
+
+    const pA = uploadFileViaBlocks(makeFile(1), { repoID: 'r', api, hashFn: hashOf('A', 1), blockSize: 1, limiter });
+    await new Promise((r) => setTimeout(r, 5)); // let A take the only slot
+    const pB = uploadFileViaBlocks(makeFile(1), {
+      repoID: 'r', api, hashFn: hashOf('B', 1), blockSize: 1, limiter, signal: ctrlB.signal,
+    });
+    await new Promise((r) => setTimeout(r, 5)); // B's block is now queued behind A
+
+    ctrlB.abort(); // cancel B while it waits for a slot
+    await expect(pB).rejects.toHaveProperty('name', 'AbortError');
+    expect(calls).toEqual(['A0']); // B never uploaded
+
+    releaseA();
+    await pA;
+    expect(calls).toEqual(['A0']); // still only A even after the slot freed
+    expect(limiter.getInFlight()).toBe(0);
   });
 });
 

--- a/frontend/src/components/file-uploader/block-upload-orchestrator.js
+++ b/frontend/src/components/file-uploader/block-upload-orchestrator.js
@@ -305,14 +305,38 @@ async function withRetry(fn, attempts, { signal } = {}) {
   throw lastErr;
 }
 
-// uploadMissingBlocks uploads the given block hashes with bounded concurrency
-// using a fixed pool of workers that pull from a shared cursor.
-// `getBlockData(index)` returns a Promise of the raw bytes for that block.
+// uploadMissingBlocks uploads the given block hashes, gating EACH block on a slot
+// from the shared global `limiter` so the total number of blocks on the wire across
+// ALL files never exceeds the configured ceiling. `getBlockData(index)` returns a
+// Promise of the raw bytes for that block.
+//
+// Anti-starvation: this file spawns at most `limiter.getMaxConcurrency()` workers
+// (NOT one waiter per block), and each worker re-acquires a slot AFTER finishing a
+// block — so it re-queues at the back of the limiter's FIFO and multiple files
+// interleave fairly instead of the first file holding every slot until it is done.
+// `getBlockData` (local byte read) runs OUTSIDE the slot; only the network upload
+// holds it. When no limiter is injected (unit tests) it falls back to a plain pool
+// of `concurrency` workers with no global gating.
 async function uploadMissingBlocks(session, missing, blockIndexByHash, getBlockData, {
-  api, concurrency, retries, onBlockUploaded, onTransferProgress, signal, stallMs, responseTimeoutMs,
+  api, concurrency, retries, onBlockUploaded, onTransferProgress, signal, stallMs, responseTimeoutMs, limiter,
 }) {
   let cursor = 0;
   let uploadedCount = 0;
+
+  const uploadOne = (hash, index) => withRetry(async () => {
+    throwIfAborted(signal);
+    const data = await getBlockData(index);
+    throwIfAborted(signal);
+    if (!limiter) {
+      return uploadBlockWithStallGuard(api, session, hash, data, { signal, stallMs, responseTimeoutMs, onTransferProgress });
+    }
+    const release = await limiter.acquire({ signal });
+    try {
+      return await uploadBlockWithStallGuard(api, session, hash, data, { signal, stallMs, responseTimeoutMs, onTransferProgress });
+    } finally {
+      release();
+    }
+  }, retries, { signal });
 
   const worker = async () => {
     for (;;) {
@@ -321,25 +345,17 @@ async function uploadMissingBlocks(session, missing, blockIndexByHash, getBlockD
       cursor += 1;
       if (i >= missing.length) return;
       const hash = missing[i];
-      const index = blockIndexByHash[hash];
       // eslint-disable-next-line no-await-in-loop
-      await withRetry(async () => {
-        throwIfAborted(signal);
-        const data = await getBlockData(index);
-        throwIfAborted(signal);
-        return uploadBlockWithStallGuard(api, session, hash, data, {
-          signal,
-          stallMs,
-          responseTimeoutMs,
-          onTransferProgress,
-        });
-      }, retries, { signal });
+      await uploadOne(hash, blockIndexByHash[hash]);
       uploadedCount += 1;
       if (onBlockUploaded) onBlockUploaded(uploadedCount, missing.length);
     }
   };
 
-  const poolSize = Math.min(concurrency, missing.length) || 0;
+  // Cap workers at the global ceiling (a single file may use every slot) without
+  // exceeding the number of blocks. No limiter → fall back to `concurrency`.
+  const cap = limiter ? limiter.getMaxConcurrency() : concurrency;
+  const poolSize = Math.min(cap || 1, missing.length) || 0;
   const workers = [];
   for (let w = 0; w < poolSize; w += 1) {
     workers.push(worker());
@@ -409,7 +425,12 @@ export async function uploadFileViaBlocks(file, {
   api = seafileAPI,
   hashFn = hashFileWithWorker,
   blockSize = BLOCK_SIZE,
-  concurrency = 3,
+  // Global per-component concurrency limiter shared across all block uploads; it
+  // bounds the TOTAL blocks on the wire to the configured ceiling. `concurrency` is
+  // only the fallback pool size when no limiter is injected (unit tests). No more
+  // hardcoded per-file "3" — production always injects `limiter`.
+  limiter = null,
+  concurrency = 1,
   retries = 3,
   commitRetries = 6,
   commitRetryBaseMs = 500,
@@ -473,6 +494,7 @@ export async function uploadFileViaBlocks(file, {
   await uploadMissingBlocks(session, missing, blockIndexByHash, getBlockData, {
     api,
     concurrency,
+    limiter,
     retries,
     onBlockUploaded: onUploadProgress,
     onTransferProgress,
@@ -508,6 +530,7 @@ export async function uploadFileViaBlocks(file, {
       await uploadMissingBlocks(session, needs, blockIndexByHash, getBlockData, {
         api,
         concurrency,
+        limiter,
         retries,
         onBlockUploaded: onUploadProgress,
         onTransferProgress,

--- a/frontend/src/components/file-uploader/file-uploader.js
+++ b/frontend/src/components/file-uploader/file-uploader.js
@@ -8,6 +8,7 @@ import { aggregateBlockUploadBitrate, clearFileUploadRuntimeState, getBaselineSi
 import { Utils } from '../../utils/utils';
 import { gettext } from '../../utils/constants';
 import UploadNavigationGuard from '../../utils/upload-navigation-guard';
+import { createBlockLimiter } from '../../utils/block-upload-limiter';
 import UploadProgressDialog from './upload-progress-dialog';
 import UploadRemindDialog from '../dialog/upload-remind-dialog';
 import toaster from '../toast';
@@ -70,6 +71,10 @@ class FileUploader extends React.Component {
     this.navigationGuard.attach();
     const configuredSimultaneousUploads = getBaselineSimultaneousUploads(this.props.simultaneousUploads || resumableSimultaneousUploads);
     const simultaneousUploads = getInitialSimultaneousUploads(configuredSimultaneousUploads);
+    // Single GLOBAL block-upload limiter shared by every block (CAS) upload, so the
+    // total blocks on the wire across all files never exceed the configured ceiling
+    // (`simultaneous_uploads`). Static here; the adaptive ramp lands in a later PR.
+    this.blockLimiter = createBlockLimiter({ maxConcurrency: configuredSimultaneousUploads });
     this.resumable = new Resumablejs({
       target: '',
       query: this.setQuery || {},
@@ -426,6 +431,8 @@ class FileUploader extends React.Component {
       parentDir: path,
       filename: file.name,
       replace: false,
+      // Shared global ceiling: every block upload competes for the same slots.
+      limiter: this.blockLimiter,
       signal: abortController ? abortController.signal : undefined,
       onPhase: (phase) => this.setBlockUploadPhase(entry, phase),
       onHashProgress: (hashed, total) => this.updateBlockUploadProgress(entry, (total ? hashed / total : 0) * 0.5),
@@ -955,6 +962,9 @@ class FileUploader extends React.Component {
 
   onCloseUploadDialog = () => {
     this.cancelActiveUploads();
+    if (this.blockLimiter) {
+      this.blockLimiter.reset();
+    }
     this.loaded = 0;
     this.legacyUploadBitrate = 0;
     this.resumable.files = [];
@@ -1007,6 +1017,9 @@ class FileUploader extends React.Component {
 
     this.loaded = 0;
     this.legacyUploadBitrate = 0;
+    if (this.blockLimiter) {
+      this.blockLimiter.reset();
+    }
 
     this.setState({
       totalProgress: 100,

--- a/frontend/src/utils/__tests__/block-upload-limiter.test.js
+++ b/frontend/src/utils/__tests__/block-upload-limiter.test.js
@@ -1,0 +1,94 @@
+import { createBlockLimiter } from '../block-upload-limiter';
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('createBlockLimiter (static global ceiling)', () => {
+  test('never lets more than max acquire at once; release wakes the next waiter FIFO', async () => {
+    const limiter = createBlockLimiter({ maxConcurrency: 2 });
+    const r1 = await limiter.acquire({});
+    const r2 = await limiter.acquire({});
+    expect(limiter.getInFlight()).toBe(2);
+
+    let third = false;
+    let fourth = false;
+    const p3 = limiter.acquire({}).then((rel) => { third = true; return rel; });
+    const p4 = limiter.acquire({}).then((rel) => { fourth = true; return rel; });
+    await flush();
+    // Both are blocked while the 2 slots are held.
+    expect(third).toBe(false);
+    expect(fourth).toBe(false);
+    expect(limiter.getWaiterCount()).toBe(2);
+
+    r1(); // free one slot → p3 (FIFO front) wakes, p4 still waits
+    const r3 = await p3;
+    expect(third).toBe(true);
+    expect(fourth).toBe(false);
+    expect(limiter.getInFlight()).toBe(2);
+
+    r2();
+    const r4 = await p4;
+    expect(fourth).toBe(true);
+
+    r3();
+    r4();
+    expect(limiter.getInFlight()).toBe(0);
+  });
+
+  test('acquire with an already-aborted signal rejects without taking a slot', async () => {
+    const limiter = createBlockLimiter({ maxConcurrency: 2 });
+    const controller = new AbortController();
+    controller.abort();
+    await expect(limiter.acquire({ signal: controller.signal })).rejects.toHaveProperty('name', 'AbortError');
+    expect(limiter.getInFlight()).toBe(0);
+  });
+
+  test('a waiter whose signal aborts is removed from the queue and never acquires', async () => {
+    const limiter = createBlockLimiter({ maxConcurrency: 1 });
+    const held = await limiter.acquire({}); // fills the only slot
+    const controller = new AbortController();
+    let acquired = false;
+    const p = limiter.acquire({ signal: controller.signal });
+    p.then(() => { acquired = true; }).catch(() => {});
+    await flush();
+    expect(limiter.getWaiterCount()).toBe(1);
+
+    controller.abort();
+    await expect(p).rejects.toHaveProperty('name', 'AbortError');
+    expect(limiter.getWaiterCount()).toBe(0);
+
+    held(); // releasing must NOT resurrect the aborted waiter
+    await flush();
+    expect(acquired).toBe(false);
+    expect(limiter.getInFlight()).toBe(0);
+  });
+
+  test('release is idempotent — a double release does not over-free slots', async () => {
+    const limiter = createBlockLimiter({ maxConcurrency: 1 });
+    const rel = await limiter.acquire({});
+    rel();
+    rel();
+    expect(limiter.getInFlight()).toBe(0);
+    const rel2 = await limiter.acquire({});
+    expect(limiter.getInFlight()).toBe(1);
+    rel2();
+  });
+
+  test('ceiling comes from maxConcurrency and is clamped to >= 1', () => {
+    expect(createBlockLimiter({ maxConcurrency: 3 }).getMaxConcurrency()).toBe(3);
+    expect(createBlockLimiter({ maxConcurrency: 0 }).getMaxConcurrency()).toBe(1);
+    expect(createBlockLimiter({}).getMaxConcurrency()).toBe(1);
+  });
+
+  test('reset rejects queued waiters and restores the ceiling', async () => {
+    const limiter = createBlockLimiter({ maxConcurrency: 1 });
+    const held = await limiter.acquire({});
+    const p = limiter.acquire({});
+    await flush();
+    expect(limiter.getWaiterCount()).toBe(1);
+
+    limiter.reset();
+    await expect(p).rejects.toHaveProperty('name', 'AbortError');
+    expect(limiter.getWaiterCount()).toBe(0);
+    held();
+  });
+});

--- a/frontend/src/utils/block-upload-limiter.js
+++ b/frontend/src/utils/block-upload-limiter.js
@@ -1,0 +1,121 @@
+// Global concurrency limiter for web block (content-addressed / CAS) uploads.
+//
+// WHY: each block-upload file runs its own orchestrator. Without a SHARED limiter
+// every file uploaded its blocks with its own fixed pool, so N large files dropped
+// at once opened N×pool concurrent requests — there was no cross-file ceiling. This
+// limiter is a single semaphore shared by every block upload in the component, so
+// the TOTAL number of blocks on the wire never exceeds the configured ceiling
+// (`simultaneous_uploads`, sourced from config — never hardcoded here).
+//
+// PR2 (this module): STATIC ceiling — `effective === max` always. A later PR adds an
+// adaptive ramp (start at 1, climb to `max` while the link stays healthy, drop back
+// to 1 when it degrades) by moving `effective` via setMax/note* hooks; the acquire
+// machinery here already honours a changing `effective`.
+
+function createAbortError() {
+  if (typeof DOMException === 'function') {
+    return new DOMException('Upload aborted', 'AbortError');
+  }
+  const error = new Error('Upload aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+// createBlockLimiter returns a shared async semaphore.
+//   acquire({ signal }) -> Promise<release>
+//     - resolves with an idempotent release() once a slot is free;
+//     - if `signal` is already aborted, rejects immediately WITHOUT taking a slot;
+//     - if it is waiting and `signal` aborts, it is removed from the queue and
+//       rejects (no "ghost" upload that starts after the user cancelled).
+//   release() (the resolved value) frees the slot and hands it to the next waiter.
+export function createBlockLimiter({ maxConcurrency } = {}) {
+  const max = Math.max(1, Math.floor(Number(maxConcurrency) || 1));
+  // effective is the live ceiling acquire() honours. Static (= max) in this PR.
+  let effective = max;
+  let inFlight = 0;
+  const waiters = []; // FIFO: { resolve, reject, signal, onAbort }
+
+  const detachAbort = (waiter) => {
+    if (waiter.signal && waiter.onAbort) {
+      waiter.signal.removeEventListener('abort', waiter.onAbort);
+      waiter.onAbort = null;
+    }
+  };
+
+  const makeRelease = () => {
+    let released = false;
+    return () => {
+      if (released) {
+        return; // idempotent: a double release must not free someone else's slot
+      }
+      released = true;
+      inFlight -= 1;
+      pump();
+    };
+  };
+
+  // Hand free slots to queued waiters in FIFO order. A worker that finishes a block
+  // and calls acquire() again goes to the BACK of this queue, so multiple files
+  // interleave fairly instead of the first file monopolising every slot.
+  function pump() {
+    while (waiters.length > 0 && inFlight < effective) {
+      const waiter = waiters.shift();
+      detachAbort(waiter);
+      inFlight += 1;
+      waiter.resolve(makeRelease());
+    }
+  }
+
+  const acquire = ({ signal } = {}) => {
+    if (signal && signal.aborted) {
+      return Promise.reject(createAbortError());
+    }
+    if (inFlight < effective) {
+      inFlight += 1;
+      return Promise.resolve(makeRelease());
+    }
+    return new Promise((resolve, reject) => {
+      const waiter = { resolve, reject, signal, onAbort: null };
+      if (signal) {
+        waiter.onAbort = () => {
+          const idx = waiters.indexOf(waiter);
+          if (idx !== -1) {
+            waiters.splice(idx, 1);
+          }
+          reject(createAbortError());
+        };
+        signal.addEventListener('abort', waiter.onAbort, { once: true });
+      }
+      waiters.push(waiter);
+    });
+  };
+
+  // setMax moves the live ceiling within [1, max]. Used by the adaptive ramp (later
+  // PR); included here so acquire/pump already react to a changing ceiling.
+  const setMax = (n) => {
+    effective = Math.max(1, Math.min(max, Math.floor(Number(n) || 1)));
+    pump();
+  };
+
+  // reset drops any queued waiters (their session ended/was cancelled) and restores
+  // the static ceiling. It does NOT zero inFlight: live uploads release their own
+  // slot via the finally release(), so the count self-heals.
+  const reset = () => {
+    while (waiters.length > 0) {
+      const waiter = waiters.shift();
+      detachAbort(waiter);
+      waiter.reject(createAbortError());
+    }
+    effective = max;
+  };
+
+  return {
+    acquire,
+    setMax,
+    reset,
+    getEffective: () => effective,
+    getMaxConcurrency: () => max,
+    getInFlight: () => inFlight,
+    getWaiterCount: () => waiters.length,
+  };
+}


### PR DESCRIPTION
Each block-upload file previously ran its own orchestrator with a hardcoded pool of 3, so N large files dropped at once opened N×3 concurrent requests with no cross-file ceiling.

Add a single shared `createBlockLimiter` (frontend/src/utils/block-upload-limiter.js) whose ceiling is the configured `simultaneous_uploads` value (sourced from config via resumableSimultaneousUploads, built once in componentDidMount). The hardcoded `concurrency = 3` is removed from the orchestrator; every block now acquires a slot before its network upload and releases after, so the total blocks on the wire across ALL files never exceed the ceiling.

- acquire({ signal }) is signal-aware: an already-aborted signal rejects without taking a slot; a waiting block whose signal aborts is removed from the FIFO and never uploads (no ghost upload after cancel).
- Anti-starvation: a file spawns at most maxConcurrency workers (not one waiter per block) and re-acquires at the back of the FIFO after each block, so files interleave instead of the first one monopolising the queue.
- Static ceiling here (effective === max); adaptive ramp lands in the next PR. Legacy resumable concurrency is untouched (block-only).

Tests: block-upload-limiter.test.js (ceiling, signal-aware cancel, FIFO, idempotent release, reset) + orchestrator integration (shared ceiling across files, no starvation, cancel a block waiting for a slot). 324 frontend tests green, lint + production build clean.