### PR TITLE
docs(gc): correct dangerous GC header + P10 imprecisions (PR-0 of 5)

### DIFF
--- a/docs/GC-DELETE-CLEANUP-INVESTIGATION.md
+++ b/docs/GC-DELETE-CLEANUP-INVESTIGATION.md
@@ -15,8 +15,10 @@ their verified status.
 > **TL;DR (current, 2026-07-16):** ⛔ **P10 is an OPEN, PROVEN live-content deletion bug and a
 > greenfield deploy blocker** — GC deletes the shared, content-addressed S3 object using an
 > **org-scoped** liveness check, so one org's delete destroys another org's still-referenced
-> block. Confirmed by a real two-org 2 GB upload (deleting one org emptied MinIO; the other org now
-> 404s) and by a seeded single-node repro (see P10). This **retracts** the previous "no open known issue
+> block. Confirmed by a real two-org 2 GB upload (deleting one org emptied MinIO; the other org's
+> downloads become unreadable — the raw GET has already sent its 200 headers, then the block 404s
+> mid-response, so the body is truncated, not a clean error) and by a seeded single-node repro (see
+> P10). This **retracts** the previous "no open known issue
 > can delete live content" verdict, which was wrong: the audit only ever reasoned about
 > liveness *within* an org.
 >
@@ -74,7 +76,7 @@ grows.
 
 | Priority | Item | Issue / branch | Prod impact (greenfield) |
 | --- | --- | --- | --- |
-| ⛔ **BLOCKER** | **Cross-org physical block isolation** | **P10 / `ISSUE-GC-CROSS-ORG-BLOCK-DELETE-01` (own branch)** | **Deleting one org's library destroys another org's still-referenced content.** Confirmed on a real 2 GB two-org upload: MinIO deduped to 2 GB, deleting one org emptied the bucket, the other org now 404s. Must be fixed **before** the greenfield deploy; org-scope the S3 key (trivial on an empty store). Regression test cross-org required |
+| ⛔ **BLOCKER** | **Cross-org physical block isolation (GC delete + orphan recovery)** | **P10 / `ISSUE-GC-CROSS-ORG-BLOCK-DELETE-01` — org-scoped-key series (storage → funnels → GC → coverage)** | **Deleting one org's library destroys another org's still-referenced content.** Confirmed on a real 2 GB two-org upload: MinIO deduped to 2 GB, deleting one org emptied the bucket, and the other org's downloads become unreadable (the raw GET has already sent 200 headers, then the block 404s mid-response → truncated body, not a clean error). Must be fixed **before** the greenfield deploy; org-scope the S3 key — migration-free on an empty store, but requires **all** storage paths (write, read, reuse, verify, GC) to use the org-scoped locator. Regression test cross-org required |
 | — | *(done)* Normal permanent delete + cascade | P1/P1b/P2, PR #129 | Closed — [~50 GB live exercise](#live-path-verification-and-confirmed-gc_pending_items-leak-2026-07-13) showed zero content residue (manual observation) |
 | — | *(done)* Safety classification | P6a/P6b | Closed |
 | — | *(done)* Block `gc_pending_items` new-row leak | P9, PR pending-items fix | Closed for new deletes |
@@ -514,11 +516,14 @@ Subsequent branches, in recommended merge order:
 
 **Recommended merge order (greenfield prod, 2026-07-16):**
 
