### PR TITLE
chore(block-ids): PR6 remove dead client SHA-1 cross-check + docs clo…

### DIFF
--- a/docs/SHA256-CANONICAL-BLOCK-IDS.md
+++ b/docs/SHA256-CANONICAL-BLOCK-IDS.md
@@ -1,8 +1,8 @@
 # SHA-256 canonical block IDs (and removing SHA-1 from the web client)
 
-**Date:** 2026-06-29
-**Status:** Design + implementation tracker. PR1-PR5 are implemented on branches/workspace;
-PR6+ remain pending.
+**Date:** 2026-06-29 (last updated 2026-06-30)
+**Status:** Design + implementation tracker. PR1-PR5 are **merged to `main`**; PR6 (cleanup)
+is in progress; PR7 (drop the reverse mapping table) remains pending its encrypted-GC check.
 **Supersedes:** the out-of-tree `implementation_plan.md` draft (backend/read-side only),
 which is removed in favour of this document.
 **Related:** [WEB-BLOCK-UPLOAD.md](./WEB-BLOCK-UPLOAD.md) (R10 dual-hash, the current state
@@ -82,7 +82,7 @@ this evolves), [CHUNKING-ANALYSIS.md](./CHUNKING-ANALYSIS.md).
     returns 500 for broken `GetFSObject`, `PackFS`, and `CheckFS` states.
   - **PR4 is functionally complete** (writer flip + guard + tests). `RecvFS` intentionally stays on
     the legacy SHA-1 layout (see above).
