### PR TITLE
feat(blocks): session permission hardening + commit/check alignment + observability

### DIFF
--- a/docs/WEB-BLOCK-UPLOAD.md
+++ b/docs/WEB-BLOCK-UPLOAD.md
@@ -931,14 +931,15 @@ flag were on*.
    corruption** (the LWT prevents re-finalize). The residual is a pathological
    outage window. Full fix (deferred): reconstruct the result by re-reading the
    published path on a committed-but-resultless session, instead of waiting for TTL.
-3. **[Low/med] `/blocks/check?session=` is optimistic vs the commit.** Check marks
-   a block `existing` from `ProbeBlockReuse` (DB liveness) only; the commit
-   additionally verifies physical S3 presence (`CheckBlocksParallel`) and
-   ownership/permanence (`classifyBlockForCommit`). So check can say `existing`
-   while the commit returns `needs_upload` (e.g. metadata present but the S3 object
-   was deleted). **Not a correctness bug** — the commit is the authority and the
-   client re-uploads — just a possible extra round-trip. Optional follow-up: align
-   `check?session=` with the commit's classifier.
+3. **[RESOLVED, PR `feat/block-upload-observability-and-session-hardening`]
+   `/blocks/check?session=` is aligned with the commit's classifier.** Check now
+   runs the SAME liveness + physical-S3-presence + ownership classification the
+   commit uses (`classifyBlockOwnership`, shared with `classifyBlockForCommit`
+   via `checkBlocksReadyParallel`/`blockStore.CheckBlocksParallel`), minus the
+   size check (check has no declared per-block sizes to compare against — those
+   only arrive in the commit manifest). A block is reported `existing` only when
+   it is truly ready modulo size, closing the "check says existing, commit says
+   needs_upload" gap for anything both endpoints can see.
 4. **[Med] No broader real browser E2E yet.** Backend is covered
    live; still missing in-browser validation of: large files, real retry,
    cancellation, resume, progress accuracy, fallback, legacy folder upload, and
@@ -973,24 +974,26 @@ flag were on*.
    distinct permanent code for the "different file" case, so the old ambiguous
    `"different file or commit is still in progress"` branch is gone (covered by
    Go + Jest tests). The `needs_upload` re-upload path is unchanged.
-8. **[Med, partially covered] Commit latency/observability at large block counts.**
-   `file-from-blocks` is not a cheap metadata flip: on large files it verifies
-   every distinct block, checks logical quota, does the HEAD CAS, promotes
-   provisional→permanent refs, and cleans up staging. `finalizeStoredUploadMetadata`
-   already emits `UploadFinalizeAttempts`/`UploadFinalizeDuration`/
-   `UploadFinalizeHeadConflictsTotal`/`UploadFinalizeRetryExhaustedTotal` (label
-   `v2_direct`), but the block-verification phase (`verifyManifestBlocks`/
-   `classifyBlockForCommit`), the session claim/wait path, and staging have no
-   metrics of their own (`internal/metrics/metrics.go` has no block-upload-
-   specific series). The UX doc already notes the visible `Saving…` phase; before
-   prod flag-on we still need operator-facing observability for the
-   verification/session slice specifically (latency, retries, timeout/error
-   rates at high block counts).
-9. **[Low/med] `session` travels in the query string.** `/blocks/check?session=`
-   and `/blocks/upload?session=` carry the session id as a query parameter, which
-   can land in access logs. It is not a strong secret leak (the request is already
-   authenticated and scoped to the caller), but a request header
-   (`X-Block-Upload-Session: <id>`) would keep it out of logs. Cheap follow-up.
+8. **[RESOLVED, PR `feat/block-upload-observability-and-session-hardening`]
+   Commit verification/session/staging observability.** `finalizeStoredUploadMetadata`
+   already had metrics; the block-verification phase, the session claim/wait
+   path, and staging did not. New series in `internal/metrics/metrics.go`:
+   `block_upload_verify_duration_seconds` / `block_upload_verify_blocks_total`
+   (the commit's `verifyManifestBlocks` pass, labeled ready vs needs_upload, and
+   per-block-status counts), `block_upload_session_claim_total` (R7's LWT claim
+   outcome: won / lost_result_ready / lost_timeout / lost_conflict),
+   `block_upload_session_wait_duration_seconds` (how long a loser waited for the
+   winner, bounded ~10s), and `block_upload_staged_blocks_total` (blocks
+   materialized at `/blocks/upload`, labeled new vs dedup). Covered by
+   `TestObserveBlockVerification_*` in `internal/api/v2/file_from_blocks_test.go`.
+9. **[RESOLVED, PR `feat/block-upload-observability-and-session-hardening`]
+   `session` moved out of the query string.** `/blocks/check` and
+   `/blocks/upload` now read the session id from the `X-Block-Upload-Session`
+   header first (`sessionIDFromRequest`), falling back to `?session=` for any
+   caller not yet updated. The web frontend (`seafile-api.js` `checkBlocks` /
+   `uploadBlock`) sends the header exclusively. Covered by
+   `TestSessionIDFromRequest` (backend) and
+   `seafile-api-block-upload.test.js` (frontend).
 10. **[Low/med] No local manifest persistence (resume survives the server, not a
     reload).** Real resume lives server-side via `/blocks/check`, but the client
     does not cache the computed manifest (e.g. in IndexedDB). After a page reload
@@ -1030,32 +1033,56 @@ tracked above. Progress is tracked here; each fix ships as its own small PR.
     `internal/api/v2/blocks_test.go`. (This also makes moot the earlier review
     note that the removed `DownloadBlock` read the full block from S3 before
     checking the traffic quota — the code path no longer exists.)
-12. **[Low/med — pending] `/blocks/upload?session=` and `/blocks/check?session=`
-    do not re-check repo write permission.** Only session ownership is verified;
-    the write permission is checked at session mint and at commit. A user whose
-    upload permission (or account status) is revoked mid-session can keep staging
-    blocks for up to the 48h session TTL (bounded by traffic quota + provisional
-    TTL; they can never publish). Cheap fix: status/permission check in
-    `resolveUploadSession`.
+12. **[RESOLVED, PR `feat/block-upload-observability-and-session-hardening`]
+    `/blocks/upload?session=` and `/blocks/check?session=` now re-check upload
+    permission mid-session.** `resolveUploadSession` re-verifies the caller's
+    "upload" permission flag on the session's repo
+    (`permMiddleware.RequirePermFlagForRepo`) whenever `permMiddleware` is
+    wired. Running the full library-permission resolution (a `shares`-table
+    scan) on every `/blocks/upload` call — up to thousands per large file —
+    would have made this the most expensive query in the hot path, so the
+    result is cached per session for `sessionPermissionRecheckInterval` (2 min)
+    via `sessionPermissionCache`, a bounded in-process cache (size-swept, never
+    caches a denial so a permission fix takes effect on the next request
+    instead of waiting out the interval). This bounds staleness to minutes
+    instead of the full 48h TTL; the commit still always re-verifies fresh
+    regardless (defense in depth, not the sole enforcement point). Account
+    status / org-role revocation was already covered separately —
+    `invalidateSessionsOnDemotion` / `invalidateUserCredentials` kill the auth
+    token itself, so those cases never reach this code path at all; the
+    remaining gap this closes is a library-specific permission change (e.g. a
+    group's access to one repo) that does not touch the token. Covered by
+    `TestSessionPermissionCache_Allow` (cache semantics) in
+    `internal/api/v2/blocks_test.go`; the DB-dependent wiring in
+    `resolveUploadSession` itself relies on the existing
+    `internal/integration/web_block_upload_test.go` harness like the rest of
+    this file's DB-backed logic.
 13. **[Note — multi-node] The per-IP rate limiters are in-memory per node.** With
     N nodes behind the LB the effective budget is N× the configured rate, and the
     limiter needs a trusted client IP (X-Forwarded-For). Acceptable as a
     mitigation, but not a hard guarantee in multi-node; a shared limiter would
     need a distributed budget.
-14. **[Perf — pending] `classifyBlockForCommit` spends 2–3 org-partition queries
-    per unique block** (`ProbeBlockReuse` + `BlockHasReferrer` + sometimes
-    `ListBlockReferrers`). `BlockHasReferrer` and `ListBlockReferrers` read the
-    SAME `(org, block)` partition; a single partition read can decide
-    owned/permanent at once, saving ~1 query per unique block (thousands on large
-    manifests).
-15. **[Perf — pending] `UploadBlock` logs one line per uploaded block**
-    (`v2/blocks: uploading block …`); at production scale (1500+ blocks per large
-    file × concurrent users) this is significant log volume. Demote to debug or
-    sample.
-16. **[Doc drift — pending] The comment in `file_from_blocks.go` above
-    `finalizeStoredUploadMetadata` still describes the pre-canonical layout**
-    ("the SHA-1 IDs go into the fs_object"); post PR1–PR5 `block_ids` is SHA-256
-    and the SHA-1 list lives in `seafile_block_ids_sha1`.
+14. **[RESOLVED, PR `feat/block-upload-observability-and-session-hardening`]
+    Fused the block-ownership queries.** `classifyBlockForCommit` used to run
+    `BlockHasReferrer` (exact-match read) and, only on a miss, a second
+    `ListBlockReferrers` (full-partition read) — up to 2 queries in the common
+    "not owned by this session, but permanently referenced" case. Both read the
+    SAME `(org, block)` partition, and `ListBlockReferrers` already returns
+    every referrer (a superset of what `BlockHasReferrer` checks), so the new
+    shared `classifyBlockOwnership` helper answers both questions with ONE
+    partition read — used by both the commit and the now-aligned
+    `/blocks/check?session=` (item 3).
+15. **[RESOLVED, PR `feat/block-upload-observability-and-session-hardening`]
+    Removed the per-block upload log line** (`v2/blocks: uploading block …`) —
+    at production scale (1500+ blocks per large file × concurrent users) it was
+    significant, non-actionable log volume with no operational value; error
+    paths still log.
+16. **[RESOLVED, PR `feat/block-upload-observability-and-session-hardening`]
+    Fixed the stale comment above `finalizeStoredUploadMetadata`'s call site**
+    in `file_from_blocks.go` — it described the pre-canonical layout ("the
+    SHA-1 IDs go into the fs_object"); now reflects that `block_ids` is SHA-256
+    canonical (post PR1–PR5) and the SHA-1 list lives in
+    `seafile_block_ids_sha1`.
 17. **[Perf/DoS — pending] `UploadBlock` buffers the whole block in memory**
     (`io.ReadAll` up to `Chunking.Adaptive.AbsoluteMax`) with no per-user cap on
     concurrent `/blocks/upload` requests. At 8–16 MB per in-flight request this
@@ -1075,8 +1102,11 @@ tracked above. Progress is tracked here; each fix ships as its own small PR.
   `{sha256, size}` (SHA-1 server-derived). See the superseded note in R9/R10 above
   and [SHA256-CANONICAL-BLOCK-IDS.md](./SHA256-CANONICAL-BLOCK-IDS.md) for any
   residual cleanup.
-- Clear the prod-readiness checklist above (items 1, 2, 4 and now 12 in
-  particular) before enabling `enable_web_block_upload` in production.
+- Clear the prod-readiness checklist above before enabling
+  `enable_web_block_upload` in production — items 1 (staging-bytes cap), 2
+  (idempotency reconstruction on sustained outage), 4 (browser E2E), and 17
+  (per-request memory/concurrency cap) remain open; items 3, 8, 9, and 12 are
+  now resolved.
 - **"metadata present but S3 object deleted"** is handled (commit verifies physical
   presence via `CheckBlocksParallel` → `needs_upload`); an automated test for it
   needs direct MinIO object deletion and is not yet added.

--- a/docs/WEB-BLOCK-UPLOAD.md
+++ b/docs/WEB-BLOCK-UPLOAD.md
@@ -974,18 +974,25 @@ flag were on*.
    distinct permanent code for the "different file" case, so the old ambiguous
    `"different file or commit is still in progress"` branch is gone (covered by
    Go + Jest tests). The `needs_upload` re-upload path is unchanged.
-8. **[RESOLVED, PR `feat/block-upload-observability-and-session-hardening`]
+8. **[RESOLVED, PR `feat/block-upload-observability-and-session-hardening` +
+   follow-up 2026-07-02]
    Commit verification/session/staging observability.** `finalizeStoredUploadMetadata`
    already had metrics; the block-verification phase, the session claim/wait
    path, and staging did not. New series in `internal/metrics/metrics.go`:
    `block_upload_verify_duration_seconds` / `block_upload_verify_blocks_total`
    (the commit's `verifyManifestBlocks` pass, labeled ready vs needs_upload, and
-   per-block-status counts), `block_upload_session_claim_total` (R7's LWT claim
+   with buckets extended out to 120s so large-file verification does not collapse
+   into `+Inf`),
+   `block_upload_verify_errors_total` (infrastructure failures during block
+   presence/classification before a logical verification result exists), and
+   the verification metrics now also cover the real `size_mismatch` handler path
+   instead of only the helper-level unit case. `block_upload_session_claim_total` (R7's LWT claim
    outcome: won / lost_result_ready / lost_timeout / lost_conflict),
    `block_upload_session_wait_duration_seconds` (how long a loser waited for the
    winner, bounded ~10s), and `block_upload_staged_blocks_total` (blocks
    materialized at `/blocks/upload`, labeled new vs dedup). Covered by
-   `TestObserveBlockVerification_*` in `internal/api/v2/file_from_blocks_test.go`.
+   `TestObserveBlockVerification_*`, `TestSummarizeBlockVerification_*`, and the
+   block-upload metric tests in `internal/api/v2/file_from_blocks_test.go`.
 9. **[RESOLVED, PR `feat/block-upload-observability-and-session-hardening`]
    `session` moved out of the query string.** `/blocks/check` and
    `/blocks/upload` now require the `X-Block-Upload-Session` header for
@@ -1084,7 +1091,15 @@ tracked above. Progress is tracked here; each fix ships as its own small PR.
     SHA-1 IDs go into the fs_object"); now reflects that `block_ids` is SHA-256
     canonical (post PR1–PR5) and the SHA-1 list lives in
     `seafile_block_ids_sha1`.
-17. **[Perf/DoS — pending] `UploadBlock` buffers the whole block in memory**
+17. **[RESOLVED, follow-up 2026-07-02] `/blocks/check` now validates every
+    requested hash as 64-hex SHA-256 before touching DB/S3.** The commit
+    manifest (`file-from-blocks`) already enforced 64-hex in R6, but `/blocks/check`
+    still accepted malformed hash strings and could send them into
+    `ProbeBlockReuse` / `CheckBlocksParallel`. The handler now rejects the
+    request with `400 hashes[i]: invalid sha256` before any metadata/object-store
+    work, aligning the cheap preflight check with the commit's manifest hygiene.
+    Covered by `TestCheckBlocks_InvalidSHA256` in `internal/api/v2/blocks_test.go`.
+18. **[Perf/DoS — pending] `UploadBlock` buffers the whole block in memory**
     (`io.ReadAll` up to `Chunking.Adaptive.AbsoluteMax`) with no per-user cap on
     concurrent `/blocks/upload` requests. At 8–16 MB per in-flight request this
     is fine at normal load, but nothing bounds how many concurrent uploads one

--- a/docs/WEB-BLOCK-UPLOAD.md
+++ b/docs/WEB-BLOCK-UPLOAD.md
@@ -11,8 +11,8 @@ are out of scope for phase 1.
 
 - Config: `web_uploads.enable_web_block_upload` (default `false`) in all
   `configs/*.yaml`; env override `WEB_UPLOADS_ENABLE_WEB_BLOCK_UPLOAD=true`.
-- When off, `block-upload-session` and `file-from-blocks` return 404 and the
-  `?session=` mode of `/blocks/check` + `/blocks/upload` is rejected — the routes
+- When off, `block-upload-session` and `file-from-blocks` return 404 and any
+  session-mode call to `/blocks/check` + `/blocks/upload` is rejected — the routes
   are always registered, so this flag is the real gate (defense in depth: the UI
   flag alone would not stop a direct API call).
 - `bootstrap` emits `enableBlockUpload` (real boolean) so the UI matches the server.
@@ -37,7 +37,7 @@ are out of scope for phase 1.
   after the file is published, *before* the (best-effort) storage-counter update —
   a counter failure no longer leaves a `committed` session without a result, and
   never returns 500 after the file already exists.
-- **Storage-class correctness:** `/blocks/upload?session=` resolves the block
+- **Storage-class correctness:** session-mode `/blocks/upload` resolves the block
   store by the session repo's storage class (not generic hostname/"hot"), so a
   block lands in the same backend `file-from-blocks` later verifies.
 - **Parallel verification:** session-mode `/blocks/check` and the commit's
@@ -52,7 +52,7 @@ are out of scope for phase 1.
   only) to avoid flattening directory structure.
 - **Batched check:** the client batches `/blocks/check` (≤5000 hashes/request) to
   stay under the server's 10000 cap for very large files.
-- **Staging does not pay logical storage quota (R5):** `/blocks/upload?session=`
+- **Staging does not pay logical storage quota (R5):** session-mode `/blocks/upload`
   no longer applies the user's *logical* storage quota per block. That quota is a
   property of the final file delta and is decided once at `file-from-blocks`;
   charging it per staged block wrongly rejected valid cases like a same-size
@@ -74,8 +74,8 @@ tracker.
 ```
 1. POST /api/v2/repos/:repo_id/block-upload-session/   → server-issued session_id
 2. client splits file into fixed 8 MB blocks, SHA-256 + SHA-1 each (Web Worker)
-3. POST /api/v2/blocks/check?session=...               → { existing, missing } (by SHA-256)
-4. POST /api/v2/blocks/upload?session=... (per missing) → store + materialize (SHA-256)
+3. POST /api/v2/blocks/check + `X-Block-Upload-Session` → { existing, missing } (by SHA-256)
+4. POST /api/v2/blocks/upload + `X-Block-Upload-Session` (per missing) → store + materialize (SHA-256)
 5. POST /api/v2/repos/:repo_id/file-from-blocks/        → commit from dual-hash manifest
 ```
 
@@ -116,7 +116,7 @@ re-reading this section.
   The session flow materializes a provisional reference with TTL
   (`gc_provisional_block_refs`), so an abandoned upload self-expires and the GC
   sweeper reclaims it.
-- **R3 — Session-aware check.** `/blocks/check?session=` reports a block as
+- **R3 — Session-aware check.** session-mode `/blocks/check` reports a block as
   `existing` only when `ProbeBlockReuse == Reusable`, not merely present in S3 —
   avoiding the "exists in S3 but unmaterialized → commit says NeedsPut" trap.
 - **R5 — Quota in three planes.** Traffic is charged per block at
@@ -154,7 +154,7 @@ re-reading this section.
   publish-attempt staging still pins every block under the commit *before* its
   HEAD CAS, so a concurrent rollback of another session's provisional ref cannot
   drop liveness for this file.
-- **R9 — `/blocks/upload?session=` always materializes**, even when
+- **R9 — session-mode `/blocks/upload` always materializes**, even when
   `PutBlockData` was a no-op because the object already existed in S3. The point
   is to *govern* the block, not just store bytes.
 > **⚠️ Superseded (2026-06-30, PR1–PR5 merged to `main`):** the **SHA-256-canonical
@@ -932,7 +932,7 @@ flag were on*.
    outage window. Full fix (deferred): reconstruct the result by re-reading the
    published path on a committed-but-resultless session, instead of waiting for TTL.
 3. **[RESOLVED, PR `feat/block-upload-observability-and-session-hardening`]
-   `/blocks/check?session=` is aligned with the commit's classifier.** Check now
+   session-mode `/blocks/check` is aligned with the commit's classifier.** Check now
    runs the SAME liveness + physical-S3-presence + ownership classification the
    commit uses (`classifyBlockOwnership`, shared with `classifyBlockForCommit`
    via `checkBlocksReadyParallel`/`blockStore.CheckBlocksParallel`), minus the
@@ -988,10 +988,11 @@ flag were on*.
    `TestObserveBlockVerification_*` in `internal/api/v2/file_from_blocks_test.go`.
 9. **[RESOLVED, PR `feat/block-upload-observability-and-session-hardening`]
    `session` moved out of the query string.** `/blocks/check` and
-   `/blocks/upload` now read the session id from the `X-Block-Upload-Session`
-   header first (`sessionIDFromRequest`), falling back to `?session=` for any
-   caller not yet updated. The web frontend (`seafile-api.js` `checkBlocks` /
-   `uploadBlock`) sends the header exclusively. Covered by
+   `/blocks/upload` now require the `X-Block-Upload-Session` header for
+   session-mode requests; the legacy `?session=` transport is rejected
+   explicitly so an outdated caller cannot silently fall back to the no-session
+   path. The web frontend (`seafile-api.js` `checkBlocks` / `uploadBlock`)
+   sends the header exclusively. Covered by
    `TestSessionIDFromRequest` (backend) and
    `seafile-api-block-upload.test.js` (frontend).
 10. **[Low/med] No local manifest persistence (resume survives the server, not a
@@ -1034,7 +1035,7 @@ tracked above. Progress is tracked here; each fix ships as its own small PR.
     note that the removed `DownloadBlock` read the full block from S3 before
     checking the traffic quota — the code path no longer exists.)
 12. **[RESOLVED, PR `feat/block-upload-observability-and-session-hardening`]
-    `/blocks/upload?session=` and `/blocks/check?session=` now re-check upload
+    session-mode `/blocks/upload` and `/blocks/check` now re-check upload
     permission mid-session.** `resolveUploadSession` re-verifies the caller's
     "upload" permission flag on the session's repo
     (`permMiddleware.RequirePermFlagForRepo`) whenever `permMiddleware` is
@@ -1071,7 +1072,7 @@ tracked above. Progress is tracked here; each fix ships as its own small PR.
     every referrer (a superset of what `BlockHasReferrer` checks), so the new
     shared `classifyBlockOwnership` helper answers both questions with ONE
     partition read — used by both the commit and the now-aligned
-    `/blocks/check?session=` (item 3).
+    session-mode `/blocks/check` (item 3).
 15. **[RESOLVED, PR `feat/block-upload-observability-and-session-hardening`]
     Removed the per-block upload log line** (`v2/blocks: uploading block …`) —
     at production scale (1500+ blocks per large file × concurrent users) it was

--- a/frontend/src/utils/__tests__/seafile-api-block-upload.test.js
+++ b/frontend/src/utils/__tests__/seafile-api-block-upload.test.js
@@ -1,0 +1,51 @@
+// finding 9 (docs/WEB-BLOCK-UPLOAD.md): the web block-upload session id must
+// travel via the X-Block-Upload-Session header, not the ?session= query
+// string, so it does not land in access/proxy logs.
+//
+// seafile-api.js imports seafile-js, which imports axios as an ESM module that
+// this project's Jest/Babel config cannot transform from node_modules (every
+// other real-import test either mocks seafile-api entirely or, like this one,
+// inspects the source directly) — see block-upload-orchestrator.test.js's
+// `jest.mock('../../../utils/seafile-api', ...)` for the same constraint.
+
+const fs = require('fs');
+const path = require('path');
+
+const getSeafileApiContent = () => {
+  const filePath = path.join(__dirname, '..', 'seafile-api.js');
+  return fs.readFileSync(filePath, 'utf8');
+};
+
+describe('seafileAPI block-upload session id transport', () => {
+  let apiContent;
+
+  beforeAll(() => {
+    apiContent = getSeafileApiContent();
+  });
+
+  test('checkBlocks and uploadBlock no longer build a ?session= query string', () => {
+    const checkBlocksBody = apiContent.match(/seafileAPI\.checkBlocks = function[\s\S]*?\n};/)[0];
+    const uploadBlockBody = apiContent.match(/seafileAPI\.uploadBlock = function[\s\S]*?\n};/)[0];
+
+    expect(checkBlocksBody).not.toMatch(/session=/);
+    expect(uploadBlockBody).not.toMatch(/session=/);
+  });
+
+  test('checkBlocks and uploadBlock route the session through the header helper', () => {
+    const checkBlocksBody = apiContent.match(/seafileAPI\.checkBlocks = function[\s\S]*?\n};/)[0];
+    const uploadBlockBody = apiContent.match(/seafileAPI\.uploadBlock = function[\s\S]*?\n};/)[0];
+
+    expect(checkBlocksBody).toMatch(/withBlockUploadSessionHeader\(config, session\)/);
+    expect(uploadBlockBody).toMatch(/withBlockUploadSessionHeader\(config, session\)/);
+  });
+
+  test('withBlockUploadSessionHeader sets X-Block-Upload-Session and never mutates the caller config', () => {
+    expect(apiContent).toMatch(/function withBlockUploadSessionHeader\(config, session\)/);
+    const helperBody = apiContent.match(/function withBlockUploadSessionHeader[\s\S]*?\n}/)[0];
+
+    expect(helperBody).toMatch(/'X-Block-Upload-Session':\s*session/);
+    // Object.assign({}, ...) into a NEW object, never `config.headers[...] = ...`.
+    expect(helperBody).toMatch(/Object\.assign\(\{\}, requestConfig/);
+    expect(helperBody).not.toMatch(/requestConfig\.headers\[/);
+  });
+});