-0. ⛔ **P10 (`ISSUE-GC-CROSS-ORG-BLOCK-DELETE-01`) — FIRST, its own branch, before the deploy.**
-   Org-scope the physical S3 key so one org's delete can never remove another org's content. Land
-   the cross-org regression test (two orgs upload identical bytes → delete + drain one → the other
-   still downloads) with the fix; it must fail on current `main`. Nothing else on this list matters
-   if live cross-org data can be deleted.
+0. ⛔ **P10 (`ISSUE-GC-CROSS-ORG-BLOCK-DELETE-01`) — FIRST, before the deploy, as an org-scoped-key
+   series of small branches:** docs corrections → storage-layer org-aware `BlockStore` (parallel
+   APIs, fail-closed validation) → API funnels flip (write/read/reuse/verify/fallback) → **GC on its
+   own branch** (delete **+ orphan recovery**, remove the global storage APIs) → coverage + doc
+   closure. Org-scope the physical S3 key so one org's delete can never remove another org's content.
+   Land the cross-org regression test (two orgs upload identical bytes → delete + drain one → the
+   other still downloads byte-for-byte) with the GC branch; it must fail on current `main`. Nothing
+   else on this list matters if live cross-org data can be deleted.
 1. ~~**1C** — replace global `ProcessOnce(storage=nil)` with scoped `ProcessOrgOnce`~~ ✅ **DONE**
    (plus a guard test that blocks reintroduction).
 2. ~~**1A / 1B** — fixture-scoped teardown for upload/`pub:foreign` residue~~ ✅ **DONE**

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -982,7 +982,8 @@ work begins.
 
 ### ISSUE-BLOCK-STORAGE-KEY-READS-01: Read Paths Ignore `storage_key` (key derived from hash)
 
-**Status**: 🟡 Pending — latent inconsistency, no live bug today
+**Status**: 🟡 Pending — **will be resolved with P10** (`ISSUE-GC-CROSS-ORG-BLOCK-DELETE-01`);
+latent inconsistency, no live bug today
 **Severity**: Low (becomes High the moment any block is stored at a non-hash-derived key)
 **Affected**: `internal/storage/blocks.go` read methods; GC delete path
 
@@ -1022,6 +1023,16 @@ objects — reads would 404 and GC could delete the wrong (or no) object.
 Make `storage_key` the primary locator for reads and deletes, with `hashToKey(hash)`
 as the fallback only when the column is empty (mirroring `EnsureReusableBlockPresent`).
 This is a pre-existing, cross-cutting change; track it independently of P-2.
+
+**Resolution path (via P10):** the org-scoped-key fix resolves this **by construction** rather than
+by making `storage_key` authoritative. Once the key is `blocks/<org_id>/<h0:2>/<h2:4>/<hash>`, the org
+is baked into the `BlockStore` at construction (the method signature stays
+`blockStore.StorageKeyForHash(hash)` — the org is not passed per call), the derivation is
+deterministic, and every path (read, GC delete, reuse/verify) recomputes the same locator — no
+divergence is possible, and no extra DB read is added on the
+download hot path. `storage_key` may only be empty or **exactly** the derived key; `EnsureReusableBlockPresent`
+always recomputes and **fails closed** (with a metric/log) if a stored `storage_key` differs from the
+derived one, and no block method accepts an arbitrary caller-supplied S3 key. Closed alongside P10.
 
 #### Related
 
@@ -2806,7 +2817,7 @@ Move/Copy operations fully implemented (batch sync + async variants) with confli
 
 ## 🚧 BACKEND NOT IMPLEMENTED
 