-- `PR5` — implemented (branch `feat/sha256-canonical-block-ids-pr5`): the frontend stops
+- `PR5` — **merged** (PR #107, branch `feat/sha256-canonical-block-ids-pr5`): the frontend stops
   computing/sending SHA-1 and the server derives it.
   - **Backend:** `file-from-blocks` manifest is `{sha256, size}` only; `manifestDigest` is over
     sha256+size. The external SHA-1 is read from `blocks.sha1` (via `ProbeBlockReuse`, surfaced
@@ -99,7 +99,21 @@ this evolves), [CHUNKING-ANALYSIS.md](./CHUNKING-ANALYSIS.md).
     SHA-256 digest per block (single digest per block; expected lower hashing CPU); `buildManifest` emits `{sha256, size}`.
   - Integration guards rewritten to the inverse semantics (forged client SHA-1 ignored;
     replay with a different client SHA-1 is the same file).
-- `PR6`–`PR7` — pending.
+- `PR6` — **in progress** (branch `feat/sha256-canonical-block-ids-pr6`): cleanup + docs close-out.
+  - **DONE — dead `X-Block-Hash-SHA1` reader removed.** `UploadBlock` no longer reads/cross-checks
+    a client-supplied SHA-1 header (the frontend stopped sending it in PR5). The server still
+    computes the SHA-1 from the real bytes and stores it in `blocks.sha1` — that is the canonical
+    source — so the removed header was pure dead code.
+  - **N/A — dead manifest-SHA-1 validation** (`resolveManifestForwardMappings` / `getBlockIDMappingFn`)
+    was already removed in PR5.
+  - **DONE — docs close-out.** This tracker + [WEB-BLOCK-UPLOAD.md](./WEB-BLOCK-UPLOAD.md) updated to
+    the canonical end-state (`block_ids` = SHA-256, `seafile_block_ids_sha1` = SHA-1, client sends
+    only `{sha256, size}`); stale regression-guard test names corrected.
+  - **Deferred to PR7 — the `WriteVerifiedWebBlockMapping` collision guard.** Removing the client
+    SHA-1 surface eliminates the *crafted-collision* threat that motivated the guard, but the guard
+    is still the active web mapping writer; it is now harmless defense-in-depth and is removed as
+    part of the PR7 mapping rework, not here.
+- `PR7` — pending (drop the reverse mapping table; gated on the encrypted-GC enumeration check, blocker #8).
 
 ## Notes / Debt
 
@@ -125,7 +139,7 @@ Carried forward from review. Status as of the PR3 partial branch:
 
 | # | Item | Severity | Gates |
 |---|---|---|---|
-| 1 | Desktop breaks if any Seafile endpoint serializes SHA-256 into `"block_ids"`. Serve path (`GetFSObject`/`PackFS`) is fixed; the remaining serializers must be audited. | Critical | PR4 |
+| 1 | ~~Desktop breaks if any Seafile endpoint serializes SHA-256 into `"block_ids"`.~~ **DONE (PR4)** — every Seafile-boundary serializer/​re-hasher (`GetFSObject`, `PackFS`, the serve/recompute path, and copy/publish) routes through the guarded `seafileServeBlockIDs` / `seafileFSObjectBlockIDs` helpers, which return `(list, ok)` and **fail closed (500)** on a 64-hex `block_ids` with an empty SHA-1 column — so a missed serializer cannot leak SHA-256 to the desktop client. | Critical | resolved |
 | 2 | ~~`CheckFS` / `buildFSIDMapping` must use `seafile_block_ids_sha1` (fallback `block_ids`), never hash SHA-256 into the file JSON.~~ **DONE (PR3)** in `computeCorrectedObject`. | Blocker | resolved |
 | 3 | ~~`CreateFile` template block must register a real SHA-1, not empty.~~ **DONE (PR4)** — `CreateFile` now computes the template SHA-1, uses it as the external block id, and writes the mapping + `blocks.sha1` via `RegisterUploadedBlockAndMapping` (mirrors `UploadFile`). Also fixes a pre-existing desktop-incompat bug: Office-created files used SHA-256 block ids / fs_id. | Blocker | resolved |
 | 4 | ~~Validate `blocks.sha1` (40-hex, non-empty) before using it for `seafile_block_ids_sha1` / `fs_id`; else `needs_upload`.~~ **DONE (PR5)** — `file-from-blocks` reads `blocks.sha1` via `ProbeBlockReuse` and `needs_upload`s any ready block whose `blocks.sha1` is missing/non-40-hex (`isHex40`, fail-closed). | Blocker | resolved |

--- a/docs/WEB-BLOCK-UPLOAD.md
+++ b/docs/WEB-BLOCK-UPLOAD.md
@@ -157,14 +157,17 @@ re-reading this section.
 - **R9 — `/blocks/upload?session=` always materializes**, even when
   `PutBlockData` was a no-op because the object already existed in S3. The point
   is to *govern* the block, not just store bytes.
-> **Planned evolution (2026-06-29):** the storage layout below (SHA-1 in
-> `fs_objects.block_ids`, resolved to SHA-256 on every read) is being moved to
-> **SHA-256-canonical block IDs** — SHA-256 in `fs_objects.block_ids` (O(0) read/GC
-> mapping lookups) plus a dedicated `seafile_block_ids_sha1` column for the desktop
-> boundary, and the web frontend stops computing/sending SHA-1 (the server derives it
-> from a new `blocks.sha1` column). The `fs_id` stays SHA-1-derived. See
-> [SHA256-CANONICAL-BLOCK-IDS.md](./SHA256-CANONICAL-BLOCK-IDS.md) for the full design
-> and PR breakdown.
+> **⚠️ Superseded (2026-06-30, PR1–PR5 merged to `main`):** the **SHA-256-canonical
+> block IDs** change has shipped. The current layout is **SHA-256 in
+> `fs_objects.block_ids`** (O(0) read/GC mapping lookups) plus a dedicated
+> `seafile_block_ids_sha1` column holding the 40-hex SHA-1 list for the desktop
+> boundary; the web frontend now sends only `{sha256, size}` and the server derives the
+> SHA-1 from the `blocks.sha1` column. The `fs_id` stays SHA-1-derived. **The R10 /
+> dual-hash narrative below (client sends `{sha1, sha256, size}`; `block_ids` = SHA-1;
+> commit validates the client SHA-1 against the forward mapping) describes the prior
+> interim state and is kept for history only — it no longer reflects the code.** See
+> [SHA256-CANONICAL-BLOCK-IDS.md](./SHA256-CANONICAL-BLOCK-IDS.md) for the shipped design,
+> the canonical end-state, and the remaining PR6/PR7 cleanup.
 
 - **R10 — Dual-hash: SHA-1 is the external Seafile block ID, SHA-256 is the
   storage identity.** A file's `fs_object.block_ids` MUST be SHA-1 (40-hex): the
@@ -251,14 +254,19 @@ verified SHA-1 into the fs_object (never trusting the client's SHA-1, never mint
 a mapping, never using the reverse table as truth). End state per the design
 decision:
 
+End state **as shipped (PR1–PR5)** — note this differs from the original dual-hash table:
+the canonical id moved into `block_ids` and the SHA-1 list moved to its own column.
+
 | Field | Value |
 |---|---|
-| `fs_objects.block_ids` | **SHA-1** (desktop/mobile Seafile compat) |
+| `fs_objects.block_ids` | **SHA-256** (canonical internal id; O(0) reads/GC) |
+| `fs_objects.seafile_block_ids_sha1` | **SHA-1** (40-hex; serialized to the desktop client + `fs_id`) |
 | `blocks.block_id` | SHA-256 |
+| `blocks.sha1` | **SHA-1** (written from real bytes at `UploadBlock`; the server-side source for the SHA-1 list) |
 | `block_references.block_id` | SHA-256 |
 | S3 object key | SHA-256 |
-| `block_id_mappings` (forward, source of truth) | SHA-1 → SHA-256 (written at upload, from verified bytes, non-Paxos) |
-| `block_id_mappings_by_internal` (reverse) | SHA-256 → SHA-1 (best-effort GC/repair projection only) |
+| `block_id_mappings` (forward) | SHA-1 → SHA-256 (still resolves the desktop bare-SHA-1 block GET) |
+| `block_id_mappings_by_internal` (reverse) | SHA-256 → SHA-1 (best-effort GC/repair projection; slated for removal in PR7) |
 
 
 **Validated end-to-end (2026-06-24) against a real Seafile desktop client** on
@@ -285,11 +293,17 @@ files already committed by the broken merge that stored SHA-256 block IDs in the
 file object. Repairing those files is a separate migration/rewrite problem
 because changing the block IDs changes the file `fs_id`; in dev/local the safe
 answer is delete and re-upload.
-Regression guards (`internal/integration/web_block_upload_test.go`):
-`TestWebBlockUploadFSObjectUsesSHA1ForDesktopCompat`,
-`TestWebBlockUploadForwardMappingIsSourceOfTruth`,
+Regression guards (`internal/integration/web_block_upload_test.go`), updated to the
+canonical layout and the server-derived-SHA-1 semantics (PR5):
+`TestWebBlockUploadFSObjectUsesSHA1ForDesktopCompat` (block_ids = SHA-256,
+seafile_block_ids_sha1 = SHA-1),
+`TestWebBlockUploadIgnoresForgedClientSHA1` (a forged client SHA-1 is ignored; the
+fs_object stores the server-derived SHA-1),
 `TestWebBlockUploadCommitIndependentOfReverseMapping`,
-`TestWebBlockUploadReplayDifferentSHA1IsDifferentFile`.
+`TestWebBlockUploadReplayIgnoresClientSHA1` (replay with a different client SHA-1 is the
+same file),
+`TestWebBlockUploadReuploadRepairsMissingBlockSHA1` (a blank `blocks.sha1` is repaired on
+re-upload).
 
 ---
 

--- a/internal/api/v2/blocks.go
+++ b/internal/api/v2/blocks.go
@@ -369,7 +369,10 @@ func (h *BlockHandler) UploadBlock(c *gin.Context) {
 	sha1Bytes := sha1.Sum(data)
 	sha1Hash := hex.EncodeToString(sha1Bytes[:])
 
-	// Optional: verify client-provided hashes if present.
+	// Optional: verify the client-provided SHA-256 if present. The SHA-1 is no
+	// longer client-asserted (PR5): the server derives it from the real bytes
+	// (sha1Hash above) and stores it in blocks.sha1, so there is no X-Block-Hash-SHA1
+	// to cross-check anymore.
 	clientHash := c.GetHeader("X-Block-Hash")
 	if clientHash != "" && clientHash != hash {
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -377,16 +380,6 @@ func (h *BlockHandler) UploadBlock(c *gin.Context) {
 			"algorithm":     "sha256",
 			"expected_hash": clientHash,
 			"actual_hash":   hash,
-		})
-		return
-	}
-	clientSHA1 := c.GetHeader("X-Block-Hash-SHA1")
-	if clientSHA1 != "" && clientSHA1 != sha1Hash {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":         "hash mismatch",
-			"algorithm":     "sha1",
-			"expected_hash": clientSHA1,
-			"actual_hash":   sha1Hash,
 		})
 		return
 	}


