### PR TITLE
feat(block-ids): PR3 read-side tolerance for SHA-256 canonical block IDs

### DIFF
--- a/docs/SHA256-CANONICAL-BLOCK-IDS.md
+++ b/docs/SHA256-CANONICAL-BLOCK-IDS.md
@@ -20,14 +20,24 @@ this evolves), [CHUNKING-ANALYSIS.md](./CHUNKING-ANALYSIS.md).
   - The read hot path was **already tolerant**: `BatchResolveBlockIDs` / `resolveBlockIDs`
     already pass 64-hex (SHA-256) IDs through untouched and only resolve 40-hex
     ([streaming.go:48,88](../internal/streaming/streaming.go#L48)), so download / zip / file view
-    / share-link become O(0) automatically once PR4 stores SHA-256 in `block_ids`. No change
-    needed there.
+    / share-link drop to **O(0) mapping reads** automatically once PR4 stores SHA-256 in
+    `block_ids` (other per-request reads — fs_object, storage, permissions — still happen). No
+    change needed there.
   - Implemented the **Seafile serve** path: `GetFSObject` and `PackFS` now serialize
     `seafile_block_ids_sha1` (falling back to `block_ids` when empty) via the shared
     `seafileServeBlockIDs` helper. No-op until PR4 (the column is empty, so it falls back to the
     still-SHA-1 `block_ids`), correct afterwards. Unit test `TestSeafileServeBlockIDs`.
-  - **Still pending in PR3** — the sync **reference-accounting / fs_id-recompute** readers, which
-    need a hash-space trace first (see open question below).
+  - **Open question RESOLVED (hash-space trace done).** `block_references` is SHA-256-keyed, and
+    every sync path that touches it resolves SHA-1 → SHA-256 *first*:
+    `stageSyncCommitBlockDelta` / `finalizeSyncCommitBlockDelta` go through `resolveSyncBlockIDs`,
+    and `RegisterFSObjectBlockReferences` ([fs_helpers.go:1088](../internal/api/v2/fs_helpers.go#L1088))
+    resolves before writing refs (asserted by `TestRegisterFSObjectBlockReferences_AddsReferencesForPersistedFSObject`).
+    → **Reference-accounting readers MUST keep reading `block_ids`** (not `seafile_block_ids_sha1`):
+    after PR4 `block_ids` is SHA-256, the resolve becomes a passthrough, and refs stay SHA-256.
+    No PR4 change needed for them; switching them to SHA-1 would be a regression.
+  - **Still pending in PR3** — only the **fs_id-recompute** boundary readers `CheckFS` /
+    `buildFSIDMapping` must switch to `seafile_block_ids_sha1` (fallback `block_ids`), since the
+    client validates those objects by `fs_id`.
 - `PR4`–`PR7` — pending.
 
 ## Notes / Debt
@@ -58,6 +68,21 @@ Do **not** start PR4/PR5 until both are closed:
 Also add, when the value first drives `fs_id` (PR5): a test with a **real 40-hex SHA-1** plus the
 integration round-trip asserting the desktop-expected `fs_id` (the current plumbing tests use
 `"sha1-1"`/`"ext-1"`, which only prove the argument travels).
+
+### Blocker checklist (single source of truth)
+
+Carried forward from review. Status as of the PR3 partial branch:
+
+| # | Item | Severity | Gates |
+|---|---|---|---|
+| 1 | Desktop breaks if any Seafile endpoint serializes SHA-256 into `"block_ids"`. Serve path (`GetFSObject`/`PackFS`) is fixed; the remaining serializers must be audited. | Critical | PR4 |
+| 2 | `CheckFS` / `buildFSIDMapping` must use `seafile_block_ids_sha1` (fallback `block_ids`), never hash SHA-256 into the file JSON. | Blocker | PR3/PR4 |
+| 3 | `CreateFile` template block must register a real SHA-1, not empty. | Blocker | PR4 |
+| 4 | Validate `blocks.sha1` (40-hex, non-empty) before using it for `seafile_block_ids_sha1` / `fs_id`; else `needs_upload`. Reuse `isHex40`, fail closed. | Blocker | PR4/PR5 |
+| 5 | After the writer flip, **no row may have SHA-256 `block_ids` with empty `seafile_block_ids_sha1`**. Add a guard (strong log / fail-closed / repair) in `seafileServeBlockIDs` and at write time. | Blocker | PR4 |
+| 6 | Add an integration test for a post-flip file object (`block_ids`=64-hex, `seafile_block_ids_sha1`=40-hex): client receives the 40-hex list and the served JSON re-hashes to the requested `fs_id`. | Med | PR4 |
+| 7 | ~~Confirm sync reference-accounting feeds `block_references` in SHA-256.~~ **DONE** — it resolves before writing refs; keep reading `block_ids`. | — | resolved |
+| 8 | Do not drop the reverse mapping (`block_id_mappings_by_internal`) until the alias / encrypted / GC enumeration check passes. | Med | PR7 |
 
 ---
 
@@ -220,14 +245,15 @@ Each PR must leave `go test` / Jest + lint + build green, keep the web block-upl
   fs_object to compute a Seafile-compatible `fs_id`, use `seafile_block_ids_sha1`; fall back to
   `block_ids` when the new column is empty. They must never hash the internal SHA-256 block-id
   list.
-- **PENDING — needs a hash-space trace first.** The sync reference-accounting readers
+- **RESOLVED — reference-accounting is SHA-256; keep reading `block_ids`.** The sync readers
   `collectSyncReachableFiles` / `loadSyncFileBlockIDs` → `buildSyncCommitBlockDelta` →
-  `block_references` ([sync.go:2561,2620](../internal/api/sync.go#L2561)).
-  **Open question — is the sync block-reference model keyed by SHA-1 or SHA-256?**
-  `block_references` is documented SHA-256-keyed, but RecvFS currently stores SHA-1 in `block_ids`.
-  Confirm whether these readers feed `block_references` in SHA-256 space (→ use `block_ids`, which
-  becomes SHA-256 in PR4) or in the client's SHA-1 space (→ use `seafile_block_ids_sha1`). Getting
-  it wrong corrupts live-sync reference counting / GC. Resolve before PR4.
+  `block_references` ([sync.go:2561,2620](../internal/api/sync.go#L2561)) feed refs only after a
+  SHA-1 → SHA-256 resolution: `stageSyncCommitBlockDelta` / `finalizeSyncCommitBlockDelta` via
+  `resolveSyncBlockIDs`, and `RegisterFSObjectBlockReferences`
+  ([fs_helpers.go:1088](../internal/api/v2/fs_helpers.go#L1088)) resolves before writing. So
+  `block_references` is SHA-256-keyed. These readers must **keep reading `block_ids`** — after PR4
+  it is SHA-256 and the resolve becomes a passthrough; switching them to `seafile_block_ids_sha1`
+  would be a regression. **No PR4 change needed here.**
 - GC reads the list directly when it is SHA-256 (the resolver passthrough already covers the
   transition).
 - With writers still emitting SHA-1, everything falls back to the old behavior → no observable

--- a/docs/SHA256-CANONICAL-BLOCK-IDS.md
+++ b/docs/SHA256-CANONICAL-BLOCK-IDS.md
@@ -16,7 +16,19 @@ this evolves), [CHUNKING-ANALYSIS.md](./CHUNKING-ANALYSIS.md).
 - `PR2` — implemented in workspace: `blocks.sha1` is now written from verified bytes on the web
   block-upload materialization path and the legacy seafhttp upload/finalize path, and
   `ProbeBlockReuse` now reads/exposes `sha1` for later commit-time use.
-- `PR3`–`PR7` — pending.
+- `PR3` — in progress (branch `feat/sha256-canonical-block-ids-pr3`):
+  - The read hot path was **already tolerant**: `BatchResolveBlockIDs` / `resolveBlockIDs`
+    already pass 64-hex (SHA-256) IDs through untouched and only resolve 40-hex
+    ([streaming.go:48,88](../internal/streaming/streaming.go#L48)), so download / zip / file view
+    / share-link become O(0) automatically once PR4 stores SHA-256 in `block_ids`. No change
+    needed there.
+  - Implemented the **Seafile serve** path: `GetFSObject` and `PackFS` now serialize
+    `seafile_block_ids_sha1` (falling back to `block_ids` when empty) via the shared
+    `seafileServeBlockIDs` helper. No-op until PR4 (the column is empty, so it falls back to the
+    still-SHA-1 `block_ids`), correct afterwards. Unit test `TestSeafileServeBlockIDs`.
+  - **Still pending in PR3** — the sync **reference-accounting / fs_id-recompute** readers, which
+    need a hash-space trace first (see open question below).
+- `PR4`–`PR7` — pending.
 
 ## Notes / Debt
 
@@ -200,13 +212,24 @@ Each PR must leave `go test` / Jest + lint + build green, keep the web block-upl
 - `BatchResolveBlockIDs` already pass-throughs 64-hex SHA-256 IDs today; keep that behavior as
   the compatibility base for mixed old/new rows. No new behavior is needed there beyond
   preserving the "resolve only 40-hex" contract.
-- Seafile serve (`GetFSObject`, `PackFS`): serialize `seafile_block_ids_sha1` as the JSON
-  `block_ids`; fall back to `block_ids` when the new column is empty.
+- **DONE** — Seafile serve (`GetFSObject`, `PackFS`): serialize `seafile_block_ids_sha1` as the
+  JSON `block_ids`, falling back to `block_ids` when the column is empty, via the shared
+  `seafileServeBlockIDs` helper ([sync.go](../internal/api/sync.go)). Unit test
+  `TestSeafileServeBlockIDs`.
 - `CheckFS` / `buildFSIDMapping` / corrected-fs-id computation: when re-serializing a file
   fs_object to compute a Seafile-compatible `fs_id`, use `seafile_block_ids_sha1`; fall back to
   `block_ids` when the new column is empty. They must never hash the internal SHA-256 block-id
   list.
-- GC reads the list directly when it is SHA-256.
+- **PENDING — needs a hash-space trace first.** The sync reference-accounting readers
+  `collectSyncReachableFiles` / `loadSyncFileBlockIDs` → `buildSyncCommitBlockDelta` →
+  `block_references` ([sync.go:2561,2620](../internal/api/sync.go#L2561)).
+  **Open question — is the sync block-reference model keyed by SHA-1 or SHA-256?**
+  `block_references` is documented SHA-256-keyed, but RecvFS currently stores SHA-1 in `block_ids`.
+  Confirm whether these readers feed `block_references` in SHA-256 space (→ use `block_ids`, which
+  becomes SHA-256 in PR4) or in the client's SHA-1 space (→ use `seafile_block_ids_sha1`). Getting
+  it wrong corrupts live-sync reference counting / GC. Resolve before PR4.
+- GC reads the list directly when it is SHA-256 (the resolver passthrough already covers the
+  transition).
 - With writers still emitting SHA-1, everything falls back to the old behavior → no observable
   change.
 

--- a/docs/SHA256-CANONICAL-BLOCK-IDS.md
+++ b/docs/SHA256-CANONICAL-BLOCK-IDS.md
@@ -35,9 +35,13 @@ this evolves), [CHUNKING-ANALYSIS.md](./CHUNKING-ANALYSIS.md).
     → **Reference-accounting readers MUST keep reading `block_ids`** (not `seafile_block_ids_sha1`):
     after PR4 `block_ids` is SHA-256, the resolve becomes a passthrough, and refs stay SHA-256.
     No PR4 change needed for them; switching them to SHA-1 would be a regression.
-  - **Still pending in PR3** — only the **fs_id-recompute** boundary readers `CheckFS` /
-    `buildFSIDMapping` must switch to `seafile_block_ids_sha1` (fallback `block_ids`), since the
-    client validates those objects by `fs_id`.
+  - Implemented the **fs_id-recompute** boundary: `computeCorrectedObject` (used by
+    `buildFSIDMapping` / `CheckFS`) now builds the file JSON from `seafile_block_ids_sha1`
+    (fallback `block_ids`) via the same `seafileServeBlockIDs` helper, so the computed→stored
+    fs_id mapping keeps matching the client after PR4. No-op until PR4.
+  - **PR3 is functionally complete.** The only remaining PR3-adjacent item is a post-flip
+    integration test, tracked as a PR4 blocker (it needs PR4 data: SHA-256 `block_ids` + SHA-1
+    `seafile_block_ids_sha1`).
 - `PR4`–`PR7` — pending.
 
 ## Notes / Debt
@@ -76,7 +80,7 @@ Carried forward from review. Status as of the PR3 partial branch:
 | # | Item | Severity | Gates |
 |---|---|---|---|
 | 1 | Desktop breaks if any Seafile endpoint serializes SHA-256 into `"block_ids"`. Serve path (`GetFSObject`/`PackFS`) is fixed; the remaining serializers must be audited. | Critical | PR4 |
-| 2 | `CheckFS` / `buildFSIDMapping` must use `seafile_block_ids_sha1` (fallback `block_ids`), never hash SHA-256 into the file JSON. | Blocker | PR3/PR4 |
+| 2 | ~~`CheckFS` / `buildFSIDMapping` must use `seafile_block_ids_sha1` (fallback `block_ids`), never hash SHA-256 into the file JSON.~~ **DONE (PR3)** in `computeCorrectedObject`. | Blocker | resolved |
 | 3 | `CreateFile` template block must register a real SHA-1, not empty. | Blocker | PR4 |
 | 4 | Validate `blocks.sha1` (40-hex, non-empty) before using it for `seafile_block_ids_sha1` / `fs_id`; else `needs_upload`. Reuse `isHex40`, fail closed. | Blocker | PR4/PR5 |
 | 5 | After the writer flip, **no row may have SHA-256 `block_ids` with empty `seafile_block_ids_sha1`**. Add a guard (strong log / fail-closed / repair) in `seafileServeBlockIDs` and at write time. | Blocker | PR4 |
@@ -241,10 +245,10 @@ Each PR must leave `go test` / Jest + lint + build green, keep the web block-upl
   JSON `block_ids`, falling back to `block_ids` when the column is empty, via the shared
   `seafileServeBlockIDs` helper ([sync.go](../internal/api/sync.go)). Unit test
   `TestSeafileServeBlockIDs`.
-- `CheckFS` / `buildFSIDMapping` / corrected-fs-id computation: when re-serializing a file
-  fs_object to compute a Seafile-compatible `fs_id`, use `seafile_block_ids_sha1`; fall back to
-  `block_ids` when the new column is empty. They must never hash the internal SHA-256 block-id
-  list.
+- **DONE** — `CheckFS` / `buildFSIDMapping` / corrected-fs-id computation: `computeCorrectedObject`
+  ([sync.go](../internal/api/sync.go)) builds the file JSON from `seafile_block_ids_sha1` (fallback
+  `block_ids`) via `seafileServeBlockIDs`, so the recomputed `fs_id` matches the client. Never
+  hashes the internal SHA-256 list.
 - **RESOLVED — reference-accounting is SHA-256; keep reading `block_ids`.** The sync readers
   `collectSyncReachableFiles` / `loadSyncFileBlockIDs` → `buildSyncCommitBlockDelta` →
   `block_references` ([sync.go:2561,2620](../internal/api/sync.go#L2561)) feed refs only after a

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -423,9 +423,10 @@ func (h *SyncHandler) computeCorrectedObject(repoID, storedFSID string, cache ma
 	var size int64
 	var entriesJSON string
 	var blockIDs []string
+	var seafileBlockIDs []string
 	err := h.db.Session().Query(`
-		SELECT obj_type, size_bytes, dir_entries, block_ids FROM fs_objects WHERE library_id = ? AND fs_id = ?
-	`, repoID, storedFSID).Scan(&fsType, &size, &entriesJSON, &blockIDs)
+		SELECT obj_type, size_bytes, dir_entries, block_ids, seafile_block_ids_sha1 FROM fs_objects WHERE library_id = ? AND fs_id = ?
+	`, repoID, storedFSID).Scan(&fsType, &size, &entriesJSON, &blockIDs, &seafileBlockIDs)
 
 	if err != nil {
 		return nil
@@ -472,9 +473,12 @@ func (h *SyncHandler) computeCorrectedObject(repoID, storedFSID string, cache ma
 			"version": 1,
 		}
 	} else {
-		// File: no children to fix
+		// File: no children to fix. The computed fs_id must match what the Seafile
+		// client computes, which hashes the SHA-1 block-id list — so serialize the
+		// SHA-1 list (seafile_block_ids_sha1), falling back to block_ids when empty.
+		// See seafileServeBlockIDs.
 		jsonObj = map[string]interface{}{
-			"block_ids": blockIDs,
+			"block_ids": seafileServeBlockIDs(blockIDs, seafileBlockIDs),
 			"size":      size,
 			"type":      1,
 			"version":   1,
@@ -1357,15 +1361,17 @@ func (h *SyncHandler) collectCorrectedObjectsWithFilter(repoID, storedFSID strin
 	}
 }
 
-// seafileServeBlockIDs returns the SHA-1 block-id list to serialize into a
-// Seafile file fs_object served to the desktop/mobile client. The client
-// requests an fs_object by its fs_id (= SHA-1 of the object JSON) and verifies
-// that the JSON it receives hashes back to that id, so the serialized block_ids
-// MUST be the SHA-1 list. After the SHA-256 canonicalization, that list lives in
-// fs_objects.seafile_block_ids_sha1 while fs_objects.block_ids holds the internal
-// SHA-256 ids. Falls back to block_ids when the SHA-1 column is empty (rows
-// written before the PR4 writer flip), which is still SHA-1 then — so this is a
-// no-op until PR4 and correct afterwards. See docs/SHA256-CANONICAL-BLOCK-IDS.md.
+// seafileServeBlockIDs returns the SHA-1 block-id list for any Seafile-boundary
+// file fs_object operation: serializing an object to the desktop/mobile client
+// (GetFSObject/PackFS) AND recomputing a Seafile-compatible fs_id
+// (computeCorrectedObject/CheckFS). In both cases the client identifies a file
+// object by its fs_id (= SHA-1 of the object JSON, which embeds the block-id
+// list), so the list MUST be the SHA-1 one. After the SHA-256 canonicalization
+// that list lives in fs_objects.seafile_block_ids_sha1 while fs_objects.block_ids
+// holds the internal SHA-256 ids. Falls back to block_ids when the SHA-1 column
+// is empty (rows written before the PR4 writer flip), which is still SHA-1 then —
+// so this is a no-op until PR4 and correct afterwards. See
+// docs/SHA256-CANONICAL-BLOCK-IDS.md.
 func seafileServeBlockIDs(blockIDs, seafileSHA1 []string) []string {
 	if len(seafileSHA1) > 0 {
 		return seafileSHA1

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -1357,6 +1357,22 @@ func (h *SyncHandler) collectCorrectedObjectsWithFilter(repoID, storedFSID strin
 	}
 }
 
+// seafileServeBlockIDs returns the SHA-1 block-id list to serialize into a
+// Seafile file fs_object served to the desktop/mobile client. The client
+// requests an fs_object by its fs_id (= SHA-1 of the object JSON) and verifies
+// that the JSON it receives hashes back to that id, so the serialized block_ids
+// MUST be the SHA-1 list. After the SHA-256 canonicalization, that list lives in
+// fs_objects.seafile_block_ids_sha1 while fs_objects.block_ids holds the internal
+// SHA-256 ids. Falls back to block_ids when the SHA-1 column is empty (rows
+// written before the PR4 writer flip), which is still SHA-1 then — so this is a
+// no-op until PR4 and correct afterwards. See docs/SHA256-CANONICAL-BLOCK-IDS.md.
+func seafileServeBlockIDs(blockIDs, seafileSHA1 []string) []string {
+	if len(seafileSHA1) > 0 {
+		return seafileSHA1
+	}
+	return blockIDs
+}
+
 // GetFSObject retrieves a filesystem object
 // GET /seafhttp/repo/:repo_id/fs/:fs_id
 // Returns zlib-compressed JSON in Seafile format:
@@ -1377,11 +1393,12 @@ func (h *SyncHandler) GetFSObject(c *gin.Context) {
 	var mtime int64
 	var entriesJSON string
 	var blockIDs []string
+	var seafileBlockIDs []string
 
 	err := h.db.Session().Query(`
-		SELECT obj_type, obj_name, size_bytes, mtime, dir_entries, block_ids
+		SELECT obj_type, obj_name, size_bytes, mtime, dir_entries, block_ids, seafile_block_ids_sha1
 		FROM fs_objects WHERE library_id = ? AND fs_id = ?
-	`, repoID, fsID).Scan(&fsType, &name, &size, &mtime, &entriesJSON, &blockIDs)
+	`, repoID, fsID).Scan(&fsType, &name, &size, &mtime, &entriesJSON, &blockIDs, &seafileBlockIDs)
 
 	if err != nil {
 		log.Printf("[GetFSObject] fs_object %s not found in repo %s: %v", fsID, repoID, err)
@@ -1410,10 +1427,11 @@ func (h *SyncHandler) GetFSObject(c *gin.Context) {
 		}
 	} else {
 		// File format: {"version": 1, "type": 1, "block_ids": [...], "size": N}
+		// Serve the SHA-1 list (Seafile boundary); see seafileServeBlockIDs.
 		jsonObj = map[string]interface{}{
 			"version":   1,
 			"type":      1, // SEAF_METADATA_TYPE_FILE
-			"block_ids": blockIDs,
+			"block_ids": seafileServeBlockIDs(blockIDs, seafileBlockIDs),
 			"size":      size,
 		}
 	}
@@ -1485,11 +1503,12 @@ func (h *SyncHandler) PackFS(c *gin.Context) {
 		var size int64
 		var entriesJSON string
 		var blockIDs []string
+		var seafileBlockIDs []string
 
 		err := h.db.Session().Query(`
-			SELECT obj_type, size_bytes, dir_entries, block_ids
+			SELECT obj_type, size_bytes, dir_entries, block_ids, seafile_block_ids_sha1
 			FROM fs_objects WHERE library_id = ? AND fs_id = ?
-		`, repoID, requestedFSID).Scan(&fsType, &size, &entriesJSON, &blockIDs)
+		`, repoID, requestedFSID).Scan(&fsType, &size, &entriesJSON, &blockIDs, &seafileBlockIDs)
 
 		if err != nil {
 			log.Printf("pack-fs: object %s not found: %v", requestedFSID, err)
@@ -1516,7 +1535,7 @@ func (h *SyncHandler) PackFS(c *gin.Context) {
 			}
 		} else {
 			jsonObj = map[string]interface{}{
-				"block_ids": blockIDs,
+				"block_ids": seafileServeBlockIDs(blockIDs, seafileBlockIDs),
 				"size":      size,
 				"type":      1,
 				"version":   1,

--- a/internal/api/sync_test.go
+++ b/internal/api/sync_test.go
@@ -2438,3 +2438,24 @@ func TestSyncFinalizedDeltaSet(t *testing.T) {
 		}
 	})
 }
+
+func TestSeafileServeBlockIDs(t *testing.T) {
+	sha256IDs := []string{strings.Repeat("a", 64), strings.Repeat("b", 64)}
+	sha1IDs := []string{strings.Repeat("c", 40), strings.Repeat("d", 40)}
+
+	t.Run("prefers the SHA-1 column when present (post-PR4 layout)", func(t *testing.T) {
+		got := seafileServeBlockIDs(sha256IDs, sha1IDs)
+		if len(got) != 2 || got[0] != sha1IDs[0] || got[1] != sha1IDs[1] {
+			t.Fatalf("got %v, want the SHA-1 list %v", got, sha1IDs)
+		}
+	})
+
+	t.Run("falls back to block_ids when the SHA-1 column is empty", func(t *testing.T) {
+		if got := seafileServeBlockIDs(sha1IDs, nil); len(got) != 2 || got[0] != sha1IDs[0] {
+			t.Fatalf("got %v, want fallback to block_ids %v", got, sha1IDs)
+		}
+		if got := seafileServeBlockIDs(sha1IDs, []string{}); len(got) != 2 || got[0] != sha1IDs[0] {
+			t.Fatalf("empty (non-nil) SHA-1 list must also fall back, got %v", got)
+		}
+	})
+}


### PR DESCRIPTION
Read-side prep so PR4 can store SHA-256 in `fs_objects.block_ids` without
breaking desktop sync. **No-op until PR4** (the new `seafile_block_ids_sha1`
column is empty, so every path falls back to the still-SHA-1 `block_ids`),
correct afterwards. Design: `docs/SHA256-CANONICAL-BLOCK-IDS.md`.

## What changed
- New shared helper `seafileServeBlockIDs(blockIDs, seafileSHA1)`: returns the
  SHA-1 list for Seafile-boundary file objects (the client identifies a file by
  `fs_id = SHA-1(JSON embedding the block-id list)`), falling back to `block_ids`.
- **Serve path** — `GetFSObject` / `PackFS` serialize `seafile_block_ids_sha1`.
- **fs_id recompute** — `computeCorrectedObject` (used by `buildFSIDMapping` /
  `CheckFS`) builds the file JSON from `seafile_block_ids_sha1`, so the
  computed→stored fs_id mapping keeps matching the client after PR4.
- Unit test `TestSeafileServeBlockIDs`.

## What did NOT need changing
- Download / zip / file-view / share-link: `BatchResolveBlockIDs` already passes
  64-hex IDs through untouched → O(0) mapping reads after PR4.
- Sync reference-accounting: `block_references` is SHA-256-keyed and every path
  resolves SHA-1→SHA-256 before writing refs (`RegisterFSObjectBlockReferences`,
  `resolveSyncBlockIDs`). These readers must KEEP reading `block_ids`.

## Validation
- `go build`, `go vet`, `go test ./internal/api/...` green.

## Deferred to PR4 (tracked in the doc blocker checklist)
- Post-flip integration test (SHA-256 `block_ids` + SHA-1 `seafile_block_ids_sha1`).
- Writer flip + template-block SHA-1 + `blocks.sha1` validation + fail-closed guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)