### PR TITLE
feat(block-ids): PR1+PR2 additive base for SHA-256 canonical block IDs

### DIFF
--- a/docs/SHA256-CANONICAL-BLOCK-IDS.md
+++ b/docs/SHA256-CANONICAL-BLOCK-IDS.md
@@ -30,6 +30,23 @@ this evolves), [CHUNKING-ANALYSIS.md](./CHUNKING-ANALYSIS.md).
   `blocks.sha1`, this path must supply the block's SHA-1 (or compute it locally) or
   template-created files would get an empty Seafile block id and break desktop `fs_id` matching.
 
+### Gating rule for the next branch (PR4/PR5)
+
+Do **not** start PR4/PR5 until both are closed:
+
+1. **Close the template-block TODO above** — `CreateFile` must persist a real `blocks.sha1`.
+2. **Add fail-closed validation of `blocks.sha1` at the point of consumption.** `ProbeBlockReuse`
+   exposes `Sha1` raw (only `TrimSpace`d); the commit that uses it as the source for
+   `seafile_block_ids_sha1` / `fs_id` (PR5) MUST reject empty or non-40-hex values by treating
+   the block as `needs_upload` (the re-upload recomputes and rewrites a verified `sha1`) — never
+   write an unvalidated SHA-1 into an fs_object. Reuse `isHex40`
+   ([file_from_blocks.go:134](../internal/api/v2/file_from_blocks.go#L134)); mirror the existing
+   R1/R10 "forward mapping missing → needs_upload" pattern. Fail closed, never silently.
+
+Also add, when the value first drives `fs_id` (PR5): a test with a **real 40-hex SHA-1** plus the
+integration round-trip asserting the desktop-expected `fs_id` (the current plumbing tests use
+`"sha1-1"`/`"ext-1"`, which only prove the argument travels).
+
 ---
 
 ## a. Context and goal

--- a/docs/SHA256-CANONICAL-BLOCK-IDS.md
+++ b/docs/SHA256-CANONICAL-BLOCK-IDS.md
@@ -1,11 +1,34 @@
 # SHA-256 canonical block IDs (and removing SHA-1 from the web client)
 
 **Date:** 2026-06-29
-**Status:** Design + PR breakdown. Not yet implemented.
+**Status:** Design + PR breakdown. PR1 and PR2 are implemented in the workspace and pending
+review/commit; PR3+ remain pending.
 **Supersedes:** the out-of-tree `implementation_plan.md` draft (backend/read-side only),
 which is removed in favour of this document.
 **Related:** [WEB-BLOCK-UPLOAD.md](./WEB-BLOCK-UPLOAD.md) (R10 dual-hash, the current state
 this evolves), [CHUNKING-ANALYSIS.md](./CHUNKING-ANALYSIS.md).
+
+## Progress
+
+- `PR1` — implemented in workspace: additive migration `005_sha256_canonical_block_ids.cql`,
+  `internal/models` fields for `seafile_block_ids_sha1` / `blocks.sha1`, and regression coverage
+  for the new migration + JSON shape. No behavior has been flipped yet.
+- `PR2` — implemented in workspace: `blocks.sha1` is now written from verified bytes on the web
+  block-upload materialization path and the legacy seafhttp upload/finalize path, and
+  `ProbeBlockReuse` now reads/exposes `sha1` for later commit-time use.
+- `PR3`–`PR7` — pending.
+
+## Notes / Debt
+
+- The current additive/no-backfill approach still assumes the current pre-deploy / empty-DB
+  rollout. If this branch were ever applied to a non-empty environment, older `blocks` rows would
+  retain empty `sha1` until a dedicated backfill or rewrite path is added.
+- **TODO (before PR4/PR5):** the template-block path in `CreateFile`
+  ([files.go:1355](../internal/api/v2/files.go#L1355)) currently registers its block with an
+  empty `sha1` (the SHA-1 is not threaded there yet). That is harmless while nothing reads
+  `blocks.sha1`, but once PR4/PR5 derive `seafile_block_ids_sha1` / the `fs_id` from
+  `blocks.sha1`, this path must supply the block's SHA-1 (or compute it locally) or
+  template-created files would get an empty Seafile block id and break desktop `fs_id` matching.
 
 ---
 

--- a/internal/api/v2/files.go
+++ b/internal/api/v2/files.go
@@ -1352,7 +1352,7 @@ func (h *FileHandler) CreateFile(c *gin.Context) {
 			}, func() error {
 				// Keep the freshly stored template block alive and respect the GC
 				// delete fence until publish-attempt refs take over below.
-				if err := fsHelper.RegisterUploadedBlock(orgID, repoID, templateBlockData.Hash, uploadOperationID, int(fileSize), templateStorageClass, ""); err != nil {
+				if err := fsHelper.RegisterUploadedBlock(orgID, repoID, templateBlockData.Hash, uploadOperationID, int(fileSize), templateStorageClass, "", ""); err != nil {
 					return fmt.Errorf("failed to register template block metadata: %w", err)
 				}
 				templateBlockPinned = true

--- a/internal/api/v2/fs_helpers.go
+++ b/internal/api/v2/fs_helpers.go
@@ -93,8 +93,8 @@ var registerUploadedBlockReleaseClaimFn = func(h *FSHelper, orgID, blockID, clai
 	return h.db.ReleaseBlockDeleteClaim(orgID, blockID, claimID)
 }
 
-var registerUploadedBlockUpsertMetadataFn = func(h *FSHelper, orgID, blockID string, sizeBytes int, storageClass, storageKey string) error {
-	return h.db.UpsertBlockMetadata(orgID, blockID, sizeBytes, storageClass, storageKey)
+var registerUploadedBlockUpsertMetadataFn = func(h *FSHelper, orgID, blockID, sha1ID string, sizeBytes int, storageClass, storageKey string) error {
+	return h.db.UpsertBlockMetadataWithSHA1(orgID, blockID, sha1ID, sizeBytes, storageClass, storageKey)
 }
 
 var registerUploadedBlockUpsertProvisionalExpiryFn = func(h *FSHelper, orgID, blockID, referrer, storageClass string, expiresAt time.Time) error {
@@ -1008,7 +1008,7 @@ func (h *FSHelper) releaseStaleUploadedBlockDeleteClaim(orgID, blockID string) (
 	return released, nil
 }
 
-func (h *FSHelper) RegisterUploadedBlock(orgID, libraryID, blockID, operationID string, sizeBytes int, storageClass, storageKey string) error {
+func (h *FSHelper) RegisterUploadedBlock(orgID, libraryID, blockID, operationID string, sizeBytes int, storageClass, storageKey, sha1ID string) error {
 	referrer := db.BlockReferrerForUpload(operationID)
 	expiresAt := time.Now().UTC().Add(time.Duration(db.ProvisionalBlockReferenceTTLSeconds) * time.Second)
 
@@ -1032,7 +1032,7 @@ func (h *FSHelper) RegisterUploadedBlock(orgID, libraryID, blockID, operationID 
 			return fmt.Errorf("read block delete fence for %s: %w", blockID, err)
 		}
 		if !deleteFenceActive {
-			if err := registerUploadedBlockUpsertMetadataFn(h, orgID, blockID, sizeBytes, storageClass, storageKey); err != nil {
+			if err := registerUploadedBlockUpsertMetadataFn(h, orgID, blockID, sha1ID, sizeBytes, storageClass, storageKey); err != nil {
 				return fmt.Errorf("upsert block metadata for %s: %w", blockID, err)
 			}
 			return nil

--- a/internal/api/v2/fs_helpers_test.go
+++ b/internal/api/v2/fs_helpers_test.go
@@ -205,10 +205,10 @@ func TestRegisterUploadedBlock_RetriesFenceWithoutDroppingProvisionalRef(t *test
 		t.Fatal("stale claim release should not run for a normal retrying fence")
 		return false, nil
 	}
-	registerUploadedBlockUpsertMetadataFn = func(h *FSHelper, orgID, blockID string, sizeBytes int, storageClass, storageKey string) error {
+	registerUploadedBlockUpsertMetadataFn = func(h *FSHelper, orgID, blockID, sha1ID string, sizeBytes int, storageClass, storageKey string) error {
 		calls = append(calls, "upsert")
-		if sizeBytes != 123 || storageClass != "hot" || storageKey != "key-1" {
-			t.Fatalf("upsert args = %d/%s/%s, want 123/hot/key-1", sizeBytes, storageClass, storageKey)
+		if sizeBytes != 123 || storageClass != "hot" || storageKey != "key-1" || sha1ID != "sha1-1" {
+			t.Fatalf("upsert args = %d/%s/%s/%s, want 123/hot/key-1/sha1-1", sizeBytes, storageClass, storageKey, sha1ID)
 		}
 		return nil
 	}
@@ -235,7 +235,7 @@ func TestRegisterUploadedBlock_RetriesFenceWithoutDroppingProvisionalRef(t *test
 		calls = append(calls, fmt.Sprintf("sleep-%s", delay))
 	}
 
-	err := helper.RegisterUploadedBlock("org-1", "lib-1", "block-1", "op-1", 123, "hot", "key-1")
+	err := helper.RegisterUploadedBlock("org-1", "lib-1", "block-1", "op-1", 123, "hot", "key-1", "sha1-1")
 	if err != nil {
 		t.Fatalf("RegisterUploadedBlock() error = %v, want nil", err)
 	}
@@ -295,8 +295,11 @@ func TestRegisterUploadedBlock_ReleasesStaleDeleteClaimWithEmptyStorageClass(t *
 		}
 		return true, nil
 	}
-	registerUploadedBlockUpsertMetadataFn = func(h *FSHelper, orgID, blockID string, sizeBytes int, storageClass, storageKey string) error {
+	registerUploadedBlockUpsertMetadataFn = func(h *FSHelper, orgID, blockID, sha1ID string, sizeBytes int, storageClass, storageKey string) error {
 		calls = append(calls, "upsert")
+		if sha1ID != "sha1-1" {
+			t.Fatalf("sha1ID = %q, want sha1-1", sha1ID)
+		}
 		return nil
 	}
 	registerUploadedBlockUpsertProvisionalExpiryFn = func(h *FSHelper, orgID, blockID, referrer, storageClass string, expiresAt time.Time) error {
@@ -315,7 +318,7 @@ func TestRegisterUploadedBlock_ReleasesStaleDeleteClaimWithEmptyStorageClass(t *
 		t.Fatalf("sleep should not run when stale claim release succeeds, got %s", delay)
 	}
 
-	if err := helper.RegisterUploadedBlock("org-1", "lib-1", "block-1", "op-1", 123, "hot", "key-1"); err != nil {
+	if err := helper.RegisterUploadedBlock("org-1", "lib-1", "block-1", "op-1", 123, "hot", "key-1", "sha1-1"); err != nil {
 		t.Fatalf("RegisterUploadedBlock() error = %v, want nil", err)
 	}
 	want := []string{"add", "expiry", "fence-1", "claim-info", "release-claim", "fence-2", "upsert"}
@@ -348,7 +351,7 @@ func TestRegisterUploadedBlock_RecordsProvisionalExpiryAtTTL(t *testing.T) {
 	registerUploadedBlockFenceActiveFn = func(h *FSHelper, orgID, blockID string) (bool, error) {
 		return false, nil
 	}
-	registerUploadedBlockUpsertMetadataFn = func(h *FSHelper, orgID, blockID string, sizeBytes int, storageClass, storageKey string) error {
+	registerUploadedBlockUpsertMetadataFn = func(h *FSHelper, orgID, blockID, sha1ID string, sizeBytes int, storageClass, storageKey string) error {
 		return nil
 	}
 
@@ -362,7 +365,7 @@ func TestRegisterUploadedBlock_RecordsProvisionalExpiryAtTTL(t *testing.T) {
 	}
 
 	before := time.Now().UTC()
-	err := helper.RegisterUploadedBlock("org-1", "lib-1", "block-1", "op-1", 123, "hot", "key-1")
+	err := helper.RegisterUploadedBlock("org-1", "lib-1", "block-1", "op-1", 123, "hot", "key-1", "sha1-1")
 	after := time.Now().UTC()
 	if err != nil {
 		t.Fatalf("RegisterUploadedBlock() error = %v, want nil", err)
@@ -403,7 +406,7 @@ func TestRegisterUploadedBlock_RollsBackWhenExpiryTrackingFails(t *testing.T) {
 		t.Fatal("fence check should not run when expiry tracking fails")
 		return false, nil
 	}
-	registerUploadedBlockUpsertMetadataFn = func(h *FSHelper, orgID, blockID string, sizeBytes int, storageClass, storageKey string) error {
+	registerUploadedBlockUpsertMetadataFn = func(h *FSHelper, orgID, blockID, sha1ID string, sizeBytes int, storageClass, storageKey string) error {
 		t.Fatal("metadata upsert should not run when expiry tracking fails")
 		return nil
 	}
@@ -420,7 +423,7 @@ func TestRegisterUploadedBlock_RollsBackWhenExpiryTrackingFails(t *testing.T) {
 		calls = append(calls, "enqueue")
 	}
 
-	err := helper.RegisterUploadedBlock("org-1", "lib-1", "block-1", "op-1", 123, "hot", "key-1")
+	err := helper.RegisterUploadedBlock("org-1", "lib-1", "block-1", "op-1", 123, "hot", "key-1", "sha1-1")
 	if !errors.Is(err, expiryErr) {
 		t.Fatalf("RegisterUploadedBlock() error = %v, want wrapped %v", err, expiryErr)
 	}
@@ -465,7 +468,7 @@ func TestRegisterUploadedBlock_ReenqueuesZeroRefWhenFenceNeverClears(t *testing.
 		calls = append(calls, "fence")
 		return true, nil
 	}
-	registerUploadedBlockUpsertMetadataFn = func(h *FSHelper, orgID, blockID string, sizeBytes int, storageClass, storageKey string) error {
+	registerUploadedBlockUpsertMetadataFn = func(h *FSHelper, orgID, blockID, sha1ID string, sizeBytes int, storageClass, storageKey string) error {
 		t.Fatal("upsert should not run while the delete fence remains active")
 		return nil
 	}
@@ -497,7 +500,7 @@ func TestRegisterUploadedBlock_ReenqueuesZeroRefWhenFenceNeverClears(t *testing.
 		}
 	}
 
-	err := helper.RegisterUploadedBlock("org-1", "lib-1", "block-1", "op-1", 123, "hot", "")
+	err := helper.RegisterUploadedBlock("org-1", "lib-1", "block-1", "op-1", 123, "hot", "", "")
 	if !errors.Is(err, ErrBlockDeleteInProgress) {
 		t.Fatalf("RegisterUploadedBlock() error = %v, want ErrBlockDeleteInProgress", err)
 	}

--- a/internal/api/v2/upload_rollback.go
+++ b/internal/api/v2/upload_rollback.go
@@ -11,8 +11,8 @@ import (
 )
 
 var rollbackUploadedBlockRefsFn = RollbackUploadedBlockRefs
-var registerUploadedBlockForMaterializationFn = func(database *db.DB, orgID, repoID, internalBlockID, operationID string, sizeBytes int, storageClass, storageKey string) error {
-	return NewFSHelper(database).RegisterUploadedBlock(orgID, repoID, internalBlockID, operationID, sizeBytes, storageClass, storageKey)
+var registerUploadedBlockForMaterializationFn = func(database *db.DB, orgID, repoID, internalBlockID, operationID string, sizeBytes int, storageClass, storageKey, sha1ID string) error {
+	return NewFSHelper(database).RegisterUploadedBlock(orgID, repoID, internalBlockID, operationID, sizeBytes, storageClass, storageKey, sha1ID)
 }
 var writeBlockMappingForMaterializationFn = func(database *db.DB, orgID, externalBlockID, internalBlockID string) error {
 	if database == nil {
@@ -63,7 +63,7 @@ func RollbackUploadedBlockRefs(database *db.DB, orgID, repoID, operationID strin
 // provisional reference is rolled back so retries can restart from a clean
 // state instead of leaving a registered block without a usable mapping.
 func RegisterUploadedBlockAndMapping(database *db.DB, orgID, repoID, internalBlockID, operationID string, sizeBytes int, storageClass, storageKey, externalBlockID string) error {
-	if err := registerUploadedBlockForMaterializationFn(database, orgID, repoID, internalBlockID, operationID, sizeBytes, storageClass, storageKey); err != nil {
+	if err := registerUploadedBlockForMaterializationFn(database, orgID, repoID, internalBlockID, operationID, sizeBytes, storageClass, storageKey, externalBlockID); err != nil {
 		return err
 	}
 	if strings.TrimSpace(externalBlockID) == "" {
@@ -88,7 +88,7 @@ func RegisterUploadedBlockAndMapping(database *db.DB, orgID, repoID, internalBlo
 // A db.ErrBlockIDMappingConflict is returned unwrapped (so callers can errors.Is
 // it into a 409); any other mapping failure is wrapped as ErrBlockMappingWriteFailed.
 func RegisterWebUploadedBlockAndMapping(database *db.DB, orgID, repoID, internalBlockID, operationID string, sizeBytes int, storageClass, storageKey, externalBlockID string) error {
-	if err := registerUploadedBlockForMaterializationFn(database, orgID, repoID, internalBlockID, operationID, sizeBytes, storageClass, storageKey); err != nil {
+	if err := registerUploadedBlockForMaterializationFn(database, orgID, repoID, internalBlockID, operationID, sizeBytes, storageClass, storageKey, externalBlockID); err != nil {
 		return err
 	}
 	if strings.TrimSpace(externalBlockID) == "" {

--- a/internal/api/v2/upload_rollback_test.go
+++ b/internal/api/v2/upload_rollback_test.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/Sesame-Disk/sesamefs/internal/db"
@@ -18,8 +19,11 @@ func TestRegisterUploadedBlockAndMapping_WritesMappingAfterMetadata(t *testing.T
 	}()
 
 	var calls []string
-	registerUploadedBlockForMaterializationFn = func(database *db.DB, orgID, repoID, internalBlockID, operationID string, sizeBytes int, storageClass, storageKey string) error {
+	registerUploadedBlockForMaterializationFn = func(database *db.DB, orgID, repoID, internalBlockID, operationID string, sizeBytes int, storageClass, storageKey, sha1ID string) error {
 		calls = append(calls, "register")
+		if sha1ID != "ext-1" {
+			t.Fatalf("sha1ID = %q, want ext-1", sha1ID)
+		}
 		return nil
 	}
 	writeBlockMappingForMaterializationFn = func(database *db.DB, orgID, externalBlockID, internalBlockID string) error {
@@ -55,7 +59,7 @@ func TestRegisterUploadedBlockAndMapping_RollsBackOnMappingFailure(t *testing.T)
 		rollbackUploadedBlockRefsFn = oldRollback
 	}()
 
-	registerUploadedBlockForMaterializationFn = func(database *db.DB, orgID, repoID, internalBlockID, operationID string, sizeBytes int, storageClass, storageKey string) error {
+	registerUploadedBlockForMaterializationFn = func(database *db.DB, orgID, repoID, internalBlockID, operationID string, sizeBytes int, storageClass, storageKey, sha1ID string) error {
 		return nil
 	}
 	wantErr := errors.New("mapping boom")
@@ -96,7 +100,10 @@ func TestRegisterUploadedBlockAndMapping_SkipsMappingWithoutExternalID(t *testin
 		writeBlockMappingForMaterializationFn = oldWriteMapping
 	}()
 
-	registerUploadedBlockForMaterializationFn = func(database *db.DB, orgID, repoID, internalBlockID, operationID string, sizeBytes int, storageClass, storageKey string) error {
+	registerUploadedBlockForMaterializationFn = func(database *db.DB, orgID, repoID, internalBlockID, operationID string, sizeBytes int, storageClass, storageKey, sha1ID string) error {
+		if strings.TrimSpace(sha1ID) != "" {
+			t.Fatalf("sha1ID = %q, want empty", sha1ID)
+		}
 		return nil
 	}
 	writeCalled := false
@@ -125,7 +132,7 @@ func TestRegisterUploadedBlockAndMapping_StopsOnRegisterFailure(t *testing.T) {
 	}()
 
 	wantErr := errors.New("register boom")
-	registerUploadedBlockForMaterializationFn = func(database *db.DB, orgID, repoID, internalBlockID, operationID string, sizeBytes int, storageClass, storageKey string) error {
+	registerUploadedBlockForMaterializationFn = func(database *db.DB, orgID, repoID, internalBlockID, operationID string, sizeBytes int, storageClass, storageKey, sha1ID string) error {
 		return wantErr
 	}
 	writeCalled := false

--- a/internal/db/block_references.go
+++ b/internal/db/block_references.go
@@ -59,12 +59,14 @@ const (
 
 type BlockReuseProbe struct {
 	Decision     BlockReuseDecision
+	Sha1         string
 	SizeBytes    int
 	StorageClass string
 	StorageKey   string
 }
 
 type blockReuseMetadataRow struct {
+	Sha1         string
 	SizeBytes    int
 	StorageClass string
 	StorageKey   string
@@ -405,20 +407,28 @@ func PromotePublishAttemptReferences(database *DB, orgID, attemptID string, bloc
 // blocks never contend — it is NOT globally serialized (the old process-wide
 // concurrency permit that did serialize it has been removed).
 func (db *DB) UpsertBlockMetadata(orgID, blockID string, sizeBytes int, storageClass, storageKey string) error {
+	return db.UpsertBlockMetadataWithSHA1(orgID, blockID, "", sizeBytes, storageClass, storageKey)
+}
+
+// UpsertBlockMetadataWithSHA1 stores immutable block metadata plus the
+// authoritative SHA-1 of the real block bytes when that value is available at
+// write time. Callers that do not know the SHA-1 can keep using
+// UpsertBlockMetadata, which passes an empty string.
+func (db *DB) UpsertBlockMetadataWithSHA1(orgID, blockID, sha1 string, sizeBytes int, storageClass, storageKey string) error {
 	now := time.Now().UTC()
 	return db.Session().Query(`
-		INSERT INTO blocks (org_id, block_id, size_bytes, storage_class, storage_key, created_at, last_accessed)
-		VALUES (?, ?, ?, ?, ?, ?, ?) IF NOT EXISTS
-	`, orgID, blockID, sizeBytes, storageClass, storageKey, now, now).Exec()
+		INSERT INTO blocks (org_id, block_id, sha1, size_bytes, storage_class, storage_key, created_at, last_accessed)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?) IF NOT EXISTS
+	`, orgID, blockID, strings.TrimSpace(sha1), sizeBytes, storageClass, storageKey, now, now).Exec()
 }
 
 var probeBlockReuseMetadataFn = func(database *DB, orgID, blockID string) (blockReuseMetadataRow, bool, error) {
 	var row blockReuseMetadataRow
 	err := database.Session().Query(`
-		SELECT size_bytes, storage_class, storage_key, gc_state
+		SELECT sha1, size_bytes, storage_class, storage_key, gc_state
 		FROM blocks
 		WHERE org_id = ? AND block_id = ?
-	`, orgID, blockID).Scan(&row.SizeBytes, &row.StorageClass, &row.StorageKey, &row.GCState)
+	`, orgID, blockID).Scan(&row.Sha1, &row.SizeBytes, &row.StorageClass, &row.StorageKey, &row.GCState)
 	if err != nil {
 		if errors.Is(err, gocql.ErrNotFound) {
 			return blockReuseMetadataRow{}, false, nil
@@ -465,6 +475,7 @@ func (db *DB) ProbeBlockReuse(orgID, blockID string) (BlockReuseProbe, error) {
 	}
 
 	probe := BlockReuseProbe{
+		Sha1:         strings.TrimSpace(metadata.Sha1),
 		SizeBytes:    metadata.SizeBytes,
 		StorageClass: strings.TrimSpace(metadata.StorageClass),
 		StorageKey:   strings.TrimSpace(metadata.StorageKey),

--- a/internal/db/block_references_test.go
+++ b/internal/db/block_references_test.go
@@ -244,7 +244,7 @@ func TestProbeBlockReuseReusable(t *testing.T) {
 	})
 
 	probeBlockReuseMetadataFn = func(database *DB, orgID, blockID string) (blockReuseMetadataRow, bool, error) {
-		return blockReuseMetadataRow{SizeBytes: 123, StorageClass: "hot-s3", StorageKey: "", GCState: ""}, true, nil
+		return blockReuseMetadataRow{Sha1: "sha1-abc", SizeBytes: 123, StorageClass: "hot-s3", StorageKey: "", GCState: ""}, true, nil
 	}
 	probeBlockReuseHasReferencesFn = func(database *DB, orgID, blockID string) (bool, error) {
 		return true, nil
@@ -262,6 +262,9 @@ func TestProbeBlockReuseReusable(t *testing.T) {
 	}
 	if probe.StorageClass != "hot-s3" {
 		t.Fatalf("storage class = %q, want hot-s3", probe.StorageClass)
+	}
+	if probe.Sha1 != "sha1-abc" {
+		t.Fatalf("sha1 = %q, want sha1-abc", probe.Sha1)
 	}
 }
 
@@ -347,7 +350,7 @@ func TestProbeBlockReuseNeedsPutWhenMetadataPresentButNoReferences(t *testing.T)
 	})
 
 	probeBlockReuseMetadataFn = func(database *DB, orgID, blockID string) (blockReuseMetadataRow, bool, error) {
-		return blockReuseMetadataRow{SizeBytes: 4096, StorageClass: "cold-archive", StorageKey: "blocks/ab/cd", GCState: ""}, true, nil
+		return blockReuseMetadataRow{Sha1: "sha1-cold", SizeBytes: 4096, StorageClass: "cold-archive", StorageKey: "blocks/ab/cd", GCState: ""}, true, nil
 	}
 	probeBlockReuseHasReferencesFn = func(database *DB, orgID, blockID string) (bool, error) {
 		return false, nil
@@ -368,6 +371,9 @@ func TestProbeBlockReuseNeedsPutWhenMetadataPresentButNoReferences(t *testing.T)
 	}
 	if probe.SizeBytes != 4096 {
 		t.Fatalf("size = %d, want 4096", probe.SizeBytes)
+	}
+	if probe.Sha1 != "sha1-cold" {
+		t.Fatalf("sha1 = %q, want sha1-cold", probe.Sha1)
 	}
 }
 

--- a/internal/db/migrations/005_sha256_canonical_block_ids.cql
+++ b/internal/db/migrations/005_sha256_canonical_block_ids.cql
@@ -1,0 +1,13 @@
+-- Migration 005: additive schema for SHA-256-canonical fs_object block IDs
+--
+-- Adds:
+--   - fs_objects.seafile_block_ids_sha1: the SHA-1 block-id list used at the
+--     Seafile compatibility boundary (fs_object serialization + fs_id).
+--   - blocks.sha1: authoritative SHA-256 -> SHA-1 lookup sourced from the real
+--     block bytes the server already hashes on upload/finalize paths.
+--
+-- This migration is additive only: existing readers/writers continue using the
+-- current schema until later PRs flip behavior.
+
+ALTER TABLE fs_objects ADD seafile_block_ids_sha1 LIST<TEXT>;
+ALTER TABLE blocks ADD sha1 TEXT;

--- a/internal/db/migrator_test.go
+++ b/internal/db/migrator_test.go
@@ -223,3 +223,12 @@ func TestMigration003AppliesLCSToGCQueueTables(t *testing.T) {
 	// Parser sanity: the five ALTERs split into exactly five executable statements.
 	assert.Len(t, parseCQLStatements(content), 5)
 }
+
+func TestMigration005AddsSHA256CanonicalBlockIDColumns(t *testing.T) {
+	raw, err := migrationsFS.ReadFile("migrations/005_sha256_canonical_block_ids.cql")
+	require.NoError(t, err)
+	content := string(raw)
+
+	assert.Contains(t, content, "ALTER TABLE fs_objects ADD seafile_block_ids_sha1 LIST<TEXT>;")
+	assert.Contains(t, content, "ALTER TABLE blocks ADD sha1 TEXT;")
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -89,14 +89,15 @@ type Commit struct {
 
 // FSObject represents a file system object (file or directory)
 type FSObject struct {
-	LibraryID uuid.UUID  `json:"library_id"`
-	FSID      string     `json:"fs_id"` // SHA-256 of content
-	Type      string     `json:"type"`  // "file" or "dir"
-	Name      string     `json:"name"`
-	Entries   []DirEntry `json:"entries,omitempty"`   // For directories
-	BlockIDs  []string   `json:"block_ids,omitempty"` // For files
-	SizeBytes int64      `json:"size"`
-	MTime     int64      `json:"mtime"` // Unix timestamp
+	LibraryID           uuid.UUID  `json:"library_id"`
+	FSID                string     `json:"fs_id"` // Seafile fs object ID (SHA-1 of object JSON)
+	Type                string     `json:"type"`  // "file" or "dir"
+	Name                string     `json:"name"`
+	Entries             []DirEntry `json:"entries,omitempty"`                // For directories
+	BlockIDs            []string   `json:"block_ids,omitempty"`              // Canonical/internal block IDs
+	SeafileBlockIDsSHA1 []string   `json:"seafile_block_ids_sha1,omitempty"` // Desktop/mobile Seafile compatibility block IDs
+	SizeBytes           int64      `json:"size"`
+	MTime               int64      `json:"mtime"` // Unix timestamp
 }
 
 // DirEntry represents an entry in a directory
@@ -112,6 +113,7 @@ type DirEntry struct {
 type Block struct {
 	OrgID        uuid.UUID `json:"org_id"`
 	BlockID      string    `json:"block_id"` // SHA-256 hash
+	Sha1         string    `json:"sha1,omitempty"`
 	SizeBytes    int       `json:"size"`
 	StorageClass string    `json:"storage_class"`
 	StorageKey   string    `json:"storage_key"` // S3 key or Glacier archive ID

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -313,13 +313,14 @@ func TestOrganizationJSONSerialization(t *testing.T) {
 
 func TestFSObjectJSONSerialization(t *testing.T) {
 	obj := FSObject{
-		LibraryID: uuid.New(),
-		FSID:      "abc123def456",
-		Type:      "file",
-		Name:      "test.txt",
-		BlockIDs:  []string{"block1", "block2"},
-		SizeBytes: 2048,
-		MTime:     time.Now().Unix(),
+		LibraryID:           uuid.New(),
+		FSID:                "abc123def456",
+		Type:                "file",
+		Name:                "test.txt",
+		BlockIDs:            []string{"block1", "block2"},
+		SeafileBlockIDsSHA1: []string{"sha1block1", "sha1block2"},
+		SizeBytes:           2048,
+		MTime:               time.Now().Unix(),
 	}
 
 	data, err := json.Marshal(obj)
@@ -338,6 +339,10 @@ func TestFSObjectJSONSerialization(t *testing.T) {
 	if jsonMap["type"] != "file" {
 		t.Errorf("type = %v, want file", jsonMap["type"])
 	}
+	seafileBlockIDs, ok := jsonMap["seafile_block_ids_sha1"].([]interface{})
+	if !ok || len(seafileBlockIDs) != 2 {
+		t.Errorf("seafile_block_ids_sha1 length = %d, want 2", len(seafileBlockIDs))
+	}
 }
 
 func TestBlockJSONSerialization(t *testing.T) {
@@ -345,6 +350,7 @@ func TestBlockJSONSerialization(t *testing.T) {
 	block := Block{
 		OrgID:        uuid.New(),
 		BlockID:      "sha256hash",
+		Sha1:         "sha1hash",
 		SizeBytes:    1024,
 		StorageClass: "hot",
 		StorageKey:   "org123/sha256hash",
@@ -367,5 +373,8 @@ func TestBlockJSONSerialization(t *testing.T) {
 	}
 	if jsonMap["storage_class"] != "hot" {
 		t.Errorf("storage_class = %v, want hot", jsonMap["storage_class"])
+	}
+	if jsonMap["sha1"] != "sha1hash" {
+		t.Errorf("sha1 = %v, want sha1hash", jsonMap["sha1"])
 	}
 }


### PR DESCRIPTION
Additive base for the SHA-256-canonical block ID work (design:
`docs/SHA256-CANONICAL-BLOCK-IDS.md`). **No behavior is flipped**; the web
block-upload flag stays OFF and nothing consumes the new fields yet.

## PR1 — schema + models (additive)
- Migration `005_sha256_canonical_block_ids.cql`: `ALTER fs_objects ADD seafile_block_ids_sha1 LIST<TEXT>`, `ALTER blocks ADD sha1 TEXT`. Incremental per policy (never edits 001); empty pre-deploy DB, no backfill.
- `models.FSObject.SeafileBlockIDsSHA1`, `models.Block.Sha1`.

## PR2 — populate `blocks.sha1` from verified bytes
- `UpsertBlockMetadataWithSHA1` writes `blocks.sha1`; `UpsertBlockMetadata` kept as a compatible wrapper.
- `RegisterUploadedBlock` threads `sha1ID`; both web (`blocks.go`) and legacy seafhttp (`2183/2661`) paths populate it via the unchanged `RegisterUploadedBlockAndMapping` signature.
- `ProbeBlockReuse` selects/exposes `sha1` for commit-time use in PR5.

## Validation
- `go build`, `go vet`, unit tests, and the integration suite pass.

## Known follow-ups (gated, documented)
- `CreateFile` template-block path still registers an empty `sha1` (harmless until consumed).
- Before PR4/PR5: close that TODO and add **fail-closed** validation of `blocks.sha1` (40-hex, non-empty -> else `needs_upload`, reusing `isHex40`). See the "Gating rule" in the design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)