### PR DESCRIPTION
…se-out

The web frontend stopped sending the X-Block-Hash-SHA1 header in PR5, so the server-side cross-check in UploadBlock was dead code (clientSHA1 was always ""):

- Remove the X-Block-Hash-SHA1 reader. The server still computes the SHA-1 from the block's real bytes (sha1Hash) and stores it in blocks.sha1 -- that is the canonical source for the external Seafile block id -- so nothing behavioral changes. The X-Block-Hash (SHA-256) integrity check stays.
- The dead manifest-SHA-1 validation (resolveManifestForwardMappings / getBlockIDMappingFn) was already removed in PR5.

Docs close-out:
- SHA256-CANONICAL-BLOCK-IDS.md: PR1-PR5 marked merged to main; PR6 progress recorded; blocker #1 marked resolved (all Seafile-boundary serializers route through the fail-closed seafileServeBlockIDs / seafileFSObjectBlockIDs guards).
- WEB-BLOCK-UPLOAD.md: the planned-evolution banner is now a "superseded" banner; the end-state table reflects the shipped layout (block_ids = SHA-256, seafile_block_ids_sha1 = SHA-1, blocks.sha1 server-derived); stale regression test names corrected to the PR5 inverse-semantics guards.

The WriteVerifiedWebBlockMapping collision guard is intentionally left in place: removing the client SHA-1 surface removes the crafted-collision threat, but the guard is still the active web mapping writer and is removed as part of the PR7 mapping rework, not here.

Part of docs/SHA256-CANONICAL-BLOCK-IDS.md (PR6).