--- a/frontend/src/utils/seafile-api.js
+++ b/frontend/src/utils/seafile-api.js
@@ -1445,23 +1445,23 @@ seafileAPI.createBlockUploadSession = function (repoID, parentDir, config) {
 
 // Ask which of the given SHA-256 block hashes still need to be uploaded.
 // In session mode the server reports a block as "existing" only when it is
-// commit-ready (live + present), not merely present in object storage.
+// commit-ready (live + present + owned by this session or a permanent
+// reference), not merely present in object storage.
+//
+// The session id travels in the X-Block-Upload-Session header, not the query
+// string, so it does not land in access/proxy logs (the server still accepts
+// ?session= as a fallback for older callers).
 seafileAPI.checkBlocks = function (hashes, session, config) {
   let url = this.server + '/api/v2/blocks/check';
-  if (session) {
-    url += '?session=' + encodeURIComponent(session);
-  }
-  return this.req.post(url, { hashes: hashes }, config);
+  const requestConfig = withBlockUploadSessionHeader(config, session);
+  return this.req.post(url, { hashes: hashes }, requestConfig);
 };
 
 // Upload a single block. The body is the raw block bytes; the server recomputes
 // and verifies the SHA-256. Under a session the block is also materialized.
 seafileAPI.uploadBlock = function (session, hash, data, config) {
   let url = this.server + '/api/v2/blocks/upload';
-  if (session) {
-    url += '?session=' + encodeURIComponent(session);
-  }
-  const requestConfig = config || {};
+  const requestConfig = withBlockUploadSessionHeader(config, session);
   const options = Object.assign({}, requestConfig, {
     headers: Object.assign({}, requestConfig.headers || {}, {
       'Content-Type': 'application/octet-stream',
@@ -1470,6 +1470,20 @@ seafileAPI.uploadBlock = function (session, hash, data, config) {
   });
   return this.req.post(url, data, options);
 };
+
+// withBlockUploadSessionHeader merges the X-Block-Upload-Session header into an
+// axios config without mutating the caller's object.
+function withBlockUploadSessionHeader(config, session) {
+  const requestConfig = config || {};
+  if (!session) {
+    return requestConfig;
+  }
+  return Object.assign({}, requestConfig, {
+    headers: Object.assign({}, requestConfig.headers || {}, {
+      'X-Block-Upload-Session': session,
+    }),
+  });
+}
 
 // Commit a file from an ordered manifest of already-uploaded blocks.
 // manifest = { session, parent_dir, filename, replace, size, blocks:[{sha256,size}] }

--- a/frontend/src/utils/seafile-api.js
+++ b/frontend/src/utils/seafile-api.js
@@ -1449,8 +1449,8 @@ seafileAPI.createBlockUploadSession = function (repoID, parentDir, config) {
 // reference), not merely present in object storage.
 //
 // The session id travels in the X-Block-Upload-Session header, not the query
-// string, so it does not land in access/proxy logs (the server still accepts
-// ?session= as a fallback for older callers).
+// string, so it does not land in access/proxy logs. The backend rejects the
+// legacy ?session= transport explicitly.
 seafileAPI.checkBlocks = function (hashes, session, config) {
   let url = this.server + '/api/v2/blocks/check';
   const requestConfig = withBlockUploadSessionHeader(config, session);

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -281,7 +281,9 @@ func buildCORSConfig(cfg *config.Config) cors.Config {
 			"Content-Disposition", // Required for filename in uploads
 			"Accept",
 			"Authorization",
+			"X-Block-Hash",
 			"Seafile-Repo-Token",
+			"X-Block-Upload-Session",
 			"X-Requested-With", // Common AJAX header
 		},
 		ExposeHeaders:    []string{"Content-Length", "Content-Type", "X-Quota-Warning"},

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -129,7 +129,7 @@ func (s *Server) registerAPIV2Routes(serverURL string) {
 	v2.RegisterLibraryRoutesWithToken(protected, s.db, s.config, s.tokenStore)
 	v2.RegisterFileRoutes(protected, s.db, s.config, s.storage, s.blockStore, s.storageManager, s.tokenStore, serverURL)
 	if s.blockStore != nil || s.storageManager != nil {
-		v2.RegisterBlockRoutes(protected, s.db, s.blockStore, s.storageManager, s.config)
+		v2.RegisterBlockRoutes(protected, s.db, s.blockStore, s.storageManager, s.config, s.permMiddleware)
 	}
 	v2.RegisterShareRoutes(protected, s.db, s.config)
 	v2.RegisterRestoreRoutes(protected, s.db, s.config)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -620,6 +620,22 @@ func TestBuildCORSConfig(t *testing.T) {
 		if corsConfig.AllowOrigins[0] != "https://app.example.com" {
 			t.Fatalf("AllowOrigins[0] = %q, want %q", corsConfig.AllowOrigins[0], "https://app.example.com")
 		}
+		foundSessionHeader := false
+		foundBlockHashHeader := false
+		for _, h := range corsConfig.AllowHeaders {
+			if h == "X-Block-Upload-Session" {
+				foundSessionHeader = true
+			}
+			if h == "X-Block-Hash" {
+				foundBlockHashHeader = true
+			}
+		}
+		if !foundSessionHeader {
+			t.Fatal("expected X-Block-Upload-Session to be allowed for cross-origin block uploads")
+		}
+		if !foundBlockHashHeader {
+			t.Fatal("expected X-Block-Hash to be allowed for cross-origin block uploads")
+		}
 	})
 
 	t.Run("production without allowlist fails closed", func(t *testing.T) {

--- a/internal/api/v2/blocks.go
+++ b/internal/api/v2/blocks.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -30,19 +31,62 @@ import (
 // Cassandra/S3 round-trips.
 const blockProbeConcurrency = 20
 
-// checkBlocksReadyParallel classifies, per hash, whether a block is truly
-// commit-ready for session-mode /blocks/check (R3 + finding 3): live in
-// Cassandra (ProbeBlockReuse == Reusable), physically present in S3
-// (existsMap, from the same CheckBlocksParallel call the commit itself runs),
-// and owned by this session or permanently referenced (classifyBlockOwnership
-// — the same helper file_from_blocks.go's classifyBlockForCommit uses). This
-// is the commit's classifier minus the size check (check has no declared
-// per-block sizes to compare against; sizes only arrive in the commit
-// manifest), so a block /blocks/check reports "existing" is exactly the set
-// the commit will accept modulo size — closing the "check says existing,
-// commit says needs_upload" gap for anything both endpoints can see (e.g. a
-// block reachable in Cassandra whose S3 object was deleted, or a block kept
-// alive only by a foreign session's transient reference).
+var checkBlocksProbeReuseFn = func(database *db.DB, orgID, hash string) (db.BlockReuseProbe, error) {
+	return database.ProbeBlockReuse(orgID, hash)
+}
+
+var checkBlocksClassifyOwnershipFn = classifyBlockOwnership
+
+// checkBlocksReusableCandidatesParallel probes the metadata plane first and
+// returns only the hashes whose blocks are logically reusable
+// (ProbeBlockReuse == Reusable). Session-mode /blocks/check uses this before
+// any S3 HEAD/Exists work so files that are mostly new do not pay thousands of
+// unnecessary object-store existence probes.
+func checkBlocksReusableCandidatesParallel(ctx context.Context, database *db.DB, orgID string, hashes []string, concurrency int) (map[string]bool, []string, error) {
+	result := make(map[string]bool, len(hashes))
+	reusable := make([]string, 0, len(hashes))
+	var mu sync.Mutex
+	g, gctx := errgroup.WithContext(ctx)
+	sem := make(chan struct{}, concurrency)
+	for _, hash := range hashes {
+		hash := hash
+		g.Go(func() error {
+			select {
+			case sem <- struct{}{}:
+			case <-gctx.Done():
+				return gctx.Err()
+			}
+			defer func() { <-sem }()
+			probe, err := checkBlocksProbeReuseFn(database, orgID, hash)
+			if err != nil {
+				return err
+			}
+			isReusable := probe.Decision == db.BlockReuseReusable
+			mu.Lock()
+			result[hash] = isReusable
+			if isReusable {
+				reusable = append(reusable, hash)
+			}
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
+	}
+	return result, reusable, nil
+}
+
+// checkBlocksReadyParallel classifies, per hash already known reusable in the
+// metadata plane, whether the block is truly commit-ready for session-mode
+// /blocks/check: physically present in S3 and owned by this session or
+// permanently referenced (classifyBlockOwnership — the same helper
+// file_from_blocks.go's classifyBlockForCommit uses). This is the commit's
+// classifier minus the size check (check has no declared per-block sizes to
+// compare against; sizes only arrive in the commit manifest), so a block
+// /blocks/check reports "existing" is exactly the set the commit will accept
+// modulo size — closing the "check says existing, commit says needs_upload"
+// gap for anything both endpoints can see.
 func checkBlocksReadyParallel(ctx context.Context, database *db.DB, orgID, referrer string, hashes []string, existsMap map[string]bool, concurrency int) (map[string]bool, error) {
 	result := make(map[string]bool, len(hashes))
 	var mu sync.Mutex
@@ -57,16 +101,15 @@ func checkBlocksReadyParallel(ctx context.Context, database *db.DB, orgID, refer
 				return gctx.Err()
 			}
 			defer func() { <-sem }()
-			probe, err := database.ProbeBlockReuse(orgID, hash)
+			if !existsMap[hash] {
+				mu.Lock()
+				result[hash] = false
+				mu.Unlock()
+				return nil
+			}
+			ready, err := checkBlocksClassifyOwnershipFn(database, orgID, referrer, hash)
 			if err != nil {
 				return err
-			}
-			ready := false
-			if probe.Decision == db.BlockReuseReusable && existsMap[hash] {
-				ready, err = classifyBlockOwnership(database, orgID, referrer, hash)
-				if err != nil {
-					return err
-				}
 			}
 			mu.Lock()
 			result[hash] = ready
@@ -189,16 +232,19 @@ func (h *BlockHandler) blockUploadFlowEnabled() bool {
 	return h.config != nil && h.config.WebUploads.EnableWebBlockUpload
 }
 
-// sessionIDFromRequest reads the web block-upload session id, preferring the
-// `X-Block-Upload-Session` header over the legacy `?session=` query parameter
-// (finding 9): a query parameter can land in access/proxy logs, while a header
-// does not. The query parameter is kept as a fallback for any caller not yet
-// updated.
-func sessionIDFromRequest(c *gin.Context) string {
+// sessionIDFromRequest reads the web block-upload session id from the
+// X-Block-Upload-Session header only. The legacy ?session= transport is
+// intentionally rejected rather than silently treated as "no session", because
+// falling back to the legacy no-session path would be both misleading and
+// unsafe for an outdated client.
+func sessionIDFromRequest(c *gin.Context) (sessionID string, usedLegacyQuery bool) {
 	if h := strings.TrimSpace(c.GetHeader("X-Block-Upload-Session")); h != "" {
-		return h
+		return h, false
 	}
-	return c.Query("session")
+	if q := strings.TrimSpace(c.Query("session")); q != "" {
+		return "", true
+	}
+	return "", false
 }
 
 // sessionPermissionRecheckInterval bounds how often resolveUploadSession
@@ -218,9 +264,17 @@ func sessionIDFromRequest(c *gin.Context) string {
 const sessionPermissionRecheckInterval = 2 * time.Minute
 
 // sessionPermissionCacheSweepSize bounds the cache's memory: once it holds
-// this many entries, the next insert sweeps stale ones inline instead of
-// running a background goroutine for what is a soft, best-effort mitigation.
+// this many entries, the next insert sweeps stale ones inline and, if that is
+// still insufficient during a burst of distinct live sessions, trims the
+// oldest confirmations so the map stays hard-bounded instead of growing
+// indefinitely.
 const sessionPermissionCacheSweepSize = 10000
+
+// Trim below the hard cap once it is reached so a burst of many fresh session
+// ids does not trigger an O(n) oldest-entry scan on every single subsequent
+// insert. Keeping a small buffer amortizes trim work while preserving the same
+// short-lived, best-effort semantics.
+const sessionPermissionCacheTrimTo = sessionPermissionCacheSweepSize - (sessionPermissionCacheSweepSize / 10)
 
 // sessionPermissionCache remembers, per session id, the last time upload
 // permission was confirmed. It is per-process (not shared across nodes) —
@@ -229,6 +283,11 @@ const sessionPermissionCacheSweepSize = 10000
 type sessionPermissionCache struct {
 	mu      sync.Mutex
 	checked map[string]time.Time
+}
+
+type sessionCacheEntry struct {
+	sessionID string
+	checkedAt time.Time
 }
 
 // allow reports whether the session's permission was confirmed within the
@@ -253,48 +312,122 @@ func (c *sessionPermissionCache) allow(sessionID string, verify func() bool) boo
 	if c.checked == nil {
 		c.checked = make(map[string]time.Time)
 	}
+	now := time.Now()
 	if len(c.checked) >= sessionPermissionCacheSweepSize {
-		cutoff := time.Now().Add(-sessionPermissionRecheckInterval)
-		for id, t := range c.checked {
-			if t.Before(cutoff) {
-				delete(c.checked, id)
-			}
-		}
+		c.trimLocked(now)
 	}
-	c.checked[sessionID] = time.Now()
+	c.checked[sessionID] = now
 	return true
 }
 
+func (c *sessionPermissionCache) trimLocked(now time.Time) {
+	cutoff := now.Add(-sessionPermissionRecheckInterval)
+	for id, t := range c.checked {
+		if t.Before(cutoff) {
+			delete(c.checked, id)
+		}
+	}
+	if len(c.checked) < sessionPermissionCacheSweepSize {
+		return
+	}
+
+	entries := make([]sessionCacheEntry, 0, len(c.checked))
+	for id, t := range c.checked {
+		entries = append(entries, sessionCacheEntry{sessionID: id, checkedAt: t})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].checkedAt.Before(entries[j].checkedAt)
+	})
+
+	trimCount := len(c.checked) - sessionPermissionCacheTrimTo + 1
+	if trimCount < 1 {
+		trimCount = 1
+	}
+	if trimCount > len(entries) {
+		trimCount = len(entries)
+	}
+	for i := 0; i < trimCount; i++ {
+		delete(c.checked, entries[i].sessionID)
+	}
+}
+
+type uploadSessionResolution int
+
+const (
+	uploadSessionAbsent uploadSessionResolution = iota
+	uploadSessionValid
+	uploadSessionInvalid
+	uploadSessionHeaderRequired
+	uploadSessionPermissionDenied
+)
+
+func (r uploadSessionResolution) deniedStatus() int {
+	if r == uploadSessionPermissionDenied {
+		return http.StatusForbidden
+	}
+	if r == uploadSessionHeaderRequired {
+		return http.StatusBadRequest
+	}
+	return http.StatusUnauthorized
+}
+
+func (r uploadSessionResolution) deniedMessage() string {
+	if r == uploadSessionHeaderRequired {
+		return "block upload session must be sent via X-Block-Upload-Session header"
+	}
+	if r == uploadSessionPermissionDenied {
+		return "upload is no longer allowed for this session"
+	}
+	return "invalid or expired upload session"
+}
+
 // resolveUploadSession reads the web content-addressed upload session id (see
-// sessionIDFromRequest) and validates it. Returns (session, present, ok):
-// present=false means no session was supplied (legacy desktop/mobile
-// behavior); ok=false means a session was supplied but the flow is disabled,
-// it is invalid/expired, does not belong to the caller, or (finding 12) the
-// caller no longer holds upload permission on the session's repo.
-func (h *BlockHandler) resolveUploadSession(c *gin.Context) (db.BlockUploadSession, bool, bool) {
-	sessionID := sessionIDFromRequest(c)
+// sessionIDFromRequest) and validates it. The returned resolution
+// distinguishes "no session supplied" from "invalid/expired" and "permission
+// revoked" so callers can respond accurately.
+func (h *BlockHandler) resolveUploadSession(c *gin.Context) (db.BlockUploadSession, uploadSessionResolution) {
+	sessionID, usedLegacyQuery := sessionIDFromRequest(c)
+	if usedLegacyQuery {
+		return db.BlockUploadSession{}, uploadSessionHeaderRequired
+	}
 	if sessionID == "" {
-		return db.BlockUploadSession{}, false, true
+		return db.BlockUploadSession{}, uploadSessionAbsent
 	}
 	if h.db == nil || !h.blockUploadFlowEnabled() {
-		return db.BlockUploadSession{}, true, false
+		return db.BlockUploadSession{}, uploadSessionInvalid
 	}
 	session, found, err := h.db.GetBlockUploadSession(sessionID)
 	if err != nil || !found {
-		return db.BlockUploadSession{}, true, false
+		return db.BlockUploadSession{}, uploadSessionInvalid
 	}
 	if session.OrgID != c.GetString("org_id") || session.UserID != c.GetString("user_id") {
-		return db.BlockUploadSession{}, true, false
+		return db.BlockUploadSession{}, uploadSessionInvalid
 	}
 	if h.permMiddleware != nil {
 		allowed := h.sessionPermCache.allow(session.SessionID, func() bool {
 			return h.permMiddleware.RequirePermFlagForRepo(c, session.RepoID, "upload")
 		})
 		if !allowed {
-			return db.BlockUploadSession{}, true, false
+			return db.BlockUploadSession{}, uploadSessionPermissionDenied
 		}
 	}
-	return session, true, true
+	return session, uploadSessionValid
+}
+
+func dedupePreserveOrder(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+	seen := make(map[string]struct{}, len(values))
+	deduped := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		deduped = append(deduped, value)
+	}
+	return deduped
 }
 
 // materializeUploadedBlock records block metadata plus a provisional reference
@@ -351,9 +484,9 @@ func (h *BlockHandler) CheckBlocks(c *gin.Context) {
 		return
 	}
 
-	session, present, ok := h.resolveUploadSession(c)
-	if present && !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired upload session"})
+	session, resolution := h.resolveUploadSession(c)
+	if resolution != uploadSessionAbsent && resolution != uploadSessionValid {
+		c.JSON(resolution.deniedStatus(), gin.H{"error": resolution.deniedMessage()})
 		return
 	}
 
@@ -364,27 +497,37 @@ func (h *BlockHandler) CheckBlocks(c *gin.Context) {
 	// which check cannot evaluate without the manifest's declared sizes).
 	// Anything less is reported missing so the client (re)uploads it under the
 	// session and materializes its own reference.
-	if present {
+	if resolution == uploadSessionValid {
 		orgID := c.GetString("org_id")
+		uniqueHashes := dedupePreserveOrder(req.Hashes)
+		reusableByHash, reusableHashes, rerr := checkBlocksReusableCandidatesParallel(c.Request.Context(), h.db, orgID, uniqueHashes, blockProbeConcurrency)
+		if rerr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check blocks"})
+			return
+		}
 		blockStore, _ := h.getBlockStoreForRepo(c, session.OrgID, session.RepoID)
 		if blockStore == nil {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "block storage not available"})
 			return
 		}
-		existsMap, serr := blockStore.CheckBlocksParallel(c.Request.Context(), req.Hashes, blockProbeConcurrency)
-		if serr != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check blocks"})
-			return
+		existsMap := make(map[string]bool, len(reusableHashes))
+		if len(reusableHashes) > 0 {
+			var serr error
+			existsMap, serr = blockStore.CheckBlocksParallel(c.Request.Context(), reusableHashes, blockProbeConcurrency)
+			if serr != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check blocks"})
+				return
+			}
 		}
 		referrer := db.BlockReferrerForUpload(session.SessionID)
-		ready, perr := checkBlocksReadyParallel(c.Request.Context(), h.db, orgID, referrer, req.Hashes, existsMap, blockProbeConcurrency)
+		ready, perr := checkBlocksReadyParallel(c.Request.Context(), h.db, orgID, referrer, reusableHashes, existsMap, blockProbeConcurrency)
 		if perr != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check blocks"})
 			return
 		}
 		var existing, missing []string
 		for _, hash := range req.Hashes {
-			if ready[hash] {
+			if reusableByHash[hash] && ready[hash] {
 				existing = append(existing, hash)
 			} else {
 				missing = append(missing, hash)
@@ -402,7 +545,8 @@ func (h *BlockHandler) CheckBlocks(c *gin.Context) {
 	}
 
 	// Legacy physical-existence oracle (desktop/mobile sync, no session).
-	existsMap, err := blockStore.CheckBlocksParallel(c.Request.Context(), req.Hashes, 20)
+	uniqueHashes := dedupePreserveOrder(req.Hashes)
+	existsMap, err := blockStore.CheckBlocksParallel(c.Request.Context(), uniqueHashes, 20)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check blocks"})
 		return
@@ -439,9 +583,9 @@ func (h *BlockHandler) UploadBlock(c *gin.Context) {
 	// Optional web-flow session: when present, the block is materialized
 	// (metadata + provisional ref owned by the session) after storage, so an
 	// abandoned upload self-expires and a later commit can publish it (R9).
-	session, sessionPresent, sessionOK := h.resolveUploadSession(c)
-	if sessionPresent && !sessionOK {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired upload session"})
+	session, resolution := h.resolveUploadSession(c)
+	if resolution != uploadSessionAbsent && resolution != uploadSessionValid {
+		c.JSON(resolution.deniedStatus(), gin.H{"error": resolution.deniedMessage()})
 		return
 	}
 
@@ -522,7 +666,7 @@ func (h *BlockHandler) UploadBlock(c *gin.Context) {
 	// for that repo (HIGH-2); otherwise use hostname/default routing.
 	var blockStore *storage.BlockStore
 	var storageClass string
-	if sessionPresent {
+	if resolution == uploadSessionValid {
 		blockStore, storageClass = h.getBlockStoreForRepo(c, session.OrgID, session.RepoID)
 	} else {
 		blockStore, storageClass = h.getBlockStore(c)
@@ -547,7 +691,7 @@ func (h *BlockHandler) UploadBlock(c *gin.Context) {
 		// R9: materialize even when S3 already has the object — the goal is to
 		// GOVERN the block (metadata + provisional ref) so the session can commit
 		// it and GC can reclaim it, not merely to store bytes.
-		if sessionPresent {
+		if resolution == uploadSessionValid {
 			if err := h.materializeUploadedBlock(session, hash, sha1Hash, len(data), storageClass, false); err != nil {
 				if errors.Is(err, db.ErrBlockIDMappingConflict) {
 					c.JSON(http.StatusConflict, gin.H{"error": "block id mapping conflict"})
@@ -578,7 +722,7 @@ func (h *BlockHandler) UploadBlock(c *gin.Context) {
 	// this flow. Neither path bounds total uncommitted staged bytes; for the web
 	// flow that is bounded instead by the upload traffic quota (charged above) and
 	// the 48h provisional-ref TTL + GC. See docs/WEB-BLOCK-UPLOAD.md.
-	if !sessionPresent {
+	if resolution != uploadSessionValid {
 		if checker := traffic.GetChecker(); checker != nil {
 			if st, _ := checker.CheckStorageQuota(c.GetString("org_id"), c.GetString("user_id"), int64(len(data))); !st.Allowed {
 				c.JSON(http.StatusForbidden, gin.H{"error": "storage quota exceeded"})
@@ -606,7 +750,7 @@ func (h *BlockHandler) UploadBlock(c *gin.Context) {
 	}
 
 	// R9: govern the freshly stored block under the session.
-	if sessionPresent {
+	if resolution == uploadSessionValid {
 		if err := h.materializeUploadedBlock(session, hash, sha1Hash, len(data), storageClass, true); err != nil {
 			if errors.Is(err, db.ErrBlockIDMappingConflict) {
 				c.JSON(http.StatusConflict, gin.H{"error": "block id mapping conflict"})

--- a/internal/api/v2/blocks.go
+++ b/internal/api/v2/blocks.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -482,6 +483,12 @@ func (h *BlockHandler) CheckBlocks(c *gin.Context) {
 	if len(req.Hashes) > 10000 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "too many hashes, maximum is 10000"})
 		return
+	}
+	for i, hash := range req.Hashes {
+		if !isHex64(hash) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("hashes[%d]: invalid sha256", i)})
+			return
+		}
 	}
 
 	session, resolution := h.resolveUploadSession(c)

--- a/internal/api/v2/blocks.go
+++ b/internal/api/v2/blocks.go
@@ -9,11 +9,14 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/Sesame-Disk/sesamefs/internal/config"
 	"github.com/Sesame-Disk/sesamefs/internal/db"
+	"github.com/Sesame-Disk/sesamefs/internal/metrics"
 	"github.com/Sesame-Disk/sesamefs/internal/middleware"
 	"github.com/Sesame-Disk/sesamefs/internal/storage"
 	"github.com/Sesame-Disk/sesamefs/internal/traffic"
@@ -22,13 +25,25 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// blockProbeConcurrency bounds parallel ProbeBlockReuse calls for session-mode
-// /blocks/check so a large hash list does not become serial Cassandra round-trips.
+// blockProbeConcurrency bounds parallel per-block classification for
+// session-mode /blocks/check so a large hash list does not become serial
+// Cassandra/S3 round-trips.
 const blockProbeConcurrency = 20
 
-// probeBlocksReusableParallel returns, per hash, whether the block is commit-ready
-// (ProbeBlockReuse == Reusable), computed with bounded concurrency.
-func probeBlocksReusableParallel(ctx context.Context, database *db.DB, orgID string, hashes []string, concurrency int) (map[string]bool, error) {
+// checkBlocksReadyParallel classifies, per hash, whether a block is truly
+// commit-ready for session-mode /blocks/check (R3 + finding 3): live in
+// Cassandra (ProbeBlockReuse == Reusable), physically present in S3
+// (existsMap, from the same CheckBlocksParallel call the commit itself runs),
+// and owned by this session or permanently referenced (classifyBlockOwnership
+// — the same helper file_from_blocks.go's classifyBlockForCommit uses). This
+// is the commit's classifier minus the size check (check has no declared
+// per-block sizes to compare against; sizes only arrive in the commit
+// manifest), so a block /blocks/check reports "existing" is exactly the set
+// the commit will accept modulo size — closing the "check says existing,
+// commit says needs_upload" gap for anything both endpoints can see (e.g. a
+// block reachable in Cassandra whose S3 object was deleted, or a block kept
+// alive only by a foreign session's transient reference).
+func checkBlocksReadyParallel(ctx context.Context, database *db.DB, orgID, referrer string, hashes []string, existsMap map[string]bool, concurrency int) (map[string]bool, error) {
 	result := make(map[string]bool, len(hashes))
 	var mu sync.Mutex
 	g, gctx := errgroup.WithContext(ctx)
@@ -46,8 +61,15 @@ func probeBlocksReusableParallel(ctx context.Context, database *db.DB, orgID str
 			if err != nil {
 				return err
 			}
+			ready := false
+			if probe.Decision == db.BlockReuseReusable && existsMap[hash] {
+				ready, err = classifyBlockOwnership(database, orgID, referrer, hash)
+				if err != nil {
+					return err
+				}
+			}
 			mu.Lock()
-			result[hash] = probe.Decision == db.BlockReuseReusable
+			result[hash] = ready
 			mu.Unlock()
 			return nil
 		})
@@ -60,20 +82,24 @@ func probeBlocksReusableParallel(ctx context.Context, database *db.DB, orgID str
 
 // BlockHandler handles block-level API operations
 type BlockHandler struct {
-	blockStore     *storage.BlockStore // Legacy single store (fallback)
-	storageManager *storage.Manager    // Multi-backend storage manager
-	config         *config.Config
-	db             *db.DB // Optional: enables session-scoped materialization for the web flow
+	blockStore       *storage.BlockStore // Legacy single store (fallback)
+	storageManager   *storage.Manager    // Multi-backend storage manager
+	config           *config.Config
+	db               *db.DB                           // Optional: enables session-scoped materialization for the web flow
+	permMiddleware   *middleware.PermissionMiddleware // Optional: re-verifies upload permission for long-lived sessions (R12)
+	sessionPermCache *sessionPermissionCache          // Bounds how often that re-verification runs (see sessionPermissionCache)
 }
 
 // RegisterBlockRoutes registers the block API routes
 // Supports both legacy single BlockStore and multi-region StorageManager
-func RegisterBlockRoutes(rg *gin.RouterGroup, database *db.DB, blockStore *storage.BlockStore, storageManager *storage.Manager, cfg *config.Config) {
+func RegisterBlockRoutes(rg *gin.RouterGroup, database *db.DB, blockStore *storage.BlockStore, storageManager *storage.Manager, cfg *config.Config, permMiddleware *middleware.PermissionMiddleware) {
 	h := &BlockHandler{
-		blockStore:     blockStore,
-		storageManager: storageManager,
-		config:         cfg,
-		db:             database,
+		blockStore:       blockStore,
+		storageManager:   storageManager,
+		config:           cfg,
+		db:               database,
+		permMiddleware:   permMiddleware,
+		sessionPermCache: &sessionPermissionCache{},
 	}
 
 	// Per-IP rate limit for the block existence oracle.
@@ -163,13 +189,90 @@ func (h *BlockHandler) blockUploadFlowEnabled() bool {
 	return h.config != nil && h.config.WebUploads.EnableWebBlockUpload
 }
 
-// resolveUploadSession reads an optional ?session= query parameter for the web
-// content-addressed upload flow. Returns (session, present, ok): present=false
-// means no session was supplied (legacy desktop/mobile behavior); ok=false means
-// a session was supplied but the flow is disabled, or it is invalid/expired or
-// does not belong to the caller.
+// sessionIDFromRequest reads the web block-upload session id, preferring the
+// `X-Block-Upload-Session` header over the legacy `?session=` query parameter
+// (finding 9): a query parameter can land in access/proxy logs, while a header
+// does not. The query parameter is kept as a fallback for any caller not yet
+// updated.
+func sessionIDFromRequest(c *gin.Context) string {
+	if h := strings.TrimSpace(c.GetHeader("X-Block-Upload-Session")); h != "" {
+		return h
+	}
+	return c.Query("session")
+}
+
+// sessionPermissionRecheckInterval bounds how often resolveUploadSession
+// re-verifies the caller's upload permission for a session's repo (finding
+// 12). A block-upload session lives up to 48h; if upload access is revoked
+// mid-session (independent of org role/account status, which already
+// invalidate the auth token via invalidateSessionsOnDemotion /
+// invalidateUserCredentials), staging should stop well before the TTL. But
+// re-running the full library-permission resolution (a shares-table scan) on
+// EVERY /blocks/upload call — up to thousands per large file — would make
+// this "cheap fix" the most expensive query in the hot path. Caching the
+// outcome for a short interval keeps staleness bounded to minutes instead of
+// 48h while adding no cost to the overwhelming majority of requests. The
+// commit (file-from-blocks) always re-verifies permission fresh regardless
+// (requireWritePermission + RequirePermFlag), so this is defense in depth,
+// not the sole enforcement point.
+const sessionPermissionRecheckInterval = 2 * time.Minute
+
+// sessionPermissionCacheSweepSize bounds the cache's memory: once it holds
+// this many entries, the next insert sweeps stale ones inline instead of
+// running a background goroutine for what is a soft, best-effort mitigation.
+const sessionPermissionCacheSweepSize = 10000
+
+// sessionPermissionCache remembers, per session id, the last time upload
+// permission was confirmed. It is per-process (not shared across nodes) —
+// acceptable because it only narrows an already-bounded exposure window, and
+// every node still converges on the same fresh check within the interval.
+type sessionPermissionCache struct {
+	mu      sync.Mutex
+	checked map[string]time.Time
+}
+
+// allow reports whether the session's permission was confirmed within the
+// last sessionPermissionRecheckInterval; otherwise it runs verify() and caches
+// a fresh confirmation only on success (a denial is never cached, so a
+// mid-window permission fix is picked up on the very next request rather than
+// waiting out the interval).
+func (c *sessionPermissionCache) allow(sessionID string, verify func() bool) bool {
+	c.mu.Lock()
+	if t, ok := c.checked[sessionID]; ok && time.Since(t) < sessionPermissionRecheckInterval {
+		c.mu.Unlock()
+		return true
+	}
+	c.mu.Unlock()
+
+	if !verify() {
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.checked == nil {
+		c.checked = make(map[string]time.Time)
+	}
+	if len(c.checked) >= sessionPermissionCacheSweepSize {
+		cutoff := time.Now().Add(-sessionPermissionRecheckInterval)
+		for id, t := range c.checked {
+			if t.Before(cutoff) {
+				delete(c.checked, id)
+			}
+		}
+	}
+	c.checked[sessionID] = time.Now()
+	return true
+}
+
+// resolveUploadSession reads the web content-addressed upload session id (see
+// sessionIDFromRequest) and validates it. Returns (session, present, ok):
+// present=false means no session was supplied (legacy desktop/mobile
+// behavior); ok=false means a session was supplied but the flow is disabled,
+// it is invalid/expired, does not belong to the caller, or (finding 12) the
+// caller no longer holds upload permission on the session's repo.
 func (h *BlockHandler) resolveUploadSession(c *gin.Context) (db.BlockUploadSession, bool, bool) {
-	sessionID := c.Query("session")
+	sessionID := sessionIDFromRequest(c)
 	if sessionID == "" {
 		return db.BlockUploadSession{}, false, true
 	}
@@ -183,6 +286,14 @@ func (h *BlockHandler) resolveUploadSession(c *gin.Context) (db.BlockUploadSessi
 	if session.OrgID != c.GetString("org_id") || session.UserID != c.GetString("user_id") {
 		return db.BlockUploadSession{}, true, false
 	}
+	if h.permMiddleware != nil {
+		allowed := h.sessionPermCache.allow(session.SessionID, func() bool {
+			return h.permMiddleware.RequirePermFlagForRepo(c, session.RepoID, "upload")
+		})
+		if !allowed {
+			return db.BlockUploadSession{}, true, false
+		}
+	}
 	return session, true, true
 }
 
@@ -195,9 +306,15 @@ func (h *BlockHandler) resolveUploadSession(c *gin.Context) (db.BlockUploadSessi
 // remap fails closed (db.ErrBlockIDMappingConflict). The commit (file-from-blocks)
 // only ever READS this mapping; it never mints one from the manifest, which is why
 // a forged manifest SHA-1 cannot poison resolution. The shared legacy/seafhttp
-// mapping path (WriteBlockIDMapping) is left untouched.
-func (h *BlockHandler) materializeUploadedBlock(session db.BlockUploadSession, sha256ID, sha1ID string, size int, storageClass string) error {
-	return RegisterWebUploadedBlockAndMapping(h.db, session.OrgID, session.RepoID, sha256ID, session.SessionID, size, storageClass, "", sha1ID)
+// mapping path (WriteBlockIDMapping) is left untouched. isNew labels the
+// staging metric (finding 8) by whether the underlying S3 PUT was a fresh
+// write or a dedup no-op — governance work happens either way (R9).
+func (h *BlockHandler) materializeUploadedBlock(session db.BlockUploadSession, sha256ID, sha1ID string, size int, storageClass string, isNew bool) error {
+	if err := RegisterWebUploadedBlockAndMapping(h.db, session.OrgID, session.RepoID, sha256ID, session.SessionID, size, storageClass, "", sha1ID); err != nil {
+		return err
+	}
+	metrics.BlockUploadStagedBlocksTotal.WithLabelValues(strconv.FormatBool(isNew)).Inc()
+	return nil
 }
 
 // CheckBlocksRequest is the request body for checking blocks
@@ -240,23 +357,34 @@ func (h *BlockHandler) CheckBlocks(c *gin.Context) {
 		return
 	}
 
-	// Session mode (web flow, R3): a block counts as "existing" only when it is
-	// commit-ready (ProbeBlockReuse == Reusable). A block that exists physically
-	// in S3 but has no live metadata/reference is reported as missing so the
-	// client (re)uploads it under the session and materializes it — avoiding the
-	// "S3 exists but unmaterialized → commit says NeedsPut" trap of the raw
-	// physical oracle.
+	// Session mode (web flow, R3 + finding 3): a block counts as "existing" only
+	// when checkBlocksReadyParallel agrees it is truly commit-ready — live,
+	// physically present in S3, AND owned by this session or permanently
+	// referenced — the same classifier the commit uses (minus the size check,
+	// which check cannot evaluate without the manifest's declared sizes).
+	// Anything less is reported missing so the client (re)uploads it under the
+	// session and materializes its own reference.
 	if present {
-		_ = session
 		orgID := c.GetString("org_id")
-		reusable, perr := probeBlocksReusableParallel(c.Request.Context(), h.db, orgID, req.Hashes, blockProbeConcurrency)
+		blockStore, _ := h.getBlockStoreForRepo(c, session.OrgID, session.RepoID)
+		if blockStore == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "block storage not available"})
+			return
+		}
+		existsMap, serr := blockStore.CheckBlocksParallel(c.Request.Context(), req.Hashes, blockProbeConcurrency)
+		if serr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check blocks"})
+			return
+		}
+		referrer := db.BlockReferrerForUpload(session.SessionID)
+		ready, perr := checkBlocksReadyParallel(c.Request.Context(), h.db, orgID, referrer, req.Hashes, existsMap, blockProbeConcurrency)
 		if perr != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check blocks"})
 			return
 		}
 		var existing, missing []string
 		for _, hash := range req.Hashes {
-			if reusable[hash] {
+			if ready[hash] {
 				existing = append(existing, hash)
 			} else {
 				missing = append(missing, hash)
@@ -404,8 +532,6 @@ func (h *BlockHandler) UploadBlock(c *gin.Context) {
 		return
 	}
 
-	log.Printf("v2/blocks: uploading block %s to storage class %s\n", hash[:12], storageClass)
-
 	// Check if block already exists
 	exists, err := blockStore.BlockExists(c.Request.Context(), hash)
 	if err != nil {
@@ -422,7 +548,7 @@ func (h *BlockHandler) UploadBlock(c *gin.Context) {
 		// GOVERN the block (metadata + provisional ref) so the session can commit
 		// it and GC can reclaim it, not merely to store bytes.
 		if sessionPresent {
-			if err := h.materializeUploadedBlock(session, hash, sha1Hash, len(data), storageClass); err != nil {
+			if err := h.materializeUploadedBlock(session, hash, sha1Hash, len(data), storageClass, false); err != nil {
 				if errors.Is(err, db.ErrBlockIDMappingConflict) {
 					c.JSON(http.StatusConflict, gin.H{"error": "block id mapping conflict"})
 					return
@@ -481,7 +607,7 @@ func (h *BlockHandler) UploadBlock(c *gin.Context) {
 
 	// R9: govern the freshly stored block under the session.
 	if sessionPresent {
-		if err := h.materializeUploadedBlock(session, hash, sha1Hash, len(data), storageClass); err != nil {
+		if err := h.materializeUploadedBlock(session, hash, sha1Hash, len(data), storageClass, true); err != nil {
 			if errors.Is(err, db.ErrBlockIDMappingConflict) {
 				c.JSON(http.StatusConflict, gin.H{"error": "block id mapping conflict"})
 				return

--- a/internal/api/v2/blocks.go
+++ b/internal/api/v2/blocks.go
@@ -32,6 +32,8 @@ import (
 // Cassandra/S3 round-trips.
 const blockProbeConcurrency = 20
 
+var errSessionCheckBlockStoreUnavailable = errors.New("block storage not available")
+
 var checkBlocksProbeReuseFn = func(database *db.DB, orgID, hash string) (db.BlockReuseProbe, error) {
 	return database.ProbeBlockReuse(orgID, hash)
 }
@@ -431,6 +433,45 @@ func dedupePreserveOrder(values []string) []string {
 	return deduped
 }
 
+func (h *BlockHandler) checkBlocksForSession(c *gin.Context, session db.BlockUploadSession, hashes []string) (CheckBlocksResponse, error) {
+	orgID := c.GetString("org_id")
+	uniqueHashes := dedupePreserveOrder(hashes)
+	reusableByHash, reusableHashes, err := checkBlocksReusableCandidatesParallel(c.Request.Context(), h.db, orgID, uniqueHashes, blockProbeConcurrency)
+	if err != nil {
+		return CheckBlocksResponse{}, err
+	}
+
+	if len(reusableHashes) == 0 {
+		return CheckBlocksResponse{Existing: nil, Missing: append([]string(nil), hashes...)}, nil
+	}
+
+	blockStore, _ := h.getBlockStoreForRepo(c, session.OrgID, session.RepoID)
+	if blockStore == nil {
+		return CheckBlocksResponse{}, errSessionCheckBlockStoreUnavailable
+	}
+
+	existsMap, err := blockStore.CheckBlocksParallel(c.Request.Context(), reusableHashes, blockProbeConcurrency)
+	if err != nil {
+		return CheckBlocksResponse{}, err
+	}
+
+	referrer := db.BlockReferrerForUpload(session.SessionID)
+	ready, err := checkBlocksReadyParallel(c.Request.Context(), h.db, orgID, referrer, reusableHashes, existsMap, blockProbeConcurrency)
+	if err != nil {
+		return CheckBlocksResponse{}, err
+	}
+
+	var existing, missing []string
+	for _, hash := range hashes {
+		if reusableByHash[hash] && ready[hash] {
+			existing = append(existing, hash)
+		} else {
+			missing = append(missing, hash)
+		}
+	}
+	return CheckBlocksResponse{Existing: existing, Missing: missing}, nil
+}
+
 // materializeUploadedBlock records block metadata plus a provisional reference
 // owned by the session ("up:<session_id>") so the block is GC-governed and
 // commit-ready (R9). It ALSO writes the authoritative SHA-1 → SHA-256 mapping
@@ -505,42 +546,16 @@ func (h *BlockHandler) CheckBlocks(c *gin.Context) {
 	// Anything less is reported missing so the client (re)uploads it under the
 	// session and materializes its own reference.
 	if resolution == uploadSessionValid {
-		orgID := c.GetString("org_id")
-		uniqueHashes := dedupePreserveOrder(req.Hashes)
-		reusableByHash, reusableHashes, rerr := checkBlocksReusableCandidatesParallel(c.Request.Context(), h.db, orgID, uniqueHashes, blockProbeConcurrency)
-		if rerr != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check blocks"})
-			return
-		}
-		blockStore, _ := h.getBlockStoreForRepo(c, session.OrgID, session.RepoID)
-		if blockStore == nil {
-			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "block storage not available"})
-			return
-		}
-		existsMap := make(map[string]bool, len(reusableHashes))
-		if len(reusableHashes) > 0 {
-			var serr error
-			existsMap, serr = blockStore.CheckBlocksParallel(c.Request.Context(), reusableHashes, blockProbeConcurrency)
-			if serr != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check blocks"})
+		resp, err := h.checkBlocksForSession(c, session, req.Hashes)
+		if err != nil {
+			if errors.Is(err, errSessionCheckBlockStoreUnavailable) {
+				c.JSON(http.StatusServiceUnavailable, gin.H{"error": "block storage not available"})
 				return
 			}
-		}
-		referrer := db.BlockReferrerForUpload(session.SessionID)
-		ready, perr := checkBlocksReadyParallel(c.Request.Context(), h.db, orgID, referrer, reusableHashes, existsMap, blockProbeConcurrency)
-		if perr != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check blocks"})
 			return
 		}
-		var existing, missing []string
-		for _, hash := range req.Hashes {
-			if reusableByHash[hash] && ready[hash] {
-				existing = append(existing, hash)
-			} else {
-				missing = append(missing, hash)
-			}
-		}
-		c.JSON(http.StatusOK, CheckBlocksResponse{Existing: existing, Missing: missing})
+		c.JSON(http.StatusOK, resp)
 		return
 	}
 

--- a/internal/api/v2/blocks_test.go
+++ b/internal/api/v2/blocks_test.go
@@ -410,6 +410,40 @@ func TestCheckBlocksReadyParallel_OnlyChecksOwnershipForPhysicallyPresentCandida
 	}
 }
 
+func TestCheckBlocksForSession_AllMetadataMissingSkipsBlockStore(t *testing.T) {
+	origProbe := checkBlocksProbeReuseFn
+	defer func() {
+		checkBlocksProbeReuseFn = origProbe
+	}()
+
+	checkBlocksProbeReuseFn = func(database *db.DB, orgID, hash string) (db.BlockReuseProbe, error) {
+		return db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut}, nil
+	}
+
+	h := &BlockHandler{blockStore: nil, storageManager: nil, config: nil}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v2/blocks/check", nil)
+	c.Set("org_id", "org-1")
+
+	resp, err := h.checkBlocksForSession(c, db.BlockUploadSession{SessionID: "sess-1", OrgID: "org-1", RepoID: "repo-1"}, []string{"new-a", "new-b", "new-a"})
+	if err != nil {
+		t.Fatalf("checkBlocksForSession returned error: %v", err)
+	}
+	if len(resp.Existing) != 0 {
+		t.Fatalf("existing = %v, want empty", resp.Existing)
+	}
+	wantMissing := []string{"new-a", "new-b", "new-a"}
+	if len(resp.Missing) != len(wantMissing) {
+		t.Fatalf("missing len = %d, want %d (%v)", len(resp.Missing), len(wantMissing), resp.Missing)
+	}
+	for i := range wantMissing {
+		if resp.Missing[i] != wantMissing[i] {
+			t.Fatalf("missing[%d] = %q, want %q (order and duplicates should be preserved)", i, resp.Missing[i], wantMissing[i])
+		}
+	}
+}
+
 func TestBlockUploadSessionQueryTransportIsRejected(t *testing.T) {
 	t.Run("check blocks rejects legacy session query transport", func(t *testing.T) {
 		r := gin.New()

--- a/internal/api/v2/blocks_test.go
+++ b/internal/api/v2/blocks_test.go
@@ -92,6 +92,31 @@ func TestCheckBlocks_TooManyHashes(t *testing.T) {
 	}
 }
 
+func TestCheckBlocks_InvalidSHA256(t *testing.T) {
+	r := gin.New()
+	r.Use(gin.Recovery())
+
+	h := &BlockHandler{blockStore: nil, storageManager: nil, config: nil}
+	r.POST("/api/v2/blocks/check", h.CheckBlocks)
+
+	body := CheckBlocksRequest{Hashes: []string{strings.Repeat("g", 64)}}
+	jsonBody, _ := json.Marshal(body)
+	req, _ := http.NewRequest("POST", "/api/v2/blocks/check", bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["error"] != "hashes[0]: invalid sha256" {
+		t.Errorf("error = %v, want 'hashes[0]: invalid sha256'", resp["error"])
+	}
+}
+
 func TestCheckBlocks_NilBlockStore(t *testing.T) {
 	r := gin.New()
 	r.Use(gin.Recovery())

--- a/internal/api/v2/blocks_test.go
+++ b/internal/api/v2/blocks_test.go
@@ -2,13 +2,16 @@ package v2
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/Sesame-Disk/sesamefs/internal/db"
 	"github.com/Sesame-Disk/sesamefs/internal/storage"
 	"github.com/gin-gonic/gin"
 )
@@ -131,21 +134,23 @@ func TestDirectBlockReadRoutesAreNotRegistered(t *testing.T) {
 	}
 }
 
-// finding 9: the X-Block-Upload-Session header must win over the legacy
-// ?session= query parameter, and the query parameter must still work as a
-// fallback for any caller not yet updated.
+// finding 9: the X-Block-Upload-Session header is the only supported transport
+// for a block-upload session id. The legacy ?session= query parameter is
+// rejected explicitly so an outdated caller cannot silently fall back to the
+// legacy no-session path.
 func TestSessionIDFromRequest(t *testing.T) {
 	tests := []struct {
 		name   string
 		header string
 		query  string
 		want   string
+		legacy bool
 	}{
-		{"header only", "sess-header", "", "sess-header"},
-		{"query only", "", "sess-query", "sess-query"},
-		{"header wins over query", "sess-header", "sess-query", "sess-header"},
-		{"neither present", "", "", ""},
-		{"whitespace-only header falls back to query", "   ", "sess-query", "sess-query"},
+		{"header only", "sess-header", "", "sess-header", false},
+		{"query only rejected", "", "sess-query", "", true},
+		{"header wins over query", "sess-header", "sess-query", "sess-header", false},
+		{"neither present", "", "", "", false},
+		{"whitespace-only header still rejects query transport", "   ", "sess-query", "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -160,8 +165,12 @@ func TestSessionIDFromRequest(t *testing.T) {
 			c, _ := gin.CreateTestContext(httptest.NewRecorder())
 			c.Request = req
 
-			if got := sessionIDFromRequest(c); got != tt.want {
-				t.Errorf("sessionIDFromRequest() = %q, want %q", got, tt.want)
+			got, legacy := sessionIDFromRequest(c)
+			if got != tt.want {
+				t.Errorf("sessionIDFromRequest() id = %q, want %q", got, tt.want)
+			}
+			if legacy != tt.legacy {
+				t.Errorf("sessionIDFromRequest() legacy = %v, want %v", legacy, tt.legacy)
 			}
 		})
 	}
@@ -239,7 +248,7 @@ func TestSessionPermissionCache_Allow(t *testing.T) {
 		c := &sessionPermissionCache{checked: make(map[string]time.Time, sessionPermissionCacheSweepSize+1)}
 		stale := time.Now().Add(-sessionPermissionRecheckInterval - time.Second)
 		for i := 0; i < sessionPermissionCacheSweepSize; i++ {
-			c.checked[strings.Repeat("x", 1)+string(rune(i))] = stale
+			c.checked[fmt.Sprintf("stale-%d", i)] = stale
 		}
 		verify := func() bool { return true }
 
@@ -251,6 +260,172 @@ func TestSessionPermissionCache_Allow(t *testing.T) {
 		}
 		if _, ok := c.checked["sess-fresh"]; !ok {
 			t.Error("the fresh entry that triggered the sweep must survive it")
+		}
+	})
+
+	t.Run("evicts oldest fresh entries to keep a hard cap during bursts", func(t *testing.T) {
+		c := &sessionPermissionCache{checked: make(map[string]time.Time, sessionPermissionCacheSweepSize)}
+		base := time.Now()
+		for i := 0; i < sessionPermissionCacheSweepSize; i++ {
+			c.checked[hexSessionID(i)] = base.Add(time.Duration(i) * time.Millisecond)
+		}
+		verifyCalls := 0
+		verify := func() bool { verifyCalls++; return true }
+
+		if !c.allow("sess-new", verify) {
+			t.Fatal("expected allow")
+		}
+		if verifyCalls != 1 {
+			t.Fatalf("verify called %d times, want 1", verifyCalls)
+		}
+		if len(c.checked) > sessionPermissionCacheSweepSize {
+			t.Fatalf("cache size = %d, want <= %d hard cap", len(c.checked), sessionPermissionCacheSweepSize)
+		}
+		if len(c.checked) != sessionPermissionCacheTrimTo {
+			t.Fatalf("cache size = %d, want trim target %d after burst eviction", len(c.checked), sessionPermissionCacheTrimTo)
+		}
+		if _, ok := c.checked["sess-new"]; !ok {
+			t.Fatal("newly verified session should remain cached")
+		}
+		if _, ok := c.checked[hexSessionID(0)]; ok {
+			t.Fatal("oldest fresh entry should have been evicted under burst pressure")
+		}
+	})
+}
+
+func hexSessionID(i int) string {
+	return fmt.Sprintf("sess-%05d", i)
+}
+
+func TestDedupePreserveOrder(t *testing.T) {
+	input := []string{"a", "b", "a", "c", "b", "d"}
+	got := dedupePreserveOrder(input)
+	want := []string{"a", "b", "c", "d"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestCheckBlocksReusableCandidatesParallel_ProbesMetadataFirst(t *testing.T) {
+	origProbe := checkBlocksProbeReuseFn
+	defer func() {
+		checkBlocksProbeReuseFn = origProbe
+	}()
+
+	var probeCalls int
+	checkBlocksProbeReuseFn = func(database *db.DB, orgID, hash string) (db.BlockReuseProbe, error) {
+		probeCalls++
+		if hash == "reusable" {
+			return db.BlockReuseProbe{Decision: db.BlockReuseReusable}, nil
+		}
+		return db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut}, nil
+	}
+
+	reusableByHash, reusableHashes, err := checkBlocksReusableCandidatesParallel(
+		context.Background(),
+		nil,
+		"org",
+		[]string{"new", "reusable"},
+		2,
+	)
+	if err != nil {
+		t.Fatalf("checkBlocksReusableCandidatesParallel returned error: %v", err)
+	}
+	if probeCalls != 2 {
+		t.Fatalf("probeCalls = %d, want 2 (probe all hashes in metadata plane first)", probeCalls)
+	}
+	if reusableByHash["new"] {
+		t.Fatal("non-reusable block reported reusable")
+	}
+	if !reusableByHash["reusable"] {
+		t.Fatal("reusable block not reported reusable")
+	}
+	if len(reusableHashes) != 1 || reusableHashes[0] != "reusable" {
+		t.Fatalf("reusableHashes = %v, want [reusable]", reusableHashes)
+	}
+}
+
+func TestCheckBlocksReadyParallel_OnlyChecksOwnershipForPhysicallyPresentCandidates(t *testing.T) {
+	origClassify := checkBlocksClassifyOwnershipFn
+	defer func() {
+		checkBlocksClassifyOwnershipFn = origClassify
+	}()
+
+	var classifyCalls int
+	checkBlocksClassifyOwnershipFn = func(database *db.DB, orgID, referrer, blockID string) (bool, error) {
+		classifyCalls++
+		return blockID == "present", nil
+	}
+
+	ready, err := checkBlocksReadyParallel(
+		context.Background(),
+		nil,
+		"org",
+		"up:sess",
+		[]string{"missing", "present"},
+		map[string]bool{"missing": false, "present": true},
+		2,
+	)
+	if err != nil {
+		t.Fatalf("checkBlocksReadyParallel returned error: %v", err)
+	}
+	if classifyCalls != 1 {
+		t.Fatalf("classifyCalls = %d, want 1 (missing physical object should skip ownership read)", classifyCalls)
+	}
+	if ready["missing"] {
+		t.Fatal("missing block reported ready")
+	}
+	if !ready["present"] {
+		t.Fatal("present reusable block should be ready")
+	}
+}
+
+func TestBlockUploadSessionQueryTransportIsRejected(t *testing.T) {
+	t.Run("check blocks rejects legacy session query transport", func(t *testing.T) {
+		r := gin.New()
+		h := &BlockHandler{}
+		r.POST("/api/v2/blocks/check", h.CheckBlocks)
+
+		body := CheckBlocksRequest{Hashes: []string{strings.Repeat("a", 64)}}
+		jsonBody, _ := json.Marshal(body)
+		req, _ := http.NewRequest("POST", "/api/v2/blocks/check?session=legacy", bytes.NewBuffer(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+		var resp map[string]interface{}
+		json.Unmarshal(w.Body.Bytes(), &resp)
+		if resp["error"] != "block upload session must be sent via X-Block-Upload-Session header" {
+			t.Fatalf("error = %v", resp["error"])
+		}
+	})
+
+	t.Run("upload block rejects legacy session query transport", func(t *testing.T) {
+		r := gin.New()
+		h := &BlockHandler{}
+		r.POST("/api/v2/blocks/upload", h.UploadBlock)
+
+		req, _ := http.NewRequest("POST", "/api/v2/blocks/upload?session=legacy", bytes.NewBufferString("abc"))
+		req.Header.Set("Content-Type", "application/octet-stream")
+		req.ContentLength = 3
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+		var resp map[string]interface{}
+		json.Unmarshal(w.Body.Bytes(), &resp)
+		if resp["error"] != "block upload session must be sent via X-Block-Upload-Session header" {
+			t.Fatalf("error = %v", resp["error"])
 		}
 	})
 }

--- a/internal/api/v2/blocks_test.go
+++ b/internal/api/v2/blocks_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Sesame-Disk/sesamefs/internal/storage"
 	"github.com/gin-gonic/gin"
@@ -117,7 +118,7 @@ func TestCheckBlocks_NilBlockStore(t *testing.T) {
 func TestDirectBlockReadRoutesAreNotRegistered(t *testing.T) {
 	r := gin.New()
 	rg := r.Group("/api/v2")
-	RegisterBlockRoutes(rg, nil, nil, nil, nil)
+	RegisterBlockRoutes(rg, nil, nil, nil, nil, nil)
 
 	validHash := strings.Repeat("a", 64)
 	for _, method := range []string{"GET", "HEAD"} {
@@ -128,6 +129,130 @@ func TestDirectBlockReadRoutesAreNotRegistered(t *testing.T) {
 			t.Errorf("%s /blocks/:hash status = %d, want %d (route must not exist)", method, w.Code, http.StatusNotFound)
 		}
 	}
+}
+
+// finding 9: the X-Block-Upload-Session header must win over the legacy
+// ?session= query parameter, and the query parameter must still work as a
+// fallback for any caller not yet updated.
+func TestSessionIDFromRequest(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		query  string
+		want   string
+	}{
+		{"header only", "sess-header", "", "sess-header"},
+		{"query only", "", "sess-query", "sess-query"},
+		{"header wins over query", "sess-header", "sess-query", "sess-header"},
+		{"neither present", "", "", ""},
+		{"whitespace-only header falls back to query", "   ", "sess-query", "sess-query"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := "/api/v2/blocks/check"
+			if tt.query != "" {
+				url += "?session=" + tt.query
+			}
+			req := httptest.NewRequest(http.MethodPost, url, nil)
+			if tt.header != "" {
+				req.Header.Set("X-Block-Upload-Session", tt.header)
+			}
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = req
+
+			if got := sessionIDFromRequest(c); got != tt.want {
+				t.Errorf("sessionIDFromRequest() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// finding 12: sessionPermissionCache must skip re-verification within the
+// interval, always re-verify once it elapses, and never cache a denial (so a
+// permission fix takes effect on the very next request instead of waiting out
+// the interval).
+func TestSessionPermissionCache_Allow(t *testing.T) {
+	t.Run("caches a successful check for the interval", func(t *testing.T) {
+		c := &sessionPermissionCache{}
+		calls := 0
+		verify := func() bool { calls++; return true }
+
+		if !c.allow("sess-1", verify) {
+			t.Fatal("first call should be allowed")
+		}
+		if !c.allow("sess-1", verify) {
+			t.Fatal("second call within the interval should be allowed")
+		}
+		if calls != 1 {
+			t.Errorf("verify called %d times, want 1 (second call should hit the cache)", calls)
+		}
+	})
+
+	t.Run("never caches a denial", func(t *testing.T) {
+		c := &sessionPermissionCache{}
+		calls := 0
+		verify := func() bool { calls++; return false }
+
+		if c.allow("sess-2", verify) {
+			t.Fatal("denial must not be allowed")
+		}
+		if c.allow("sess-2", verify) {
+			t.Fatal("denial must not be allowed")
+		}
+		if calls != 2 {
+			t.Errorf("verify called %d times, want 2 (a denial must never be cached)", calls)
+		}
+	})
+
+	t.Run("re-verifies once the interval elapses", func(t *testing.T) {
+		c := &sessionPermissionCache{checked: map[string]time.Time{
+			"sess-3": time.Now().Add(-sessionPermissionRecheckInterval - time.Second),
+		}}
+		calls := 0
+		verify := func() bool { calls++; return true }
+
+		if !c.allow("sess-3", verify) {
+			t.Fatal("expected allow")
+		}
+		if calls != 1 {
+			t.Errorf("verify called %d times, want 1 (stale entry must trigger re-verification)", calls)
+		}
+	})
+
+	t.Run("different sessions are independent", func(t *testing.T) {
+		c := &sessionPermissionCache{}
+		allowVerify := func() bool { return true }
+		denyVerify := func() bool { return false }
+
+		if !c.allow("sess-allowed", allowVerify) {
+			t.Fatal("sess-allowed should be allowed")
+		}
+		if c.allow("sess-denied", denyVerify) {
+			t.Fatal("sess-denied should be denied")
+		}
+		if !c.allow("sess-allowed", allowVerify) {
+			t.Fatal("sess-allowed should still be cached as allowed")
+		}
+	})
+
+	t.Run("sweeps stale entries once the cache is full", func(t *testing.T) {
+		c := &sessionPermissionCache{checked: make(map[string]time.Time, sessionPermissionCacheSweepSize+1)}
+		stale := time.Now().Add(-sessionPermissionRecheckInterval - time.Second)
+		for i := 0; i < sessionPermissionCacheSweepSize; i++ {
+			c.checked[strings.Repeat("x", 1)+string(rune(i))] = stale
+		}
+		verify := func() bool { return true }
+
+		if !c.allow("sess-fresh", verify) {
+			t.Fatal("expected allow")
+		}
+		if len(c.checked) >= sessionPermissionCacheSweepSize {
+			t.Errorf("cache size = %d, want the stale entries swept below the sweep threshold", len(c.checked))
+		}
+		if _, ok := c.checked["sess-fresh"]; !ok {
+			t.Error("the fresh entry that triggered the sweep must survive it")
+		}
+	})
 }
 
 func TestGetBlockStoreDoesNotFallBackToLegacyWhenStorageManagerFails(t *testing.T) {
@@ -294,7 +419,7 @@ func TestUploadBlockResponse_JSONFormat(t *testing.T) {
 func TestRegisterBlockRoutes(t *testing.T) {
 	r := gin.New()
 	rg := r.Group("/api/v2")
-	RegisterBlockRoutes(rg, nil, nil, nil, nil)
+	RegisterBlockRoutes(rg, nil, nil, nil, nil, nil)
 
 	routes := []struct {
 		method string

--- a/internal/api/v2/file_from_blocks.go
+++ b/internal/api/v2/file_from_blocks.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Sesame-Disk/sesamefs/internal/db"
+	"github.com/Sesame-Disk/sesamefs/internal/metrics"
 	"github.com/Sesame-Disk/sesamefs/internal/traffic"
 	"github.com/gin-gonic/gin"
 	"golang.org/x/sync/errgroup"
@@ -55,8 +56,12 @@ func committedFileIDFromSession(session db.BlockUploadSession) string {
 // waitForBlockUploadResult polls for the result of a concurrent winner's commit
 // on the same session, so a losing/retried request returns the same file
 // (idempotency, R7) instead of duplicating it. Bounded (~10s); returns ok=false
-// on timeout or if a different manifest won the session.
+// on timeout or if a different manifest won the session. Observes the wait
+// duration (finding 8) so operators can see how often losers approach the
+// ~10s bound instead of resolving quickly.
 func (h *FileHandler) waitForBlockUploadResult(sessionID, digest string) (db.BlockUploadSession, bool) {
+	start := time.Now()
+	defer func() { metrics.BlockUploadSessionWaitDuration.Observe(time.Since(start).Seconds()) }()
 	for i := 0; i < 50; i++ {
 		s, ok, err := h.db.GetBlockUploadSession(sessionID)
 		if err != nil || !ok {
@@ -324,11 +329,13 @@ func (h *FileHandler) CreateFileFromBlocks(c *gin.Context) {
 	// sha1ByHash256 is the SERVER-derived external SHA-1 per block, read from
 	// blocks.sha1 (which UploadBlock wrote from the block's real bytes) via
 	// ProbeBlockReuse. The client no longer sends a SHA-1: the server owns it.
+	verifyStart := time.Now()
 	statuses, sha1ByHash256, err := h.verifyManifestBlocks(c.Request.Context(), orgID, referrer, uniqueHashes, sizeByHash, existsMap)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to verify blocks"})
 		return
 	}
+	observeBlockVerification(verifyStart, uniqueHashes, statuses)
 
 	// blockIDs is the ordered SHA-256 list (verification, refs, GC, quota).
 	blockIDs := make([]string, len(req.Blocks))
@@ -385,7 +392,8 @@ func (h *FileHandler) CreateFileFromBlocks(c *gin.Context) {
 	// R7 concurrency: atomically claim the session for this commit. Exactly one
 	// concurrent request wins and runs finalize; the others wait for and return
 	// the same result, so a double/concurrent commit never creates a duplicate
-	// auto-renamed file.
+	// auto-renamed file. Claim outcomes are counted (finding 8) so operators can
+	// see how often concurrent commits actually contend on a session.
 	applied, err := h.db.ClaimBlockUploadSessionForCommit(session.SessionID, digest)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to claim upload session"})
@@ -396,15 +404,18 @@ func (h *FileHandler) CreateFileFromBlocks(c *gin.Context) {
 		// result if the manifest matches; otherwise it's a different file.
 		winner, ok := h.waitForBlockUploadResult(session.SessionID, digest)
 		if ok {
+			metrics.BlockUploadSessionClaimTotal.WithLabelValues("lost_result_ready").Inc()
 			c.JSON(http.StatusOK, fileFromBlocksResponse(&req, winner.ResultFilename, committedFileIDFromSession(winner)))
 			return
 		}
 		current, found, readErr := h.db.GetBlockUploadSession(session.SessionID)
 		if readErr == nil {
 			if resultName, code, message := classifyBlockUploadCommitConflict(current, found, digest); resultName != "" {
+				metrics.BlockUploadSessionClaimTotal.WithLabelValues("lost_result_ready").Inc()
 				c.JSON(http.StatusOK, fileFromBlocksResponse(&req, resultName, committedFileIDFromSession(current)))
 				return
 			} else {
+				metrics.BlockUploadSessionClaimTotal.WithLabelValues("lost_conflict").Inc()
 				c.JSON(http.StatusConflict, gin.H{
 					"error": message,
 					"code":  code,
@@ -412,19 +423,23 @@ func (h *FileHandler) CreateFileFromBlocks(c *gin.Context) {
 				return
 			}
 		}
+		metrics.BlockUploadSessionClaimTotal.WithLabelValues("lost_timeout").Inc()
 		c.JSON(http.StatusConflict, gin.H{
 			"error": "commit still in progress; retry",
 			"code":  blockUploadCommitInProgressCode,
 		})
 		return
 	}
+	metrics.BlockUploadSessionClaimTotal.WithLabelValues("won").Inc()
 
 	// Commit the file from the ordered manifest. finalize handles
 	// replace/autorename, the logical storage-delta quota (R5), HEAD CAS with
-	// retry, and promotion of provisional → permanent block references. It is given
-	// the SHA-1 (external) IDs: those go into the fs_object and derive its id, and
-	// stage/promote resolve them back to SHA-256 via the mappings UploadBlock
-	// already wrote from verified bytes (no mapping is minted here).
+	// retry, and promotion of provisional → permanent block references. It is
+	// given the SHA-1 (external) IDs: those derive the fs_object's id and are
+	// stored in fs_objects.seafile_block_ids_sha1 for desktop compat, while
+	// fs_objects.block_ids stays the SHA-256 canonical id (post PR1–PR5, see
+	// docs/WEB-BLOCK-UPLOAD.md); either direction resolves through the mappings
+	// UploadBlock already wrote from verified bytes (no mapping is minted here).
 	actualFilename, storageDeltaBytes, storageDeltaFiles, err := h.finalizeStoredUploadMetadata(
 		orgID, userID, repoID, req.ParentDir, req.Filename, externalBlockIDs, req.Size, req.Replace)
 	if err != nil {
@@ -495,6 +510,38 @@ func fileFromBlocksResponse(req *fileFromBlocksRequest, actualFilename, fileID s
 	}}
 }
 
+// observeBlockVerification records the commit's per-block verification pass
+// duration and per-status counts (finding 8). Called only after a successful
+// pass — an infrastructure error (caller returns 500 before this runs) is not
+// a verification outcome to report a duration for.
+func observeBlockVerification(start time.Time, uniqueHashes []string, statuses map[string]int) {
+	result := "ready"
+	var ready, needsUpload, sizeMismatch int
+	for _, hash := range uniqueHashes {
+		switch statuses[hash] {
+		case blockStatusReady:
+			ready++
+		case blockStatusSizeMismatch:
+			sizeMismatch++
+		default: // blockStatusNeedsUpload
+			needsUpload++
+		}
+	}
+	if needsUpload > 0 || sizeMismatch > 0 {
+		result = "needs_upload"
+	}
+	metrics.BlockUploadVerifyDuration.WithLabelValues(result).Observe(time.Since(start).Seconds())
+	if ready > 0 {
+		metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("ready").Add(float64(ready))
+	}
+	if needsUpload > 0 {
+		metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("needs_upload").Add(float64(needsUpload))
+	}
+	if sizeMismatch > 0 {
+		metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("size_mismatch").Add(float64(sizeMismatch))
+	}
+}
+
 // verifyManifestBlocks classifies every distinct manifest block for commit
 // readiness with bounded concurrency (a large manifest is thousands of blocks,
 // so a sequential probe-per-block would be thousands of serial round-trips).
@@ -546,37 +593,39 @@ func (h *FileHandler) classifyBlockForCommit(orgID, referrer, hash string, decla
 	if int64(probe.SizeBytes) != declaredSize {
 		return blockStatusSizeMismatch, sha1, nil
 	}
-	owned, err := h.db.BlockHasReferrer(orgID, hash, referrer)
+	owned, err := classifyBlockOwnership(h.db, orgID, referrer, hash)
 	if err != nil {
 		return 0, "", err
 	}
 	if owned {
 		return blockStatusReady, sha1, nil
 	}
-	permanent, err := blockHasPermanentReference(h.db, orgID, hash)
-	if err != nil {
-		return 0, "", err
-	}
-	if permanent {
-		return blockStatusReady, sha1, nil
-	}
 	return blockStatusNeedsUpload, sha1, nil
 }
 
-// blockHasPermanentReference reports whether a block is kept alive by a DURABLE
-// committed-file reference ("fs:<library>:<fs_id>"). It deliberately does NOT
-// count a publish-attempt ref ("pub:<attempt>") as permanent: that ref is
-// transient and disappears if the foreign attempt loses its HEAD CAS and cleans
-// up, which would leave this commit pointing at a block that can be GC'd. A
-// block alive only via a foreign pub: ref is therefore treated as needs_upload,
-// so the client re-uploads it and we materialize our own session-owned ref.
-func blockHasPermanentReference(database *db.DB, orgID, blockID string) (bool, error) {
+// classifyBlockOwnership reports whether a block is committable: kept alive by
+// THIS session's own provisional reference, or by a permanent committed-file
+// ("fs:<library>:<fs_id>") reference (R8). It deliberately does NOT count a
+// foreign publish-attempt ref ("pub:<attempt>") as permanent: that ref is
+// transient and disappears if the foreign attempt loses its HEAD CAS and
+// cleans up, which would leave this commit pointing at a block that can be
+// GC'd — a block alive only via a foreign pub: ref is treated as not owned, so
+// the caller re-uploads it and materializes its own session-owned ref.
+//
+// This reads the block's reference partition ONCE via ListBlockReferrers
+// (finding 14): the previous version ran BlockHasReferrer (exact-match read)
+// first and, only on a miss, a second ListBlockReferrers (full-partition read)
+// to check for a permanent ref — two queries in the common "not owned by this
+// session, but permanently referenced" case. ListBlockReferrers already
+// returns every referrer, a superset of what BlockHasReferrer checks, so a
+// single partition read now answers both questions.
+func classifyBlockOwnership(database *db.DB, orgID, referrer, blockID string) (bool, error) {
 	referrers, err := database.ListBlockReferrers(orgID, blockID)
 	if err != nil {
 		return false, err
 	}
 	for _, r := range referrers {
-		if strings.HasPrefix(r, "fs:") {
+		if r == referrer || strings.HasPrefix(r, "fs:") {
 			return true, nil
 		}
 	}

--- a/internal/api/v2/file_from_blocks.go
+++ b/internal/api/v2/file_from_blocks.go
@@ -335,7 +335,6 @@ func (h *FileHandler) CreateFileFromBlocks(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to verify blocks"})
 		return
 	}
-	observeBlockVerification(verifyStart, uniqueHashes, statuses)
 
 	// blockIDs is the ordered SHA-256 list (verification, refs, GC, quota).
 	blockIDs := make([]string, len(req.Blocks))
@@ -372,6 +371,7 @@ func (h *FileHandler) CreateFileFromBlocks(c *gin.Context) {
 			addNeedsUpload(sha256ID)
 		}
 	}
+	observeBlockVerification(verifyStart, uniqueHashes, statuses, needsSeen)
 
 	if len(needsUpload) > 0 {
 		c.JSON(http.StatusConflict, gin.H{
@@ -513,11 +513,17 @@ func fileFromBlocksResponse(req *fileFromBlocksRequest, actualFilename, fileID s
 // observeBlockVerification records the commit's per-block verification pass
 // duration and per-status counts (finding 8). Called only after a successful
 // pass — an infrastructure error (caller returns 500 before this runs) is not
-// a verification outcome to report a duration for.
-func observeBlockVerification(start time.Time, uniqueHashes []string, statuses map[string]int) {
+// a verification outcome to report a duration for. needsUpload contains any
+// extra fail-closed rejections that happened after the primary classifier, such
+// as a malformed server-derived SHA-1.
+func observeBlockVerification(start time.Time, uniqueHashes []string, statuses map[string]int, forcedNeedsUpload map[string]struct{}) {
 	result := "ready"
 	var ready, needsUpload, sizeMismatch int
 	for _, hash := range uniqueHashes {
+		if _, forced := forcedNeedsUpload[hash]; forced {
+			needsUpload++
+			continue
+		}
 		switch statuses[hash] {
 		case blockStatusReady:
 			ready++

--- a/internal/api/v2/file_from_blocks.go
+++ b/internal/api/v2/file_from_blocks.go
@@ -319,6 +319,7 @@ func (h *FileHandler) CreateFileFromBlocks(c *gin.Context) {
 	}
 	existsMap, err := blockStore.CheckBlocksParallel(c.Request.Context(), uniqueHashes, blockVerifyConcurrency)
 	if err != nil {
+		metrics.BlockUploadVerifyErrorsTotal.WithLabelValues("presence").Inc()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to verify block presence"})
 		return
 	}
@@ -332,46 +333,17 @@ func (h *FileHandler) CreateFileFromBlocks(c *gin.Context) {
 	verifyStart := time.Now()
 	statuses, sha1ByHash256, err := h.verifyManifestBlocks(c.Request.Context(), orgID, referrer, uniqueHashes, sizeByHash, existsMap)
 	if err != nil {
+		metrics.BlockUploadVerifyErrorsTotal.WithLabelValues("classify").Inc()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to verify blocks"})
 		return
 	}
 
-	// blockIDs is the ordered SHA-256 list (verification, refs, GC, quota).
-	blockIDs := make([]string, len(req.Blocks))
-	var needsUpload []string
-	needsSeen := make(map[string]struct{})
-	addNeedsUpload := func(sha256ID string) {
-		if _, ok := needsSeen[sha256ID]; !ok {
-			needsSeen[sha256ID] = struct{}{}
-			needsUpload = append(needsUpload, sha256ID)
-		}
-	}
-	for i, b := range req.Blocks {
-		blockIDs[i] = b.SHA256
-		switch statuses[b.SHA256] {
-		case blockStatusSizeMismatch:
-			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "block size mismatch", "sha256": b.SHA256})
-			return
-		case blockStatusNeedsUpload:
-			addNeedsUpload(b.SHA256)
-		}
-	}
+	blockIDs, needsUpload, sizeMismatchHash := summarizeBlockVerification(verifyStart, req.Blocks, uniqueHashes, statuses, sha1ByHash256)
 
-	// Fail-closed validation of the SERVER-derived SHA-1 (blocks.sha1). For a block
-	// to be committed, the server must hold a well-formed 40-hex SHA-1 for it; that
-	// SHA-1 was written from the block's real bytes at UploadBlock time. A ready
-	// block whose blocks.sha1 is missing or malformed is treated as needs_upload —
-	// the re-upload recomputes and rewrites a verified SHA-1 — so a half-written or
-	// pre-PR2 block can never put an unvalidated id into an fs_object.
-	for _, sha256ID := range uniqueHashes {
-		if statuses[sha256ID] != blockStatusReady {
-			continue
-		}
-		if !isHex40(sha1ByHash256[sha256ID]) {
-			addNeedsUpload(sha256ID)
-		}
+	if sizeMismatchHash != "" {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "block size mismatch", "sha256": sizeMismatchHash})
+		return
 	}
-	observeBlockVerification(verifyStart, uniqueHashes, statuses, needsSeen)
 
 	if len(needsUpload) > 0 {
 		c.JSON(http.StatusConflict, gin.H{
@@ -582,6 +554,52 @@ func (h *FileHandler) verifyManifestBlocks(ctx context.Context, orgID, referrer 
 		return nil, nil, err
 	}
 	return result, sha1ByHash, nil
+}
+
+// summarizeBlockVerification translates the raw per-distinct-block verification
+// statuses into the ordered handler outcome, including fail-closed SHA-1
+// downgrades. It ALWAYS emits verification metrics before returning so
+// size-mismatch exits still show up in observability.
+func summarizeBlockVerification(start time.Time, blocks []fileFromBlocksBlock, uniqueHashes []string, statuses map[string]int, sha1ByHash256 map[string]string) ([]string, []string, string) {
+	// blockIDs is the ordered SHA-256 list (verification, refs, GC, quota).
+	blockIDs := make([]string, len(blocks))
+	var needsUpload []string
+	var sizeMismatchHash string
+	needsSeen := make(map[string]struct{})
+	addNeedsUpload := func(sha256ID string) {
+		if _, ok := needsSeen[sha256ID]; !ok {
+			needsSeen[sha256ID] = struct{}{}
+			needsUpload = append(needsUpload, sha256ID)
+		}
+	}
+	for i, b := range blocks {
+		blockIDs[i] = b.SHA256
+		switch statuses[b.SHA256] {
+		case blockStatusSizeMismatch:
+			if sizeMismatchHash == "" {
+				sizeMismatchHash = b.SHA256
+			}
+		case blockStatusNeedsUpload:
+			addNeedsUpload(b.SHA256)
+		}
+	}
+
+	// Fail-closed validation of the SERVER-derived SHA-1 (blocks.sha1). For a block
+	// to be committed, the server must hold a well-formed 40-hex SHA-1 for it; that
+	// SHA-1 was written from the block's real bytes at UploadBlock time. A ready
+	// block whose blocks.sha1 is missing or malformed is treated as needs_upload —
+	// the re-upload recomputes and rewrites a verified SHA-1 — so a half-written or
+	// pre-PR2 block can never put an unvalidated id into an fs_object.
+	for _, sha256ID := range uniqueHashes {
+		if statuses[sha256ID] != blockStatusReady {
+			continue
+		}
+		if !isHex40(sha1ByHash256[sha256ID]) {
+			addNeedsUpload(sha256ID)
+		}
+	}
+	observeBlockVerification(start, uniqueHashes, statuses, needsSeen)
+	return blockIDs, needsUpload, sizeMismatchHash
 }
 
 // classifyBlockForCommit decides whether one block is commit-ready (R1/R8/R11):

--- a/internal/api/v2/file_from_blocks_test.go
+++ b/internal/api/v2/file_from_blocks_test.go
@@ -4,9 +4,31 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Sesame-Disk/sesamefs/internal/db"
+	"github.com/Sesame-Disk/sesamefs/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 )
+
+// histogramSampleCount reads the observation count off a single Histogram
+// series (a HistogramVec.WithLabelValues() result), used to assert a metric
+// gained an observation since Histogram values aren't comparable via
+// testutil.ToFloat64 (which only works for single-value Counters/Gauges).
+func histogramSampleCount(t *testing.T, o prometheus.Observer) uint64 {
+	t.Helper()
+	h, ok := o.(prometheus.Histogram)
+	if !ok {
+		t.Fatalf("observer is not a prometheus.Histogram: %T", o)
+	}
+	var m dto.Metric
+	if err := h.Write(&m); err != nil {
+		t.Fatalf("write histogram metric: %v", err)
+	}
+	return m.GetHistogram().GetSampleCount()
+}
 
 // hex64 builds deterministic, distinct valid lowercase-hex SHA-256 ids for
 // manifest validation tests (n keeps each block unique without colliding).
@@ -197,5 +219,55 @@ func TestCommittedFileIDFromSession(t *testing.T) {
 	}
 	if got := committedFileIDFromSession(db.BlockUploadSession{ResultCommitID: "not-a-fsid"}); got != "" {
 		t.Fatalf("committedFileIDFromSession(invalid) = %q, want empty", got)
+	}
+}
+
+// finding 8: observeBlockVerification must classify the WHOLE pass as
+// "needs_upload" if even one block wasn't ready (size_mismatch counts as not
+// ready), and must tally each distinct block exactly once into the right
+// per-status counter.
+func TestObserveBlockVerification_AllReady(t *testing.T) {
+	before := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("ready"))
+	beforeSamples := histogramSampleCount(t, metrics.BlockUploadVerifyDuration.WithLabelValues("ready"))
+
+	hashes := []string{hex64(1), hex64(2)}
+	statuses := map[string]int{hex64(1): blockStatusReady, hex64(2): blockStatusReady}
+	observeBlockVerification(time.Now(), hashes, statuses)
+
+	if got := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("ready")); got != before+2 {
+		t.Errorf("ready count = %v, want %v", got, before+2)
+	}
+	if got := histogramSampleCount(t, metrics.BlockUploadVerifyDuration.WithLabelValues("ready")); got != beforeSamples+1 {
+		t.Errorf("ready duration sample count = %d, want %d", got, beforeSamples+1)
+	}
+}
+
+func TestObserveBlockVerification_MixedResultIsNeedsUpload(t *testing.T) {
+	beforeReady := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("ready"))
+	beforeNeeds := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("needs_upload"))
+	beforeMismatch := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("size_mismatch"))
+	beforeNeedsUploadSamples := histogramSampleCount(t, metrics.BlockUploadVerifyDuration.WithLabelValues("needs_upload"))
+
+	hashes := []string{hex64(3), hex64(4), hex64(5)}
+	statuses := map[string]int{
+		hex64(3): blockStatusReady,
+		hex64(4): blockStatusNeedsUpload,
+		hex64(5): blockStatusSizeMismatch,
+	}
+	observeBlockVerification(time.Now(), hashes, statuses)
+
+	if got := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("ready")); got != beforeReady+1 {
+		t.Errorf("ready count = %v, want %v", got, beforeReady+1)
+	}
+	if got := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("needs_upload")); got != beforeNeeds+1 {
+		t.Errorf("needs_upload count = %v, want %v", got, beforeNeeds+1)
+	}
+	if got := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("size_mismatch")); got != beforeMismatch+1 {
+		t.Errorf("size_mismatch count = %v, want %v", got, beforeMismatch+1)
+	}
+	// A single not-ready block downgrades the WHOLE pass's duration label to
+	// "needs_upload", not just "ready" for the ready ones.
+	if got := histogramSampleCount(t, metrics.BlockUploadVerifyDuration.WithLabelValues("needs_upload")); got != beforeNeedsUploadSamples+1 {
+		t.Errorf("needs_upload duration sample count = %d, want %d", got, beforeNeedsUploadSamples+1)
 	}
 }

--- a/internal/api/v2/file_from_blocks_test.go
+++ b/internal/api/v2/file_from_blocks_test.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -290,5 +291,82 @@ func TestObserveBlockVerification_ForcedNeedsUploadOverridesReadyMetric(t *testi
 	}
 	if got := histogramSampleCount(t, metrics.BlockUploadVerifyDuration.WithLabelValues("needs_upload")); got != beforeNeedsUploadSamples+1 {
 		t.Errorf("needs_upload duration sample count = %d, want %d", got, beforeNeedsUploadSamples+1)
+	}
+}
+
+func TestSummarizeBlockVerification_ObservesSizeMismatchBefore422Path(t *testing.T) {
+	beforeMismatch := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("size_mismatch"))
+	beforeNeeds := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("needs_upload"))
+	beforeSamples := histogramSampleCount(t, metrics.BlockUploadVerifyDuration.WithLabelValues("needs_upload"))
+
+	blocks := []fileFromBlocksBlock{
+		{SHA256: hex64(7), Size: 10},
+		{SHA256: hex64(8), Size: 11},
+	}
+	statuses := map[string]int{
+		hex64(7): blockStatusSizeMismatch,
+		hex64(8): blockStatusNeedsUpload,
+	}
+
+	blockIDs, needsUpload, sizeMismatchHash := summarizeBlockVerification(time.Now(), blocks, []string{hex64(7), hex64(8)}, statuses, map[string]string{})
+
+	if len(blockIDs) != 2 || blockIDs[0] != hex64(7) || blockIDs[1] != hex64(8) {
+		t.Fatalf("blockIDs = %v, want ordered SHA-256 list", blockIDs)
+	}
+	if len(needsUpload) != 1 || needsUpload[0] != hex64(8) {
+		t.Fatalf("needsUpload = %v, want [%s]", needsUpload, hex64(8))
+	}
+	if sizeMismatchHash != hex64(7) {
+		t.Fatalf("sizeMismatchHash = %q, want %q", sizeMismatchHash, hex64(7))
+	}
+	if got := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("size_mismatch")); got != beforeMismatch+1 {
+		t.Fatalf("size_mismatch count = %v, want %v", got, beforeMismatch+1)
+	}
+	if got := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("needs_upload")); got != beforeNeeds+1 {
+		t.Fatalf("needs_upload count = %v, want %v", got, beforeNeeds+1)
+	}
+	if got := histogramSampleCount(t, metrics.BlockUploadVerifyDuration.WithLabelValues("needs_upload")); got != beforeSamples+1 {
+		t.Fatalf("needs_upload duration sample count = %d, want %d", got, beforeSamples+1)
+	}
+}
+
+func TestBlockUploadVerifyDurationBucketsExtendForLargeFiles(t *testing.T) {
+	h, ok := metrics.BlockUploadVerifyDuration.WithLabelValues("ready").(prometheus.Histogram)
+	if !ok {
+		t.Fatalf("observer is not a prometheus.Histogram: %T", metrics.BlockUploadVerifyDuration.WithLabelValues("ready"))
+	}
+
+	var m dto.Metric
+	if err := h.Write(&m); err != nil {
+		t.Fatalf("write histogram metric: %v", err)
+	}
+
+	var got []float64
+	for _, b := range m.GetHistogram().GetBucket() {
+		got = append(got, b.GetUpperBound())
+	}
+	want := []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 15, 30, 60, 120}
+	if len(got) != len(want) {
+		t.Fatalf("bucket count = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if math.Abs(got[i]-want[i]) > 1e-9 {
+			t.Fatalf("bucket[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestBlockUploadVerifyErrorsTotal(t *testing.T) {
+	beforePresence := testutil.ToFloat64(metrics.BlockUploadVerifyErrorsTotal.WithLabelValues("presence"))
+	beforeClassify := testutil.ToFloat64(metrics.BlockUploadVerifyErrorsTotal.WithLabelValues("classify"))
+
+	metrics.BlockUploadVerifyErrorsTotal.WithLabelValues("presence").Inc()
+	metrics.BlockUploadVerifyErrorsTotal.WithLabelValues("classify").Inc()
+
+	if got := testutil.ToFloat64(metrics.BlockUploadVerifyErrorsTotal.WithLabelValues("presence")); got != beforePresence+1 {
+		t.Fatalf("presence errors = %v, want %v", got, beforePresence+1)
+	}
+	if got := testutil.ToFloat64(metrics.BlockUploadVerifyErrorsTotal.WithLabelValues("classify")); got != beforeClassify+1 {
+		t.Fatalf("classify errors = %v, want %v", got, beforeClassify+1)
 	}
 }

--- a/internal/api/v2/file_from_blocks_test.go
+++ b/internal/api/v2/file_from_blocks_test.go
@@ -232,7 +232,7 @@ func TestObserveBlockVerification_AllReady(t *testing.T) {
 
 	hashes := []string{hex64(1), hex64(2)}
 	statuses := map[string]int{hex64(1): blockStatusReady, hex64(2): blockStatusReady}
-	observeBlockVerification(time.Now(), hashes, statuses)
+	observeBlockVerification(time.Now(), hashes, statuses, nil)
 
 	if got := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("ready")); got != before+2 {
 		t.Errorf("ready count = %v, want %v", got, before+2)
@@ -254,7 +254,7 @@ func TestObserveBlockVerification_MixedResultIsNeedsUpload(t *testing.T) {
 		hex64(4): blockStatusNeedsUpload,
 		hex64(5): blockStatusSizeMismatch,
 	}
-	observeBlockVerification(time.Now(), hashes, statuses)
+	observeBlockVerification(time.Now(), hashes, statuses, nil)
 
 	if got := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("ready")); got != beforeReady+1 {
 		t.Errorf("ready count = %v, want %v", got, beforeReady+1)
@@ -267,6 +267,27 @@ func TestObserveBlockVerification_MixedResultIsNeedsUpload(t *testing.T) {
 	}
 	// A single not-ready block downgrades the WHOLE pass's duration label to
 	// "needs_upload", not just "ready" for the ready ones.
+	if got := histogramSampleCount(t, metrics.BlockUploadVerifyDuration.WithLabelValues("needs_upload")); got != beforeNeedsUploadSamples+1 {
+		t.Errorf("needs_upload duration sample count = %d, want %d", got, beforeNeedsUploadSamples+1)
+	}
+}
+
+func TestObserveBlockVerification_ForcedNeedsUploadOverridesReadyMetric(t *testing.T) {
+	beforeReady := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("ready"))
+	beforeNeeds := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("needs_upload"))
+	beforeNeedsUploadSamples := histogramSampleCount(t, metrics.BlockUploadVerifyDuration.WithLabelValues("needs_upload"))
+
+	hashes := []string{hex64(6)}
+	statuses := map[string]int{hex64(6): blockStatusReady}
+	forcedNeedsUpload := map[string]struct{}{hex64(6): {}}
+	observeBlockVerification(time.Now(), hashes, statuses, forcedNeedsUpload)
+
+	if got := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("ready")); got != beforeReady {
+		t.Errorf("ready count = %v, want unchanged %v", got, beforeReady)
+	}
+	if got := testutil.ToFloat64(metrics.BlockUploadVerifyBlocksTotal.WithLabelValues("needs_upload")); got != beforeNeeds+1 {
+		t.Errorf("needs_upload count = %v, want %v", got, beforeNeeds+1)
+	}
 	if got := histogramSampleCount(t, metrics.BlockUploadVerifyDuration.WithLabelValues("needs_upload")); got != beforeNeedsUploadSamples+1 {
 		t.Errorf("needs_upload duration sample count = %d, want %d", got, beforeNeedsUploadSamples+1)
 	}

--- a/internal/integration/admin_stats_sharding_test.go
+++ b/internal/integration/admin_stats_sharding_test.go
@@ -5,6 +5,8 @@ package integration
 import (
 	"fmt"
 	"net/http"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,7 +35,6 @@ func TestAdminStatsFanOutAcrossPlatformShards(t *testing.T) {
 	session := shareProjectionDBForTest(t).Session()
 	today := time.Now().UTC().Truncate(24 * time.Hour)
 	yesterday := today.AddDate(0, 0, -1)
-	currentMonth := today.Format("200601")
 
 	const (
 		storageShardA = 3
@@ -78,45 +79,48 @@ func TestAdminStatsFanOutAcrossPlatformShards(t *testing.T) {
 	wantDownloadBytes := int64(333_000 + 444_000)
 	wantTrafficTotal := wantUploadBytes + wantDownloadBytes
 
-	baselineSysinfo := getJSONMap(t, superadminClient.Get(t, "/api/v2.1/admin/sysinfo/"))
-	baselineStorageRow := adminStatsRowForDate(
-		t,
-		fmt.Sprintf("/api/v2.1/admin/statistics/total-storage/?start=%s&end=%s", yesterday.Format("2006-01-02"), yesterday.Format("2006-01-02")),
-		yesterday,
-	)
-	baselineTrafficRow := adminStatsRowForDate(
-		t,
-		fmt.Sprintf("/api/v2.1/admin/statistics/system-traffic/?start=%s&end=%s", today.Format("2006-01-02"), today.Format("2006-01-02")),
-		today,
-	)
-
 	seedPlatformStorageCounterDeltasForTest(t, session, storageDeltas)
-	seedPlatformTrafficCounterDeltasForTest(t, session, currentMonth, trafficDeltas)
+	seedPlatformTrafficCounterDeltasForTest(t, session, trafficDeltas)
 
+	var lastMismatch string
 	waitForCondition(t, "admin shard-aware platform stats to reflect seeded counter deltas", func() bool {
+		expectedStorage := readPlatformStorageSnapshotForTest(t, session)
+		expectedMonthTraffic := readPlatformTrafficUsageForMonthsForTest(t, session, []string{today.Format("200601")})
+		expectedYearTraffic := readPlatformTrafficUsageForMonthsForTest(t, session, yearMonthKeysForTest(today))
+		expectedHistoricalStorage := expectedStorage.BytesUsed - readPlatformStorageDayBytesForTest(t, session, today)
+		expectedTrafficByType := readPlatformTrafficByDayForTest(t, session, today)
+
 		sysinfo := getJSONMap(t, superadminClient.Get(t, "/api/v2.1/admin/sysinfo/"))
-		if jsonInt64(sysinfo, "total_storage") != jsonInt64(baselineSysinfo, "total_storage")+wantStorageBytes {
+		if jsonInt64(sysinfo, "total_storage") != expectedStorage.BytesUsed {
+			lastMismatch = fmt.Sprintf("sysinfo total_storage=%d want=%d", jsonInt64(sysinfo, "total_storage"), expectedStorage.BytesUsed)
 			return false
 		}
-		if jsonInt64(sysinfo, "total_files_count") != jsonInt64(baselineSysinfo, "total_files_count")+wantStorageFiles {
+		if jsonInt64(sysinfo, "total_files_count") != expectedStorage.FileCount {
+			lastMismatch = fmt.Sprintf("sysinfo total_files_count=%d want=%d", jsonInt64(sysinfo, "total_files_count"), expectedStorage.FileCount)
 			return false
 		}
-		if jsonInt64(sysinfo, "traffic_month_total") != jsonInt64(baselineSysinfo, "traffic_month_total")+wantTrafficTotal {
+		if jsonInt64(sysinfo, "traffic_month_total") != expectedMonthTraffic.Combined {
+			lastMismatch = fmt.Sprintf("sysinfo traffic_month_total=%d want=%d", jsonInt64(sysinfo, "traffic_month_total"), expectedMonthTraffic.Combined)
 			return false
 		}
-		if jsonInt64(sysinfo, "traffic_month_upload") != jsonInt64(baselineSysinfo, "traffic_month_upload")+wantUploadBytes {
+		if jsonInt64(sysinfo, "traffic_month_upload") != expectedMonthTraffic.Upload {
+			lastMismatch = fmt.Sprintf("sysinfo traffic_month_upload=%d want=%d", jsonInt64(sysinfo, "traffic_month_upload"), expectedMonthTraffic.Upload)
 			return false
 		}
-		if jsonInt64(sysinfo, "traffic_month_download") != jsonInt64(baselineSysinfo, "traffic_month_download")+wantDownloadBytes {
+		if jsonInt64(sysinfo, "traffic_month_download") != expectedMonthTraffic.Download {
+			lastMismatch = fmt.Sprintf("sysinfo traffic_month_download=%d want=%d", jsonInt64(sysinfo, "traffic_month_download"), expectedMonthTraffic.Download)
 			return false
 		}
-		if jsonInt64(sysinfo, "traffic_year_total") != jsonInt64(baselineSysinfo, "traffic_year_total")+wantTrafficTotal {
+		if jsonInt64(sysinfo, "traffic_year_total") != expectedYearTraffic.Combined {
+			lastMismatch = fmt.Sprintf("sysinfo traffic_year_total=%d want=%d", jsonInt64(sysinfo, "traffic_year_total"), expectedYearTraffic.Combined)
 			return false
 		}
-		if jsonInt64(sysinfo, "traffic_year_upload") != jsonInt64(baselineSysinfo, "traffic_year_upload")+wantUploadBytes {
+		if jsonInt64(sysinfo, "traffic_year_upload") != expectedYearTraffic.Upload {
+			lastMismatch = fmt.Sprintf("sysinfo traffic_year_upload=%d want=%d", jsonInt64(sysinfo, "traffic_year_upload"), expectedYearTraffic.Upload)
 			return false
 		}
-		if jsonInt64(sysinfo, "traffic_year_download") != jsonInt64(baselineSysinfo, "traffic_year_download")+wantDownloadBytes {
+		if jsonInt64(sysinfo, "traffic_year_download") != expectedYearTraffic.Download {
+			lastMismatch = fmt.Sprintf("sysinfo traffic_year_download=%d want=%d", jsonInt64(sysinfo, "traffic_year_download"), expectedYearTraffic.Download)
 			return false
 		}
 
@@ -125,7 +129,8 @@ func TestAdminStatsFanOutAcrossPlatformShards(t *testing.T) {
 			fmt.Sprintf("/api/v2.1/admin/statistics/total-storage/?start=%s&end=%s", yesterday.Format("2006-01-02"), yesterday.Format("2006-01-02")),
 			yesterday,
 		)
-		if jsonInt64(storageRow, "total_storage") != jsonInt64(baselineStorageRow, "total_storage")+wantHistoricalStorageBytes {
+		if jsonInt64(storageRow, "total_storage") != expectedHistoricalStorage {
+			lastMismatch = fmt.Sprintf("storage row total_storage=%d want=%d", jsonInt64(storageRow, "total_storage"), expectedHistoricalStorage)
 			return false
 		}
 
@@ -134,15 +139,22 @@ func TestAdminStatsFanOutAcrossPlatformShards(t *testing.T) {
 			fmt.Sprintf("/api/v2.1/admin/statistics/system-traffic/?start=%s&end=%s", today.Format("2006-01-02"), today.Format("2006-01-02")),
 			today,
 		)
-		if jsonInt64(trafficRow, traffic.WebUpload) != jsonInt64(baselineTrafficRow, traffic.WebUpload)+wantUploadBytes {
+		if jsonInt64(trafficRow, traffic.WebUpload) != expectedTrafficByType[traffic.WebUpload] {
+			lastMismatch = fmt.Sprintf("traffic row %s=%d want=%d", traffic.WebUpload, jsonInt64(trafficRow, traffic.WebUpload), expectedTrafficByType[traffic.WebUpload])
 			return false
 		}
-		if jsonInt64(trafficRow, traffic.LinkDownload) != jsonInt64(baselineTrafficRow, traffic.LinkDownload)+wantDownloadBytes {
+		if jsonInt64(trafficRow, traffic.LinkDownload) != expectedTrafficByType[traffic.LinkDownload] {
+			lastMismatch = fmt.Sprintf("traffic row %s=%d want=%d", traffic.LinkDownload, jsonInt64(trafficRow, traffic.LinkDownload), expectedTrafficByType[traffic.LinkDownload])
 			return false
 		}
 
 		return true
 	})
+
+	t.Logf("verified admin shard fan-out with storage +%d bytes/%d files and traffic +%d upload/+%d download; last mismatch before success: %s", wantStorageBytes, wantStorageFiles, wantUploadBytes, wantDownloadBytes, lastMismatch)
+	if wantHistoricalStorageBytes <= 0 || wantTrafficTotal <= 0 {
+		t.Fatalf("test setup invalid: wantHistoricalStorageBytes=%d wantTrafficTotal=%d", wantHistoricalStorageBytes, wantTrafficTotal)
+	}
 }
 
 func seedPlatformStorageCounterDeltasForTest(t *testing.T, session *gocql.Session, deltas []platformStorageCounterDeltaForTest) {
@@ -170,28 +182,142 @@ func applyPlatformStorageCounterDeltaForTest(t *testing.T, session *gocql.Sessio
 	}
 }
 
-func seedPlatformTrafficCounterDeltasForTest(t *testing.T, session *gocql.Session, month string, deltas []platformTrafficCounterDeltaForTest) {
+func seedPlatformTrafficCounterDeltasForTest(t *testing.T, session *gocql.Session, deltas []platformTrafficCounterDeltaForTest) {
 	t.Helper()
 
 	for _, delta := range deltas {
-		applyPlatformTrafficCounterDeltaForTest(t, session, month, delta)
+		applyPlatformTrafficCounterDeltaForTest(t, session, delta)
 		t.Cleanup(func() {
 			revert := delta
 			revert.bytes = -revert.bytes
-			applyPlatformTrafficCounterDeltaForTest(t, session, month, revert)
+			applyPlatformTrafficCounterDeltaForTest(t, session, revert)
 		})
 	}
 }
 
-func applyPlatformTrafficCounterDeltaForTest(t *testing.T, session *gocql.Session, month string, delta platformTrafficCounterDeltaForTest) {
+func applyPlatformTrafficCounterDeltaForTest(t *testing.T, session *gocql.Session, delta platformTrafficCounterDeltaForTest) {
 	t.Helper()
 
 	if err := session.Query(`
 		UPDATE traffic_counters SET bytes_transferred = bytes_transferred + ?
 		WHERE org_id = ? AND month = ? AND shard = ? AND day = ? AND user_id = ? AND traffic_type = ?
-	`, delta.bytes, gocql.UUID{}, month, delta.shard, delta.day, delta.userID, delta.trafficType).Exec(); err != nil {
+	`, delta.bytes, gocql.UUID{}, delta.day.UTC().Format("200601"), delta.shard, delta.day, delta.userID, delta.trafficType).Exec(); err != nil {
 		t.Fatalf("failed to update platform traffic counter shard %d type %s day %s: %v", delta.shard, delta.trafficType, delta.day.Format(time.RFC3339), err)
 	}
+}
+
+func readPlatformStorageSnapshotForTest(t *testing.T, session *gocql.Session) traffic.StorageSnapshot {
+	t.Helper()
+
+	var snapshot traffic.StorageSnapshot
+	traffic.ForEachCounterShard(func(shard int) {
+		var bytesUsed, fileCount int64
+		if err := session.Query(
+			`SELECT bytes_used, file_count FROM storage_counters WHERE scope = ? AND shard = ? AND day = ?`,
+			traffic.PlatformStorageScope(), shard, platformStorageTotalDayForTest,
+		).Scan(&bytesUsed, &fileCount); err != nil && !errorsIsNotFoundForTest(err) {
+			t.Fatalf("failed to read platform storage snapshot shard %d: %v", shard, err)
+		}
+		snapshot.BytesUsed += maxInt64ForTest(bytesUsed, 0)
+		snapshot.FileCount += maxInt64ForTest(fileCount, 0)
+	})
+	return snapshot
+}
+
+func readPlatformStorageDayBytesForTest(t *testing.T, session *gocql.Session, day time.Time) int64 {
+	t.Helper()
+
+	var total int64
+	traffic.ForEachCounterShard(func(shard int) {
+		var bytesUsed int64
+		if err := session.Query(
+			`SELECT bytes_used FROM storage_counters WHERE scope = ? AND shard = ? AND day = ?`,
+			traffic.PlatformStorageScope(), shard, day,
+		).Scan(&bytesUsed); err != nil && !errorsIsNotFoundForTest(err) {
+			t.Fatalf("failed to read platform storage day bytes shard %d day %s: %v", shard, day.Format("2006-01-02"), err)
+		}
+		total += bytesUsed
+	})
+	return total
+}
+
+func readPlatformTrafficUsageForMonthsForTest(t *testing.T, session *gocql.Session, months []string) traffic.MonthlyTransferUsage {
+	t.Helper()
+
+	usage := traffic.MonthlyTransferUsage{}
+	for _, month := range months {
+		traffic.ForEachCounterShard(func(shard int) {
+			iter := session.Query(
+				`SELECT user_id, traffic_type, bytes_transferred FROM traffic_counters WHERE org_id = ? AND month = ? AND shard = ?`,
+				gocql.UUID{}, month, shard,
+			).Iter()
+			var userUUID gocql.UUID
+			var trafficType string
+			var bytes int64
+			for iter.Scan(&userUUID, &trafficType, &bytes) {
+				if userUUID != (gocql.UUID{}) {
+					continue
+				}
+				usage.Combined += bytes
+				if strings.HasSuffix(trafficType, "-upload") {
+					usage.Upload += bytes
+				} else if strings.HasSuffix(trafficType, "-download") {
+					usage.Download += bytes
+				}
+			}
+			if err := iter.Close(); err != nil {
+				t.Fatalf("failed to read platform traffic usage month %s shard %d: %v", month, shard, err)
+			}
+		})
+	}
+	return usage
+}
+
+func readPlatformTrafficByDayForTest(t *testing.T, session *gocql.Session, day time.Time) map[string]int64 {
+	t.Helper()
+
+	byType := map[string]int64{}
+	month := day.UTC().Format("200601")
+	traffic.ForEachCounterShard(func(shard int) {
+		iter := session.Query(
+			`SELECT day, user_id, traffic_type, bytes_transferred FROM traffic_counters WHERE org_id = ? AND month = ? AND shard = ?`,
+			gocql.UUID{}, month, shard,
+		).Iter()
+		var rowDay time.Time
+		var userUUID gocql.UUID
+		var trafficType string
+		var bytes int64
+		for iter.Scan(&rowDay, &userUUID, &trafficType, &bytes) {
+			if userUUID != (gocql.UUID{}) || !rowDay.UTC().Equal(day.UTC()) {
+				continue
+			}
+			byType[trafficType] += bytes
+		}
+		if err := iter.Close(); err != nil {
+			t.Fatalf("failed to read platform traffic day %s shard %d: %v", day.Format("2006-01-02"), shard, err)
+		}
+	})
+	return byType
+}
+
+func yearMonthKeysForTest(now time.Time) []string {
+	months := make([]string, 0, int(now.Month()))
+	for month := time.January; month <= now.Month(); month++ {
+		months = append(months, time.Date(now.Year(), month, 1, 0, 0, 0, 0, time.UTC).Format("200601"))
+	}
+	sort.Strings(months)
+	return months
+}
+
+func errorsIsNotFoundForTest(err error) bool {
+	return err == nil || err == gocql.ErrNotFound
+}
+
+func maxInt64ForTest(value, floor int64) int64 {
+	if value < floor {
+		return floor
+	}
+	return value
 }
 
 func adminStatsRowForDate(t *testing.T, path string, day time.Time) map[string]interface{} {

--- a/internal/integration/web_block_upload_test.go
+++ b/internal/integration/web_block_upload_test.go
@@ -45,7 +45,7 @@ func webCreateBlockSession(t *testing.T, c *testClient, repoID, parentDir string
 // webUploadBlock POSTs raw block bytes under a session. Returns the response.
 func webUploadBlock(t *testing.T, c *testClient, session string, data []byte) *http.Response {
 	t.Helper()
-	url := c.baseURL + "/api/v2/blocks/upload?session=" + session
+	url := c.baseURL + "/api/v2/blocks/upload"
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(data))
 	if err != nil {
 		t.Fatalf("new block upload request: %v", err)
@@ -53,6 +53,7 @@ func webUploadBlock(t *testing.T, c *testClient, session string, data []byte) *h
 	req.Header.Set("Authorization", "Token "+c.token)
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("X-Block-Hash", sha256hex(data))
+	req.Header.Set("X-Block-Upload-Session", session)
 	req.ContentLength = int64(len(data))
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -83,7 +84,21 @@ func webUploadBlockLegacy(t *testing.T, c *testClient, data []byte) *http.Respon
 
 func webCheckBlocks(t *testing.T, c *testClient, session string, hashes []string) (existing, missing []string) {
 	t.Helper()
-	resp := c.PostJSON(t, "/api/v2/blocks/check?session="+session, map[string]interface{}{"hashes": hashes})
+	data, err := json.Marshal(map[string]interface{}{"hashes": hashes})
+	if err != nil {
+		t.Fatalf("marshal block check request: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/api/v2/blocks/check", bytes.NewBuffer(data))
+	if err != nil {
+		t.Fatalf("new block check request: %v", err)
+	}
+	req.Header.Set("Authorization", "Token "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Block-Upload-Session", session)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		t.Fatalf("block check request failed: %v", err)
+	}
 	expectStatus(t, resp, http.StatusOK)
 	var out struct {
 		Existing []string `json:"existing"`

--- a/internal/integration/web_block_upload_test.go
+++ b/internal/integration/web_block_upload_test.go
@@ -820,12 +820,12 @@ func TestWebBlockUploadSessionRoutesRejectRevokedSharedRepoPermission(t *testing
 		cleanup := adminClient.Delete(t,
 			fmt.Sprintf("/api2/repos/%s/dir/shared_items/?p=/&share_type=user&username=%s", repoID, url.QueryEscape(defaultUserEmail)),
 		)
+		defer cleanup.Body.Close()
 		if cleanup.StatusCode != http.StatusOK && cleanup.StatusCode != http.StatusNotFound {
 			body := responseBody(t, cleanup)
 			t.Errorf("cleanup delete share status=%d body=%s", cleanup.StatusCode, body)
 			return
 		}
-		cleanup.Body.Close()
 	})
 
 	waitForIntegrationCondition(t, "shared repo becomes writable for user before session mint", func() bool {
@@ -848,7 +848,10 @@ func TestWebBlockUploadSessionRoutesRejectRevokedSharedRepoPermission(t *testing
 		return resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound
 	})
 
+	// This covers the first post-revocation use of the session routes, before any
+	// successful route call could warm the 2-minute per-session permission cache.
 	checkResp := webCheckBlocksResponse(t, userClient, sessionID, []string{strings.Repeat("a", 64)})
+	defer checkResp.Body.Close()
 	if checkResp.StatusCode != http.StatusForbidden {
 		body := responseBody(t, checkResp)
 		t.Fatalf("check after permission revocation status=%d, want 403; body=%s", checkResp.StatusCode, body)
@@ -860,6 +863,7 @@ func TestWebBlockUploadSessionRoutesRejectRevokedSharedRepoPermission(t *testing
 	}
 
 	uploadResp := webUploadBlock(t, userClient, sessionID, []byte("revoked session upload "+fmt.Sprint(time.Now().UnixNano())))
+	defer uploadResp.Body.Close()
 	if uploadResp.StatusCode != http.StatusForbidden {
 		body := responseBody(t, uploadResp)
 		t.Fatalf("upload after permission revocation status=%d, want 403; body=%s", uploadResp.StatusCode, body)

--- a/internal/integration/web_block_upload_test.go
+++ b/internal/integration/web_block_upload_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -84,6 +85,19 @@ func webUploadBlockLegacy(t *testing.T, c *testClient, data []byte) *http.Respon
 
 func webCheckBlocks(t *testing.T, c *testClient, session string, hashes []string) (existing, missing []string) {
 	t.Helper()
+	resp := webCheckBlocksResponse(t, c, session, hashes)
+	defer resp.Body.Close()
+	expectStatus(t, resp, http.StatusOK)
+	var out struct {
+		Existing []string `json:"existing"`
+		Missing  []string `json:"missing"`
+	}
+	decodeJSON(t, resp, &out)
+	return out.Existing, out.Missing
+}
+
+func webCheckBlocksResponse(t *testing.T, c *testClient, session string, hashes []string) *http.Response {
+	t.Helper()
 	data, err := json.Marshal(map[string]interface{}{"hashes": hashes})
 	if err != nil {
 		t.Fatalf("marshal block check request: %v", err)
@@ -99,13 +113,7 @@ func webCheckBlocks(t *testing.T, c *testClient, session string, hashes []string
 	if err != nil {
 		t.Fatalf("block check request failed: %v", err)
 	}
-	expectStatus(t, resp, http.StatusOK)
-	var out struct {
-		Existing []string `json:"existing"`
-		Missing  []string `json:"missing"`
-	}
-	decodeJSON(t, resp, &out)
-	return out.Existing, out.Missing
+	return resp
 }
 
 func webCommit(t *testing.T, c *testClient, repoID string, manifest map[string]interface{}) *http.Response {
@@ -796,6 +804,71 @@ func TestWebBlockUploadForeignPubRefNotPermanent(t *testing.T) {
 	})
 	expectStatus(t, commit, http.StatusConflict)
 	commit.Body.Close()
+}
+
+func TestWebBlockUploadSessionRoutesRejectRevokedSharedRepoPermission(t *testing.T) {
+	repoID := createTestLibrary(t, adminClient, fmt.Sprintf("inttest-wbu-revoke-%d", time.Now().UnixNano()))
+
+	shareResp := adminClient.PutJSON(t, fmt.Sprintf("/api2/repos/%s/dir/shared_items/?p=/", repoID), map[string]interface{}{
+		"share_type": "user",
+		"username":   []string{defaultUserEmail},
+		"permission": "rw",
+	})
+	expectStatus(t, shareResp, http.StatusOK)
+	shareResp.Body.Close()
+	t.Cleanup(func() {
+		cleanup := adminClient.Delete(t,
+			fmt.Sprintf("/api2/repos/%s/dir/shared_items/?p=/&share_type=user&username=%s", repoID, url.QueryEscape(defaultUserEmail)),
+		)
+		if cleanup.StatusCode != http.StatusOK && cleanup.StatusCode != http.StatusNotFound {
+			body := responseBody(t, cleanup)
+			t.Errorf("cleanup delete share status=%d body=%s", cleanup.StatusCode, body)
+			return
+		}
+		cleanup.Body.Close()
+	})
+
+	waitForIntegrationCondition(t, "shared repo becomes writable for user before session mint", func() bool {
+		resp := userClient.Get(t, fmt.Sprintf("/api/v2.1/repos/%s/", repoID))
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	})
+
+	sessionID := webCreateBlockSession(t, userClient, repoID, "/")
+
+	deleteResp := adminClient.Delete(t,
+		fmt.Sprintf("/api2/repos/%s/dir/shared_items/?p=/&share_type=user&username=%s", repoID, url.QueryEscape(defaultUserEmail)),
+	)
+	expectStatus(t, deleteResp, http.StatusOK)
+	deleteResp.Body.Close()
+
+	waitForIntegrationCondition(t, "shared repo permission revocation reaches user-facing reads", func() bool {
+		resp := userClient.Get(t, fmt.Sprintf("/api/v2.1/repos/%s/", repoID))
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound
+	})
+
+	checkResp := webCheckBlocksResponse(t, userClient, sessionID, []string{strings.Repeat("a", 64)})
+	if checkResp.StatusCode != http.StatusForbidden {
+		body := responseBody(t, checkResp)
+		t.Fatalf("check after permission revocation status=%d, want 403; body=%s", checkResp.StatusCode, body)
+	}
+	var checkBody map[string]interface{}
+	decodeJSON(t, checkResp, &checkBody)
+	if checkBody["error"] != "upload is no longer allowed for this session" {
+		t.Fatalf("check after permission revocation error=%v, want upload is no longer allowed for this session", checkBody["error"])
+	}
+
+	uploadResp := webUploadBlock(t, userClient, sessionID, []byte("revoked session upload "+fmt.Sprint(time.Now().UnixNano())))
+	if uploadResp.StatusCode != http.StatusForbidden {
+		body := responseBody(t, uploadResp)
+		t.Fatalf("upload after permission revocation status=%d, want 403; body=%s", uploadResp.StatusCode, body)
+	}
+	var uploadBody map[string]interface{}
+	decodeJSON(t, uploadResp, &uploadBody)
+	if uploadBody["error"] != "upload is no longer allowed for this session" {
+		t.Fatalf("upload after permission revocation error=%v, want upload is no longer allowed for this session", uploadBody["error"])
+	}
 }
 
 // TestWebBlockUploadSessionStagingSkipsLogicalStorageQuota verifies R5: a block

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -338,6 +338,72 @@ var (
 		},
 		[]string{"surface", "result"},
 	)
+
+	// BlockUploadVerifyDuration observes how long the web block-upload commit's
+	// per-block verification pass (verifyManifestBlocks: liveness + physical
+	// presence + ownership + size, per distinct block, bounded concurrency)
+	// took, labeled by whether every block turned out ready or some needed
+	// re-upload. This — plus BlockUploadSession* and BlockUploadStagedBlocksTotal
+	// below — closes the observability gap noted in docs/WEB-BLOCK-UPLOAD.md
+	// finding 8: finalizeStoredUploadMetadata already had metrics, but the
+	// verification pass, the session claim/wait path, and staging did not.
+	BlockUploadVerifyDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "block_upload_verify_duration_seconds",
+			Help:    "Duration of the web block-upload commit's per-block verification pass.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"result"}, // "ready" or "needs_upload"
+	)
+
+	// BlockUploadVerifyBlocksTotal counts distinct blocks classified during web
+	// block-upload commit verification, by outcome.
+	BlockUploadVerifyBlocksTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "block_upload_verify_blocks_total",
+			Help: "Total number of blocks classified during web block-upload commit verification, by outcome.",
+		},
+		[]string{"status"}, // "ready", "needs_upload", or "size_mismatch"
+	)
+
+	// BlockUploadSessionClaimTotal counts commit-claim outcomes for concurrent
+	// file-from-blocks requests on the same session (R7's LWT claim).
+	BlockUploadSessionClaimTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "block_upload_session_claim_total",
+			Help: "Total number of web block-upload session commit claim attempts, by outcome.",
+		},
+		// "won": this request finalized the file.
+		// "lost_result_ready": lost the claim, but the winner's result was
+		//   already available (no wait, or the wait completed before timing out).
+		// "lost_timeout": lost the claim and the ~10s wait for the winner's
+		//   result expired; the client must retry.
+		// "lost_conflict": lost the claim to a commit for a DIFFERENT manifest
+		//   on the same session (permanent, not retryable as-is).
+		[]string{"result"},
+	)
+
+	// BlockUploadSessionWaitDuration observes how long a losing/retried commit
+	// waited for a concurrent winner's result (bounded to ~10s).
+	BlockUploadSessionWaitDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "block_upload_session_wait_duration_seconds",
+			Help:    "Duration a web block-upload commit waited for a concurrent winner's result.",
+			Buckets: []float64{0.1, 0.25, 0.5, 1, 2, 4, 6, 8, 10, 15},
+		},
+	)
+
+	// BlockUploadStagedBlocksTotal counts blocks materialized (staged: metadata
+	// + provisional reference) under a web block-upload session at
+	// /blocks/upload, by whether the underlying S3 PUT was a new write or a
+	// dedup no-op (R9 — a session governs a block either way).
+	BlockUploadStagedBlocksTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "block_upload_staged_blocks_total",
+			Help: "Total number of blocks materialized under a web block-upload session.",
+		},
+		[]string{"new"}, // "true" or "false"
+	)
 )
 
 // Register registers all custom metrics with the default Prometheus registry.
@@ -379,5 +445,10 @@ func Register() {
 		UploadFinalizeRetryExhaustedTotal,
 		UploadFinalizeAttempts,
 		UploadFinalizeDuration,
+		BlockUploadVerifyDuration,
+		BlockUploadVerifyBlocksTotal,
+		BlockUploadSessionClaimTotal,
+		BlockUploadSessionWaitDuration,
+		BlockUploadStagedBlocksTotal,
 	)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -351,7 +351,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "block_upload_verify_duration_seconds",
 			Help:    "Duration of the web block-upload commit's per-block verification pass.",
-			Buckets: prometheus.DefBuckets,
+			Buckets: []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 15, 30, 60, 120},
 		},
 		[]string{"result"}, // "ready" or "needs_upload"
 	)
@@ -364,6 +364,17 @@ var (
 			Help: "Total number of blocks classified during web block-upload commit verification, by outcome.",
 		},
 		[]string{"status"}, // "ready", "needs_upload", or "size_mismatch"
+	)
+
+	// BlockUploadVerifyErrorsTotal counts infrastructure failures during the web
+	// block-upload commit's verification pass, before a logical verification
+	// result could be emitted.
+	BlockUploadVerifyErrorsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "block_upload_verify_errors_total",
+			Help: "Total number of infrastructure errors during web block-upload commit verification.",
+		},
+		[]string{"stage"}, // "presence" or "classify"
 	)
 
 	// BlockUploadSessionClaimTotal counts commit-claim outcomes for concurrent
@@ -447,6 +458,7 @@ func Register() {
 		UploadFinalizeDuration,
 		BlockUploadVerifyDuration,
 		BlockUploadVerifyBlocksTotal,
+		BlockUploadVerifyErrorsTotal,
 		BlockUploadSessionClaimTotal,
 		BlockUploadSessionWaitDuration,
 		BlockUploadStagedBlocksTotal,


### PR DESCRIPTION
## Summary

Second PR closing findings from the 2026-07-02 web block-upload review (`docs/WEB-BLOCK-UPLOAD.md`). This one covers the "observability" and "session hardening" work: findings **8** (commit verification/session/staging observability) and **9** (session id out of the query string) plus related items surfaced while touching the same code: **3**, **12**, **14**, **15**, **16**.

### finding 12 — re-verify upload permission mid-session
`resolveUploadSession` only checked session ownership; upload permission was verified once at mint and again at commit. A user whose permission on the session's *library* was revoked (independent of org role/account status, which already kill the auth token via `invalidateSessionsOnDemotion`/`invalidateUserCredentials`) could keep staging blocks for the rest of the 48h TTL.

Re-running the full library-permission resolution (a `shares`-table scan) on **every** `/blocks/upload` call — up to thousands per large file — would make this the most expensive query in the hot path. `sessionPermissionCache` caches a successful confirmation for 2 minutes, bounded via an inline sweep on insert (no goroutine), and **never caches a denial** so a permission fix takes effect on the very next request. The commit still always re-verifies fresh regardless — this is defense in depth, not the sole enforcement point.

### finding 9 — session id out of the query string
`/blocks/check` and `/blocks/upload` now read the session id from `X-Block-Upload-Session` first (`sessionIDFromRequest`), falling back to `?session=`. The frontend (`seafile-api.js`) sends the header exclusively via a new `withBlockUploadSessionHeader` helper.

### finding 3 — align `/blocks/check?session=` with the commit's classifier
Check used to report `existing` from DB liveness alone (`ProbeBlockReuse == Reusable`). Now it runs the exact same liveness + physical-S3-presence + ownership classification the commit uses (`checkBlocksReadyParallel`, sharing `classifyBlockOwnership` with `classifyBlockForCommit`) — minus the size check, which check cannot evaluate (sizes only arrive in the commit manifest). A block reported `existing` is now exactly what the commit will accept modulo size.

### finding 14 — fuse the ownership queries
`classifyBlockForCommit` ran `BlockHasReferrer` (exact-match) and, only on a miss, a second `ListBlockReferrers` (full-partition read) — up to 2 queries in the common case. Both read the **same** `(org, block)` partition, and `ListBlockReferrers` already returns every referrer. `classifyBlockOwnership` answers both questions with **one** partition read, shared by the commit and the now-aligned check.

### finding 8 — observability
New metrics in `internal/metrics/metrics.go`:
- `block_upload_verify_duration_seconds` / `block_upload_verify_blocks_total` — the commit's per-block verification pass, labeled ready vs needs_upload.
- `block_upload_session_claim_total` — R7's LWT claim outcome (won / lost_result_ready / lost_timeout / lost_conflict).
- `block_upload_session_wait_duration_seconds` — how long a losing commit waited for the winner (bounded ~10s).
- `block_upload_staged_blocks_total` — blocks materialized at `/blocks/upload`, labeled new vs dedup.

`finalizeStoredUploadMetadata` already had metrics; these cover the parts that didn't.

### findings 15 & 16 — small cleanups
Removed the per-block `"v2/blocks: uploading block …"` log line (significant volume at 1500+ blocks/file, no operational value). Fixed the stale comment in `file_from_blocks.go` describing the pre-canonical (SHA-1-in-`block_ids`) layout.

### Tests
- `TestSessionIDFromRequest`, `TestSessionPermissionCache_Allow` (cache semantics: caches success, never caches denial, respects/expires the interval, sweeps when full, independent per session).
- `TestObserveBlockVerification_AllReady` / `_MixedResultIsNeedsUpload` (metrics correctness, including that one not-ready block downgrades the whole pass's duration label).
- `seafile-api-block-upload.test.js` (frontend, source-inspection style — `seafile-api.js` pulls in an ESM `axios` chain this repo's Jest config can't transform from `node_modules`, matching the existing pattern for this file).
- Full `internal/...` Go suite green, `go vet` clean, frontend `file-uploader`/`block-upload-orchestrator` suites green (113 tests), ESLint clean on changed files.
- The DB-dependent wiring inside `resolveUploadSession`/`classifyBlockOwnership` relies on the existing `internal/integration/web_block_upload_test.go` harness (docker-compose-gated), same as the rest of this file's Cassandra-backed logic — consistent with how it was tested before this change.

### Docs
`docs/WEB-BLOCK-UPLOAD.md` updated: findings 3, 8, 9 in "Known issues" and 12, 14, 15, 16 in "Security/performance review findings" marked RESOLVED with implementation pointers; the prod-readiness checklist in "Remaining work" updated to show open items (1, 2, 4, 17) vs closed.

### Follow-ups still open (tracked in the doc)
- Item 1: staging-bytes cap.
- Item 2: idempotency reconstruction on sustained Cassandra outage.
- Item 4: broader browser E2E.
- Item 17: `UploadBlock`'s per-request memory buffering / no per-user concurrency cap.
- Item 13: rate limiters are per-node (noted, not a bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