-### Garbage Collection — IMPLEMENTED, SAFE FOR GREENFIELD PROD; OPEN RECLAMATION/OPS DEBT
+### Garbage Collection — IMPLEMENTED; ⛔ BLOCKED FOR GREENFIELD BY P10 (cross-org block delete)
 **Status**: Core engine implemented (2026-01-30), major overhaul (2026-03-17);
 2026-07-10 audit found P1–P10 follow-ups. Refreshed 2026-07-16: the safety-classification gaps
 (P6a/P6b) and the normal permanent-delete path (P1/P1b/P2, PR #129) are **closed** on `main`.
@@ -4362,7 +4373,9 @@ The claim+verify fence does not help: it re-checks the same org-scoped partition
 **Real two-org E2E (operator, 2026-07-16) — the definitive evidence.** ~2 GB of **identical** files
 uploaded through the API into **two** orgs. MinIO showed **2 GB**, not 4 — the upload path deduplicates
 globally by content hash, so both orgs' metadata pointed at one physical copy. Deleting **all** files
-in one org and draining GC left the MinIO volume **empty**, and the other org's files now 404:
+in one org and draining GC left the MinIO volume **empty**, and the other org's files become
+**unreadable** — the external request has already returned 200, then the 404/`NoSuchKey` happens
+internally while fetching the block, truncating the body:
 
 ```
 [ServeRawFile] Failed to get block 0/1: ... GetObject ... StatusCode: 404 ... NoSuchKey
@@ -4388,8 +4401,12 @@ re-uploaded document.
 
 1. **Org-scope the physical key** — e.g. `blocks/<org_id>/<h0:2>/<h2:4>/<hash>`. Aligns physical
    ownership with the existing per-org tables, claims and references; no coordination needed. Costs
-   cross-org dedup (each org stores its own copy). **Simplest and safest for a greenfield deploy — the
-   store is empty, so there is no migration.**
+   cross-org dedup (each org stores its own copy). **Migration-free on an empty (greenfield) store —
+   but not trivial: it requires *all* storage paths (write, read, reuse, verify, GC delete + orphan
+   recovery) to resolve the org-scoped locator, and the org must enter the `BlockStore` at
+   construction with fail-closed validation so no path can ever produce a global key again.** This
+   is the chosen approach — see the org-scoped-key plan (docs-first, storage layer, API funnels, GC
+   own branch, coverage/closure).
 2. **Global liveness per `(storage_class, block_id)`** — a global ref/owner registry plus a global claim
    before physical delete. Keeps cross-org dedup, but needs global coordination and is materially more
    complex.


### PR DESCRIPTION
## PR-0 of 5 — docs-only, no code change

First branch of the org-scoped block-key work for the P10 blocker (`ISSUE-GC-CROSS-ORG-BLOCK-DELETE-01`). Closes the pre-fix documentation debt PR#2 left, **before** any code lands. **P10 stays OPEN** until the fix ships (PR-3).

### What this fixes
- **Dangerous header (Medium):** `docs/KNOWN_ISSUES.md` no longer says `Garbage Collection — IMPLEMENTED, SAFE FOR GREENFIELD PROD` while a proven live-data-loss blocker sits immediately below it. Now `IMPLEMENTED; ⛔ BLOCKED FOR GREENFIELD BY P10 (cross-org block delete)`. This header could have driven a wrong operational decision.
- **"the other org now 404s" (Low, imprecise):** the raw GET has already sent its 200 headers, then the block 404s **mid-response** → truncated body, **not** a clean error. Corrected in the TL;DR and the blocker table row of `docs/GC-DELETE-CLEANUP-INVESTIGATION.md`.
- **"trivial on an empty store" (Low, understated):** migration-free on an empty store, **but** requires all storage paths (write / read / reuse / verify / GC delete + orphan recovery) to use the org-scoped locator, with fail-closed org validation at `BlockStore` construction.
- **ISSUE-BLOCK-STORAGE-KEY-READS-01:** noted it will be **resolved by P10** (deterministic org-scoped locator; fail-closed on divergent `storage_key`) — not marked closed yet.

### The plan (5 branches, GC on its own)
- **PR-0 (this):** docs corrections.
- **PR-1:** storage layer org-aware `BlockStore` (parallel APIs, fail-closed validation, unit tests) — no behavior change.
- **PR-2:** flip API funnels (write/read/reuse/verify/fallback) to the org-scoped key + write/read integration tests.
- **PR-3 (GC own branch):** GC delete + orphan recovery org-scoped, **remove the global storage APIs** (compiler net), cross-org regression test that fails on `main`.
- **PR-4:** broad coverage (multiregion/buckets, per-org independent reclamation) + doc closure marking P10 resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)