### PR TITLE
fix(gc): make the claim stub an explicit lifecycle state

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -215,11 +215,13 @@ CORS_ALLOWED_ORIGINS=https://files.sesamedisk.com
 
 
 # =============================================================================
-# GC Operational Guard (temporary)
+# GC Operational Safety Gate
 # =============================================================================
-# Until distributed GC leadership exists, exactly ONE backend replica must run GC.
-# Set GC_ENABLED=true only on the designated GC node. Set GC_ENABLED=false on all
-# other replicas. Single-node deployments can leave this as true.
+# X1 (physical-delete ABA) and X2 (cross-DC reference visibility) are open.
+# Keep GC_ENABLED=false on EVERY replica in EVERY DC, including single-node
+# deployments. The LWT lease does not close either blocker. Only after both close
+# may designated replicas in one DC use true and participate under the lease; all
+# replicas in every other DC must remain false.
 GC_ENABLED=false
 
 # GC retention tuning (days) — override the built-in defaults.

--- a/CURRENT_WORK.md
+++ b/CURRENT_WORK.md
@@ -1,7 +1,7 @@
 # Current Work - SesameFS
 
-**Last Updated**: 2026-05-21
-**Session**: Session 60 — Desktop Sync Conflict Hardening + Sync Test Runner/cleanup + PR61 Closeout
+**Last Updated**: 2026-07-21
+**Session**: Upload-fence / GC safety PR series
 
 **📏 File Size Rule**: Keep this file under **500 lines** unless unavoidable. Move detailed content to:
 - `docs/KNOWN_ISSUES.md` - Detailed bug tracking
@@ -17,7 +17,7 @@
 
 **🔴 PRODUCTION BLOCKERS** (Must complete before deploy):
 1. ~~**OIDC Authentication**~~ - ✅ **COMPLETE** (Phase 1 - Basic Login)
-2. ~~**Garbage Collection**~~ - ✅ **COMPLETE** (Queue worker + 12-phase scanner + 3 cascade types + admin API + audit log + health metrics)
+2. **Destructive Garbage Collection** - 🔴 **BLOCKED** by X1 physical-delete ABA and X2 cross-DC reference visibility. Keep `GC_ENABLED=false` everywhere; the implementation and lease exist but are not permission to activate deletion.
 3. ~~**Monitoring/Health Checks**~~ - ✅ **COMPLETE** (Structured logging, `/health`, `/ready`, `/metrics`)
 
 **Then review**:
@@ -27,10 +27,10 @@
 
 ### Quick Context
 1. **Sync Protocol**: Baseline-verified for the current desktop sync hardening scope. Do not treat it as frozen; compatibility-sensitive follow-up coverage still exists.
-2. **Backend API**: ~98% complete - OIDC ✅, GC ✅, Library Settings ✅, Monitoring ✅, Departments ✅, Admin Panel (groups/users) ✅, OIDC Group/Dept Sync ✅, Tag cascade ✅, Admin Link Management ✅, Upload Links ✅, Org Admin Panel ✅, Superadmin Departments ✅, Custom Share Permissions ✅
+2. **Backend API**: ~98% complete - OIDC ✅, GC implementation present but destructive activation blocked by X1/X2, Library Settings ✅, Monitoring ✅, Departments ✅, Admin Panel (groups/users) ✅, OIDC Group/Dept Sync ✅, Tag cascade ✅, Admin Link Management ✅, Upload Links ✅, Org Admin Panel ✅, Superadmin Departments ✅, Custom Share Permissions ✅
 3. **Frontend UI**: ~85% complete (all modals migrated, About modal rebranded, File History UI ✅, History Download ✅, Snapshot View ✅, Restore from History ✅, Share Dialog all 8 tabs ✅, permission UI ~75% with granular flags, ~51 ModalPortal wrappers to clean up, folder icons ✅). Plans/permissions Phase 3 is in progress, not closed.
 4. **Test flow**: Prefer Docker-first validation. `./scripts/test.sh sync` now runs the single-client sync suite plus the real active-active desktop harness; default behavior is fail-fast and `--keep-going` is opt-in.
-5. **Current risk shape**: No confirmed production bug remains in the current sync hardening slice; the open items are narrower follow-up coverage and cleanup debt, not known correctness regressions.
+5. **Current risk shape**: destructive GC has two confirmed live-data safety blockers (X1/X2) and must remain disabled fleet-wide. The upload-fence PR series addresses separate writer/GC races but does not close those activation gates.
 
 ### Inter-session Update (2026-05-21)
 
@@ -397,11 +397,11 @@ Detail sidebar now has Info | History tabs for files. Full-page history also wor
 
 ### 📊 Current State (Updated 2026-03-05)
 - **Sync Protocol**: 100% working, desktop clients fully compatible 🔒 FROZEN
-- **Backend API**: ~98% implemented — OIDC ✅, GC ✅, Library Settings ✅, OnlyOffice ✅, Tags cascade ✅, Org Admin Panel ✅, Superadmin Departments ✅
+- **Backend API**: ~98% implemented — OIDC ✅, GC implementation present but destructive activation blocked by X1/X2, Library Settings ✅, OnlyOffice ✅, Tags cascade ✅, Org Admin Panel ✅, Superadmin Departments ✅
 - **Frontend UI**: ~83% functional (all modals migrated, folder icons ✅, ~51 ModalPortal wrappers to clean up)
-- **Production Ready**: All production blockers complete — OIDC ✅, GC ✅, Monitoring ✅
+- **Production Ready**: blocked for destructive GC until X1/X2 close; keep `GC_ENABLED=false` on every replica/DC
 - **Admin Panels**: Both superadmin and org admin at feature parity
-- **Active Bugs**: 0 open (all 5 resolved Session 32)
+- **Active Bugs**: tracked canonically in `docs/KNOWN_ISSUES.md`; X1/X2 are current GC blockers
 
 ### Critical Facts to Remember
 

--- a/configs/config.docker.yaml
+++ b/configs/config.docker.yaml
@@ -271,7 +271,7 @@ versioning:
   gc_interval: 24h
 
 gc:
-  enabled: false                  # Safe default; enable explicitly with GC_ENABLED=true when this container should run GC
+  enabled: false                  # Production stays false everywhere while X1/X2 are open; local tests may opt in only to exercise GC behavior
   worker_interval: 30s
   scan_interval: 30s                 # Keep scanner fast in docker/test so deleted users/orgs are enqueued promptly
   batch_size: 5000                   # Local/docker only: drain large post-test GC queues faster

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -263,7 +263,7 @@ seafhttp:
   chunked_staging_max_bytes: 0       # 0 = unlimited; set a node-local byte budget (for example 214748364800 for 200 GiB) to cap active chunked temp-file staging
 
 gc:
-  enabled: false                   # Safe default; enable explicitly with GC_ENABLED=true on the designated GC replica
+  enabled: false                   # Required everywhere while GC blockers X1/X2 remain open; only after closure may one DC designate participants under the lease
   worker_interval: 30s
   scan_interval: 24h
   batch_size: 100

--- a/configs/config.prod.yaml
+++ b/configs/config.prod.yaml
@@ -289,7 +289,7 @@ versioning:
   gc_interval: 24h
 
 gc:
-  enabled: false                  # Safe default; enable explicitly with GC_ENABLED=true on the designated GC replica
+  enabled: false                  # Required on every replica/DC while GC safety blockers X1/X2 remain open
   worker_interval: 30s
   scan_interval: 24h
   batch_size: 100
@@ -302,10 +302,12 @@ gc:
   trash_retention_days: 30
   audit_retention_days: 365
 
-# Production activation pattern:
-# keep gc.enabled=false in YAML and set GC_ENABLED=true only on the replica that
-# should participate in GC. Lease-based coordination still protects against
-# accidental overlap if more than one replica is enabled.
+# Production activation gate:
+# keep gc.enabled=false and GC_ENABLED=false on EVERY replica in EVERY DC while
+# X1 (physical-delete ABA) or X2 (cross-DC reference visibility) remains open.
+# The LWT lease does not close either blocker. Only after both close may designated
+# replicas in one DC set GC_ENABLED=true and participate under the lease; every
+# replica in every other DC remains false.
 
 # =============================================================================
 # CORS

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -357,13 +357,18 @@ PUT /api2/repos/:id/file/?p=/path
 **GC Configuration:**
 ```yaml
 gc:
-  enabled: true
+  enabled: false  # Required on every replica/DC while GC safety blockers X1/X2 remain open
   interval: 24h
   grace_period: 24h
   batch_size: 1000
   max_duration: 4h
   dry_run: false
 ```
+
+The lease is not an activation signal. Keep `GC_ENABLED=false` everywhere until
+both `ISSUE-GC-UPLOAD-FENCE-REMATERIALIZATION-01` (X1) and
+`ISSUE-GC-CROSS-DC-REFERENCE-VISIBILITY-01` (X2) close. Only then may designated
+replicas in one DC participate under the lease; every other DC remains disabled.
 
 ---
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -374,8 +374,9 @@ ACCOUNTS_DISABLE_ORG_USER_WRITES=true
 # If you use the bundled nginx on Docker's external sfs-net network, inspect the
 # actual subnet first and use that exact CIDR instead of guessing.
 
-# Temporary GC guard for multi-replica prod: keep this true on exactly one backend replica.
-GC_ENABLED=true
+# Destructive GC safety gate: X1/X2 are open. Keep false on EVERY backend
+# replica in EVERY DC. Do not designate a GC replica yet.
+GC_ENABLED=false
 
 # External OnlyOffice deployment: SesameFS only needs these three values.
 ONLYOFFICE_ENABLED=true
@@ -444,7 +445,7 @@ instead of attempting `CREATE KEYSPACE` through the restricted app role.
 
 > `ACCOUNTS_DISABLE_ORG_USER_WRITES` should normally stay `true`. That keeps tenant org-admin user lifecycle writes disabled so Accounts remains the operational authority. Platform superadmins still bypass that tenant lock as an operational fallback, but Accounts should prefer the `/admin/...` surface.
 
-> `gc.enabled` now defaults to `false` in YAML. Activate GC explicitly with `GC_ENABLED=true` only on the replicas that are allowed to participate in GC. When more than one enabled replica is up, SesameFS now uses a short Cassandra LWT lease so only one replica runs worker/scanner/rollover work at a time. For multi-region, still enable GC in exactly one DC to avoid unnecessary cross-DC Paxos churn.
+> `gc.enabled` defaults to `false` in YAML. While X1 (`ISSUE-GC-UPLOAD-FENCE-REMATERIALIZATION-01`) or X2 (`ISSUE-GC-CROSS-DC-REFERENCE-VISIBILITY-01`) remains open, keep `GC_ENABLED=false` on **every replica in every DC**. The LWT lease prevents concurrent leaders but does not close either data-loss blocker. Only after both issues close may designated replicas in one DC set `GC_ENABLED=true` and participate under the lease; all replicas in every other DC must remain false.
 
 > `SERVER_TRUSTED_PROXIES` should never be set to `0.0.0.0/0`, `::/0`, or another blanket range. In the supported two-nginx topology above, trust only the internal SesameFS nginx network that talks directly to Go. If you leave it unset, SesameFS ignores forwarded-IP headers and uses the direct socket peer instead.
 
@@ -758,8 +759,8 @@ Do not use `--build` for the normal prod path. The production compose consumes p
 > **Not applicable to a greenfield deploy.** This procedure exists for clusters that already ran
 > an older GC binary against populated `gc_queue` / `gc_failed_items` tables. A fresh install
 > applies every migration at first boot, before any scanner or worker runs, so there is no
-> version skew and no pre-011 backlog to drain — deploy normally and enable GC per the
-> single-leader guidance below.
+> version skew and no pre-011 backlog to drain. Deploy normally, but keep GC disabled
+> fleet-wide while X1/X2 remain open.
 
 Migration 011 adds `library_guard_mode` to `gc_queue` / `gc_failed_items` and the
 scanner starts stamping orphan work as `canonical_absent` (P6b execution-time
@@ -784,8 +785,9 @@ operation across the **whole fleet** (every region/DC), not as a rolling deploy:
 4. Deploy the new image to **all** replicas in all DCs while GC stays disabled.
 5. Confirm the deployed image/commit is identical on every replica — no old
    binary remains anywhere.
-6. Only then re-enable GC (`GC_ENABLED=true`) on exactly the designated
-   replica(s)/DC, per the single-leader guidance below.
+6. Keep `GC_ENABLED=false` on every replica in every DC while X1/X2 remain open.
+   After both close, designated replicas in one DC may be re-enabled under the LWT
+   lease; every replica in every other DC must remain disabled.
 
 Legacy queue/DLQ rows written before the migration (NULL `library_guard_mode` +
 `requires_library_deleted_check=true`) remain correct: the new binary hydrates
@@ -1121,7 +1123,7 @@ What the stock production deploy does **not** provide by itself yet:
 - there is no built-in migration workflow for existing non-empty libraries that need to move from one storage class to another
 - org policy only affects **new library creation** in this slice; it does not relocate existing libraries
 - create-time placement is intentionally limited to hot classes; cold-tier primary placement remains future design work
-- GC uses a Cassandra LWT lease (`gc_leader` row) so only one enabled replica runs worker/scanner/rollover at a time. `GC_ENABLED` is the per-replica safety belt: enable it on the replicas that are allowed to participate, and the lease guarantees mutual exclusion automatically. Lease takeover from a crashed leader is supported via the admin endpoint without waiting for TTL.
+- GC has a Cassandra LWT lease (`gc_leader` row), but the lease does not close X1/X2. While either blocker remains open, set `GC_ENABLED=false` on every replica in every DC. After both close, designated replicas in one DC may participate and the lease will select one leader; all other DCs remain disabled. Lease takeover from a crashed leader is supported via the admin endpoint without waiting for TTL.
 
 For production multi-region, treat this feature as requiring operator-provided topology plus the shared config and `.env` values below.
 
@@ -1493,14 +1495,18 @@ docker compose -f docker-compose.prod.yml exec cassandra sh -lc 'cqlsh -u cassan
 > sesamefs.deploy_sentinel;` after the cutover or just let the TTL'd rows
 > age out and leave it in place.
 
-#### M5.5 — GC lease is single-leader
+#### M5.5 — GC remains disabled while X1/X2 are open
 
-If you enabled `GC_ENABLED=true` on more than one replica (across regions or
-within the same region), confirm only one is actually running GC work:
+Current production verification is that every replica in every DC reports
+`GC_ENABLED=false`; do not use the lease as permission to enable destructive GC.
+After both blockers close, if multiple designated replicas in one DC participate,
+confirm that the lease selects only one active leader:
 
 ```bash
 docker compose -f docker-compose.prod.yml exec cassandra sh -lc 'cqlsh -u cassandra -p "$CASSANDRA_SUPERUSER_PASSWORD" -e "SELECT role, instance_id, heartbeat, ttl(instance_id) FROM sesamefs.gc_leases WHERE role='gc';"'
-# Exactly one row, with a positive TTL and a recent heartbeat (< 90s old).
+# Before X1/X2 close: no active GC leader is expected.
+# After X1/X2 close and one-DC activation: exactly one row, with a positive TTL
+# and a recent heartbeat (< 90s old).
 # instance_id format is <hostname>-<pid>-<unix_nanos>. Re-run on every node —
 # the answer must be identical (it's the same Cassandra row, replicated to
 # every DC).

--- a/docs/GC-DELETE-CLEANUP-INVESTIGATION.md
+++ b/docs/GC-DELETE-CLEANUP-INVESTIGATION.md
@@ -14,6 +14,11 @@ table (P1–P10), the architectural invariants, and the branch roadmap live in t
 section at the end. The `F1`–`F4` findings below are the original notes, now annotated with
 their verified status.
 
+> **Production activation update (2026-07-21):** this delete-cleanup audit predates the
+> upload-fence X1/X2 findings. Keep `GC_ENABLED=false` on every replica in every DC while
+> either remains open. The LWT lease does not close them. Only after both close may
+> designated replicas in one DC participate under the lease.
+
 > **TL;DR (current, 2026-07-16):** P10 was a **proven live-content deletion bug and
 > greenfield deploy blocker** — GC deleted the shared, content-addressed S3 object using an
 > **org-scoped** liveness check, so one org's delete destroyed another org's still-referenced
@@ -39,7 +44,8 @@ their verified status.
 > see its provenance note before citing it). The initial audit residue was dominated by
 > integration-test fixtures, not production behavior.
 >
-> **Still open** (storage retention / ops / scale — not live-data safety):
+> **Still open in this audit** (storage retention / ops / scale — not live-data safety).
+> Separately, X1/X2 are current live-data safety blockers and override this older scope:
 > - **P4** — `pub:` refs lack a discoverable zero-ref→candidate transition after TTL expiry.
 > - **P5** — Phase 13 logs enqueue failures but returns success.
 > - **P7** — markerless commit/fs_object partitions are undiscoverable once both library indexes
@@ -67,7 +73,7 @@ their verified status.
 ## Current open work (2026-07-16)
 
 **Deploy context:** production will start from an **empty** Cassandra keyspace and MinIO buckets with
-GC enabled. No reconcile/backfill pass is required before launch — there is no historical residue to
+GC disabled on every replica in every DC while upload-fence blockers X1/X2 remain open. No reconcile/backfill pass is required before launch — there is no historical residue to
 repair. Do **not** use `TRUNCATE` or direct S3 deletes to "clean" a cluster; the safe worker
 protocol owns physical deletion.
 
@@ -109,7 +115,7 @@ grows.
 - Direct Cassandra/MinIO inspection recorded in the residue table below.
 - Unit suite: `go test ./...` passed at the audited commit. Integration tests require the
   `integration` build tag and an external backend, so they are not part of that command.
-- The dev environment used by the suite had `GC_ENABLED=true`. The harness does not start or
+- **Historical non-production observation:** the dev environment used by the suite had `GC_ENABLED=true`. The harness does not start or
   own the backend service, but tests explicitly call `/api/v2.1/admin/gc/run`, and one normal
   integration test constructs a global `Worker` directly. Reproduction must record GC enabled,
   grace-period, retention, and backend lifetime; otherwise post-suite residue is not comparable.
@@ -405,7 +411,7 @@ re-discovered by scanner Phase 0.
 | P4 | `pub:` refs have no discoverable expiry projection (`up:` has one via `gc_provisional_block_refs` + Phase 0). When the last `pub:` expires by Cassandra TTL (35d), nothing runs the zero-ref → `EnsureBlockGCCandidate` transition; `scanOrphanedBlocks` only walks already-created candidates. Block + mapping + S3 can be retained. Confirmed by protocol analysis; no production incident demonstrated. | Med | [block_references.go:339](../internal/db/block_references.go#L339); [scanner.go:335](../internal/gc/scanner.go#L335) | `ISSUE-GC-PUB-REF-ZERO-REF-01` |
 | P5 | Phase 13 **logs** delivery failures but does not surface them: on `EnqueueBatch` failure it logs and returns `nil`; on per-library `PendingItemExists` failure it logs and `continue`s. The failure is invisible to the phase result, health, and dedicated metrics, so the overall scan cycle can appear successful. | Med | [scanner.go:1267-1271,1304-1315](../internal/gc/scanner.go#L1267) | `ISSUE-GC-PHASE13-ERROR-VISIBILITY-01` |
 | P6a ✅ **FIXED (1D)** | **Fail-open live-library classification (transient errors).** `LibraryExists`/`GroupExists` mapped every read error to `(false,nil)`, so a transient Cassandra error could make Phases 3/4 enqueue a live library's commits/fs_objects and Phase 9 delete a valid group share. **Fixed 2026-07-10:** existence reads return `(false,nil)` only for `gocql.ErrNotFound` and propagate all other errors; Phases 3/4/9 fail closed and surface the error. Phase 9 scans `shares_by_group` directly, uses each projection row's `OrgID`, and has unit plus real-Cassandra regression coverage. | **High** | [store_cassandra.go:2357-2373](../internal/gc/store_cassandra.go#L2357), [scanner.go:532-546](../internal/gc/scanner.go#L532), [scanner.go:624-638](../internal/gc/scanner.go#L624), [scanner.go:1073-1090](../internal/gc/scanner.go#L1073), [store_cassandra.go:3290-3312](../internal/gc/store_cassandra.go#L3290), [store_cassandra.go:3314-3329](../internal/gc/store_cassandra.go#L3314) | `ISSUE-GC-EXISTENCE-CHECK-FAILOPEN-01` |
-| P6b ✅ **FIXED (1E)** | **Execution-time canonical revalidation of orphan AND cascade work.** Phase 3/4 persist `canonical_absent`; cascade children persist `deleted_at_identity`; retry/DLQ preserve the mode and legacy booleans remain compatible. The worker takes the existing library lock, point-reads `libraries[(org_id, library_id)]`, cancels on presence, fails closed on errors/unknown modes, and synchronously renews the token before destructive commit/fs_object/reference mutations. Crucially, a `deleted_at_identity` child also requires the canonical row to be **absent**: a matching delete marker does not prove the parent finished `HardDeleteLibrary`, so if the parent crashed mid-cascade (marker + canonical both survive, lease stolen while stale) the child **postpones** (no retry burn, no DLQ) instead of purging a still-restorable library. Library cascade, org cascade, and restore all take the same library lock. Restore reuses the same stale-aware lease, re-reads the canonical row under the lease (present+soft-deleted ⇒ restore; absent ⇒ reject; active ⇒ reject), and fences before its batch — so restore can never revive a partially-purged library. Mixed-version rollout note: pause GC across the fleet, deploy the migration and new binaries everywhere, verify no old workers remain, then re-enable GC. P7 discovery remains separate. | Med (fixed) | [scanner.go:576-586](../internal/gc/scanner.go#L576), [worker.go:1729-1830](../internal/gc/worker.go#L1729), [write_helpers.go:980-996](../internal/api/v2/write_helpers.go#L980) | `ISSUE-GC-ORPHAN-WORKER-REVALIDATION-01` |
+| P6b ✅ **FIXED (1E)** | **Execution-time canonical revalidation of orphan AND cascade work.** Phase 3/4 persist `canonical_absent`; cascade children persist `deleted_at_identity`; retry/DLQ preserve the mode and legacy booleans remain compatible. The worker takes the existing library lock, point-reads `libraries[(org_id, library_id)]`, cancels on presence, fails closed on errors/unknown modes, and synchronously renews the token before destructive commit/fs_object/reference mutations. Crucially, a `deleted_at_identity` child also requires the canonical row to be **absent**: a matching delete marker does not prove the parent finished `HardDeleteLibrary`, so if the parent crashed mid-cascade (marker + canonical both survive, lease stolen while stale) the child **postpones** (no retry burn, no DLQ) instead of purging a still-restorable library. Library cascade, org cascade, and restore all take the same library lock. Restore reuses the same stale-aware lease, re-reads the canonical row under the lease (present+soft-deleted ⇒ restore; absent ⇒ reject; active ⇒ reject), and fences before its batch — so restore can never revive a partially-purged library. Mixed-version rollout note: pause GC across the fleet and deploy/verify new binaries everywhere. While X1/X2 remain open, keep it disabled; only after both close may designated replicas in one DC participate under the lease. P7 discovery remains separate. | Med (fixed) | [scanner.go:576-586](../internal/gc/scanner.go#L576), [worker.go:1729-1830](../internal/gc/worker.go#L1729), [write_helpers.go:980-996](../internal/api/v2/write_helpers.go#L980) | `ISSUE-GC-ORPHAN-WORKER-REVALIDATION-01` |
 | P7 | **Orphan phases cannot discover markerless artifact libraries.** `ListDistinctCommitLibraries` / `ListDistinctFSObjectLibraries` do not enumerate commits/fs_objects; both return the union of `libraries_by_id` + `deleted_libraries`. Once both library rows are gone, surviving commits/fs_objects are invisible to Phases 3/4. Observed in the dev audit snapshot (test drift); **not reproduced on the live ~50 GB delete path.** But it is **not** confined to historical clusters: `cascadeDeleteLibrary` enqueues children ([worker.go:1325](../internal/gc/worker.go#L1325)) *before* `HardDeleteLibrary` drops canonical + marker ([worker.go:1338](../internal/gc/worker.go#L1338)), so on **any** cluster a child that exhausts retries → DLQ → `DeleteExpiredFailedItem` ([store_cassandra.go:891-942](../internal/gc/store_cassandra.go#L891)) leaves a commit/fs_object with no index and no marker to rediscover it. Trigger set: terminal child-work loss / DLQ expiry, corruption, or manual drift — never a normal successful delete. Under-reclamation only. | Med | [store_cassandra.go:2314-2355](../internal/gc/store_cassandra.go#L2314) | `ISSUE-GC-ORPHAN-ARTIFACT-DISCOVERY-01` |
 | P8 | **Phase 9 group-share discovery still performs a global table scan.** The immediate fix streams `shares_by_group` with context and 256-row driver pages, so process memory is bounded and cancellation works, but Cassandra still reads every partition each cycle. Replace it with a bucketed active-partition projection plus reconcile/backfill. | Med (performance/operability) | [store_cassandra.go:3290-3312](../internal/gc/store_cassandra.go#L3290) | `ISSUE-GC-GROUP-SHARE-DISCOVERY-SCAN-01` |
 | P9 ✅ **FIXED (2026-07-13)** | **`gc_pending_items` block rows leaked** when `ItemBlock` was enqueued under the real `library_id` while dedup/complete used `uuid.Nil` — one orphan pending row per deleted block (~9.6k on the 50 GB live test). No data-safety impact. Fixed: all block producers key `uuid.Nil`; store-level `pendingItemLibraryID` backstop. Pre-existing orphan rows on old clusters need a one-off sweep; **not present on greenfield prod.** | Low (fixed for new work) | [worker.go:1614-1633](../internal/gc/worker.go#L1614), [store_cassandra.go:448-464](../internal/gc/store_cassandra.go#L448) | `ISSUE-GC-PENDING-ITEM-BLOCK-LIBRARY-SCOPE-01` |
@@ -573,7 +579,7 @@ first remove/isolate global cross-test processing (1C), then use two gates:
 
 ## Live-path verification and confirmed `gc_pending_items` leak (2026-07-13)
 
-After the P6b guard-mode work merged (PR #126), we re-ran the full suite on a wiped dev
+**Historical non-production evidence:** after the P6b guard-mode work merged (PR #126), we re-ran the full suite on a wiped dev
 cluster (`docker compose down -v` → clean deploy) and, separately, exercised the **real**
 production delete path (uploaded ~50 GB across three folders through the normal web/desktop
 flow, then deleted the libraries and let GC drain). Direct Cassandra + MinIO inspection

--- a/docs/GC-SERVICE-ANALYSIS.md
+++ b/docs/GC-SERVICE-ANALYSIS.md
@@ -33,6 +33,11 @@ plan integration tests for long-running monitoring.
 > Full audit (P1–P10, invariants, branch roadmap):
 > [GC-DELETE-CLEANUP-INVESTIGATION.md](GC-DELETE-CLEANUP-INVESTIGATION.md);
 > per-item issues: `ISSUE-GC-*` in [KNOWN_ISSUES.md](KNOWN_ISSUES.md).
+>
+> **Production activation gate (2026-07-21):** X1 physical-delete ABA and X2
+> cross-DC reference visibility remain open. Keep `GC_ENABLED=false` on every
+> replica in every DC. The leader lease does not close either blocker. Only after
+> both close may designated replicas in one DC participate under the lease.
 
 ---
 
@@ -178,7 +183,9 @@ These are deliberate safety mechanisms that are correctly implemented and tested
 
 1. **Claim-then-verify block deletion** — Cassandra lightweight transactions only guard
    the delete claim, and the worker re-checks live `block_references` before S3
-   deletion. That prevents live content from being removed even under concurrent upload.
+   deletion before authorization. It does not close X1: Cassandra claims/generations cannot
+   revoke an S3 DELETE already in flight; only never-reused generational physical keys close
+   that ABA. This mechanism must not be treated as production-safe activation while X1/X2 are open.
 2. **Grace period** (default 1h) — Recently enqueued items can't be processed. Gives
    time for concurrent operations to finish registering or promoting references.
 3. **Idempotent cleanup by liveness rows** — keyed `block_references` rows replace the
@@ -343,9 +350,9 @@ removes the stale candidate. Before removing the canonical block row it persists
 ### Scenario 4: Library soft-delete and purge
 
 Soft-delete keeps the library row and stamps `deleted_libraries.block_representation_id`. Phase 13
-queues `ItemLibraryCascade` after retention. Direct permanent-delete paths have P1/P2 debt: some
-omit immediate content enqueue; others use a non-durable, content-only goroutine. The durable purge
-marker roadmap makes Phase 13 immediately eligible while keeping content cleanup idempotent.
+queues `ItemLibraryCascade` after retention. Direct permanent-delete paths now stamp the durable
+`purge_requested_at` marker and wired paths also issue a best-effort immediate
+`ItemLibraryCascade` enqueue. Phase 13 remains the durable recovery path and cleanup is idempotent.
 
 ### Scenario 5: User/organization cascades
 
@@ -367,6 +374,10 @@ worker must never touch unrelated org work.
 ### Current safety statement
 
 The physical block claim/recheck/recovery sequence is conservative **given correct classification**.
+That statement ends at delete authorization: it does not close X1's in-flight S3 DELETE ABA, and
+the reference check does not close X2's cross-DC visibility gap. Cassandra authorization/claim
+generations alone cannot close X1; new materializations need never-reused generational physical
+keys. Consequently destructive GC remains disabled on every replica/DC.
 The transient-error fail-open existence read (P6a) and execution-time canonical revalidation gap
 (P6b) are fixed. P6b uses durable guard modes, the existing library lock, an O(1) canonical
 point read, and synchronous fences before destructive mutations. P8 tracks Phase 9's provisional
@@ -380,7 +391,7 @@ deleting referenced blocks.
 
 ## Test Coverage Assessment
 
-### Coverage snapshot (historical counts; re-run before using as a release gate)
+### Coverage snapshot (historical, non-production counts; re-run before using as a release gate)
 
 > These counts were recorded in the original 2026-04 audit and are not a current inventory.
 > The 2026-07 audit added P6 fault-injection coverage (done: `TestScanner_ScanOrphaned*_FailClosedOn*Error`)
@@ -439,14 +450,16 @@ Tests are in `internal/integration/gc_integration_test.go` (core) and
 `internal/integration/gc_soak_test.go` (soak). Run independently with:
 
 ```bash
-# Core GC tests only (7 tests, ~20s)
+# Core GC tests
 go test -tags integration -v -run "TestGC_" -timeout 10m ./internal/integration/...
 
 # Soak test (default 5 min, configure with GC_SOAK_DURATION)
 go test -tags 'integration gcsoak' -v -run "TestGC_Soak" -timeout 30m ./internal/integration/...
 ```
 
-### Implemented tests
+### Selected foundational tests
+
+This is a representative historical list, not the complete current `TestGC_` inventory.
 
 | # | Test | File | Status | Run time |
 |---|------|------|--------|----------|
@@ -481,9 +494,10 @@ one → the other ref remains → no destructive candidate wins → second file 
 Validates that shared
 blocks are never deleted while referenced.
 
-**Test 3 — Concurrent upload during GC:** Delete file → re-upload same content → trigger
-GC → LWT guard prevents deletion → re-uploaded file intact. Validates the core safety
-mechanism against real Cassandra LWT behavior (not mocks).
+**Historical non-production Test 3 — Concurrent upload during GC:** Delete file → re-upload
+same content → trigger GC → LWT guard prevents deletion → re-uploaded file intact. This validates
+the observed Cassandra LWT path (not mocks), but does not reproduce X1's delayed in-flight S3
+DELETE ABA or X2's multi-DC visibility gap and is not a production activation gate.
 
 **Test 4 — Library cascade:** Upload files → soft-delete library → trigger scanner
 (finds expired library) → trigger worker (cascades through commits, fs_objects, blocks).
@@ -549,7 +563,8 @@ For a deployment with millions of blocks, this may not keep up with deletion rat
 **Scaling recommendations:**
 - Increase `batch_size` (e.g., 500) for faster processing
 - Reduce `worker_interval` (e.g., 10s) for more frequent ticks
-- For multi-node: only one node should run GC (no leader election exists yet)
+- Production: keep GC disabled on every node/DC while X1/X2 remain open. After both
+  close, designated replicas in one DC may participate under the existing LWT lease.
 
 ---
 
@@ -557,9 +572,9 @@ For a deployment with millions of blocks, this may not keep up with deletion rat
 
 | Aspect | Rating | Notes |
 |--------|--------|-------|
-| **Safety mechanisms** | Excellent | LWT, grace period, idempotency, locks, scanner safety net |
+| **Safety mechanisms** | Production-blocked | LWT, grace period, idempotency, locks, and scanner safety nets exist; X1/X2 still block destructive GC |
 | **Cascade correctness** | Good | Ordering is correct; partial failure handling could improve |
-| **Test coverage** | Good | 107 unit + 4 integration; key gaps in S3 failure and concurrent access |
+| **Test coverage** | Good | Unit, race, and Docker integration suites cover the GC lifecycle; failure and concurrency coverage should continue expanding |
 | **Error handling** | Adequate | Retries with cap; S3 orphan is the main gap |
 | **Performance** | Adequate | 12K items/hour; may need tuning for large deployments |
 | **Monitoring** | Basic | Prometheus metrics exist; alerting rules not defined |

--- a/docs/GC-UPLOAD-FENCE-PR-PLAN.md
+++ b/docs/GC-UPLOAD-FENCE-PR-PLAN.md
@@ -3,7 +3,8 @@
 **Date:** 2026-07-21
 **Research branch:** `docs/gc-upload-fence-rematerialization` — **not for merge**
 **Status:** PR-1 merged as [#137](https://github.com/Sesame-Disk/sesamefs/pull/137);
-PR-2 is active on `fix/gc-claim-stub-lifecycle`, with implementation not started.
+PR-2 is implemented and verified on `fix/gc-claim-stub-lifecycle`, pending review
+and merge. F2/X7 remain open on `main` until that merge.
 
 ## Why this document exists
 
@@ -83,11 +84,12 @@ PR a row to close.
 
 **Scope:** `internal/gc/worker.go` (re-referenced stub deleted under its claim rather
 than released), `internal/db/block_references.go` (`DeleteClaimedBlockStub`,
-`DeleteReleasedBlockStub`, `storage_class` invariant on write, and an explicit
+`RepairReleasedBlockStub`, `storage_class` invariant on write, and an explicit
 `RepairableStub` probe decision), `internal/gc/store.go`,
 `internal/gc/store_cassandra.go` and `internal/gc/store_mock.go` (conditional-delete
 contract and adapters), `internal/api/v2/upload_reuse.go` (shared released-stub
-repair), plus the existing probe switches in `internal/api/sync.go`,
+repair), `internal/api/v2/fs_helpers.go` (remove writer-side active-claim release;
+writers must wait/retry or fail closed, never clear GC ownership), plus the existing probe switches in `internal/api/sync.go`,
 `internal/api/seafhttp.go`, `internal/api/v2/files.go` and
 `internal/api/v2/onlyoffice.go`. The metadata-upsert path also provides a race
 backstop for the unprobed web-session path in `internal/api/v2/blocks.go`. Unit/API
@@ -100,9 +102,12 @@ genuinely missing row too, and `BlockReuseProbe` carries no `Found`, `IsStub` or
 claim id to separate them. PR-2 adds `RepairableStub` from the same metadata read.
 `created_at IS NULL` is the lifecycle discriminator; incidental `sha1` or
 `representation_id` backfilled by an earlier failed materialization do not make the
-stub complete. Each funnel conditionally removes the released stub and follows its
-ordinary `NeedsPut` store path only when that CAS applies. Active claims remain
-`BlockedByGC`; unexpected ownership state and failed CAS application fail closed.
+stub complete. Each funnel claims the released stub with a deterministic per-block
+`repairing_stub` token, rechecks `gc_s3_orphans`, removes only that owned repair
+claim, and follows its ordinary `NeedsPut` store path only after the repair succeeds.
+Active claims remain `BlockedByGC`; unexpected ownership state, a new orphan fence,
+and failed CAS application all stop the PUT and retry/fail closed. The deterministic
+token also lets a retry confirm and resume an ambiguously-applied Cassandra LWT.
 This avoids both an unconditional third read and an LWT on every brand-new block —
 see X7.
 
@@ -124,23 +129,28 @@ unreachable behind the probe.
    unowned row with null `created_at` and blank class, check `gc_s3_orphans` before
    returning `RepairableStub`; an observed orphan remains `BlockedByGC`. Do not
    require `sha1` or `representation_id` to be empty on a stub.
-2. Add `db.DeleteReleasedBlockStub(...)(bool, error)`, fenced on null `created_at`,
-   blank/absent canonical class and absent ownership. Add the narrower worker-side
+2. Add `db.RepairReleasedBlockStub(...)(bool, error)`: acquire an upload-owned
+   `repairing_stub` token only from null `created_at`/`storage_class` and absent GC
+   ownership, recheck `gc_s3_orphans`, then delete only that token. This two-LWT
+   shape is required because Cassandra can report a null-only conditional DELETE as
+   applied for an already-absent row. Add the narrower worker-side
    `GCStore.DeleteClaimedBlockStub(...)(bool, error)`, fenced by claim id and the stub
-   lifecycle. Prove the exact null predicates against real Cassandra/Scylla rather
-   than relying only on mocks.
+   lifecycle. Prove all predicates against real Cassandra/Scylla, not only mocks.
 3. Reject whitespace-only `storage_class` before issuing a metadata LWT. When the
    first-writer insert does not apply, make metadata materialization recognize a
-   released stub, delete it conditionally and retry the insert. This is the race
+   released stub, claim/repair it and retry the insert. This is the race
    backstop for a stub appearing after a probe and for the unprobed web-session
    upload path; complete/malformed rows still fail closed.
 4. Extend the GC Store interface, Cassandra adapter and mock. In `processBlock`,
    delete a re-referenced stub under the owned claim instead of releasing it; retain
    the ordinary release behavior for a complete metadata row. A false CAS result is
-   a stale observation and must not be treated as success.
+   a stale observation and must not be treated as success. Remove the writer-side
+   active-claim release in `internal/api/v2/fs_helpers.go`; only the GC owner may
+   release or delete an active claim. Writers wait/retry or fail closed.
 5. Handle `RepairableStub` through one shared helper in all six existing upload probe
-   switches. `applied=true` continues through the exact existing `NeedsPut` branch;
-   `applied=false` or a Cassandra error performs no PUT and returns the existing
+   switches. A completed repair continues through the exact existing `NeedsPut`
+   branch; a lost claim, observed orphan, or Cassandra error performs no PUT and
+   returns the existing
    retryable fence error or fails closed. Do not add a read to the ordinary absent-row
    path and do not import PR-3's new retry sentinels or metrics.
 6. Unit-test the full decision and race matrix: absent row (with/without orphan
@@ -161,8 +171,8 @@ unreachable behind the probe.
    merges. X1/X2 remain open, later-PR behavior stays excluded and destructive GC
    remains disabled.
 
-Planned verification commands (the full integration service retains its built-in
-health waits; do not override its command with a focused test invocation):
+Verification completed 2026-07-21 (the full integration service retains its built-in
+health waits; its command was not overridden):
 
 ```bash
 docker compose --profile test run --rm --build gotest go test -count=1 ./internal/db ./internal/gc ./internal/api/...
@@ -172,6 +182,11 @@ docker compose --profile test run --rm --build gotest go vet ./...
 docker compose --profile test run --rm --build gotest go vet -tags=integration ./...
 docker compose --profile test run --rm --build go-integration-test
 ```
+
+All six commands passed. The first integration run found one stale fixture that set
+only `gc_state='deleting'`; it was corrected to seed the full claim identity and the
+complete integration suite then passed. The race run also exposed an unsynchronized
+test counter in `blocks_test.go`; the counter is now atomic and the rerun passed.
 
 ---
 
@@ -394,8 +409,9 @@ in `UPLOAD-PERFORMANCE-SECURITY-2026-06.md`.
 
 These stay open and keep destructive GC disabled:
 
-- **Physical delete ABA** — `gc_s3_orphans` has no per-lifecycle claim or generation,
-  so an already-authorized key-only S3 delete can run after the visible fence clears.
+- **Physical delete ABA** — an already-authorized key-only S3 delete can run after
+  the visible fence clears. Cassandra authorization/claim generations cannot revoke
+  a DELETE already in flight; only never-reused generational physical keys close X1.
 - **Cross-DC reference visibility** — `block_references` are ordinary `LOCAL_QUORUM`
   writes that `SERIAL` does not cover; with RF 1 per DC the write and read quorums
   need not intersect (`ISSUE-GC-CROSS-DC-REFERENCE-VISIBILITY-01`).

--- a/docs/GC-UPLOAD-FENCE-PR-PLAN.md
+++ b/docs/GC-UPLOAD-FENCE-PR-PLAN.md
@@ -2,7 +2,8 @@
 
 **Date:** 2026-07-21
 **Research branch:** `docs/gc-upload-fence-rematerialization` — **not for merge**
-**Status:** PR-1 is the documentation-only first step; no code PRs are open yet.
+**Status:** PR-1 merged as [#137](https://github.com/Sesame-Disk/sesamefs/pull/137);
+PR-2 is active on `fix/gc-claim-stub-lifecycle`, with implementation not started.
 
 ## Why this document exists
 
@@ -85,19 +86,25 @@ than released), `internal/db/block_references.go` (`DeleteClaimedBlockStub`,
 `DeleteReleasedBlockStub`, `storage_class` invariant on write, and an explicit
 `RepairableStub` probe decision), `internal/gc/store.go`,
 `internal/gc/store_cassandra.go` and `internal/gc/store_mock.go` (conditional-delete
-contract and adapters), plus the existing probe switches in `internal/api/sync.go`,
+contract and adapters), `internal/api/v2/upload_reuse.go` (shared released-stub
+repair), plus the existing probe switches in `internal/api/sync.go`,
 `internal/api/seafhttp.go`, `internal/api/v2/files.go` and
-`internal/api/v2/onlyoffice.go`. Unit tests and a non-skipping production-engine
-lifecycle regression in `internal/integration/gc_integration_test.go` travel with it.
+`internal/api/v2/onlyoffice.go`. The metadata-upsert path also provides a race
+backstop for the unprobed web-session path in `internal/api/v2/blocks.go`. Unit/API
+tests and non-skipping production-engine lifecycle regressions in
+`internal/integration/gc_integration_test.go` travel with it.
 
 **The stub is an explicit store-phase state.** Classifying it as plain `NeedsPut` is not
 enough: `ProbeBlockReuse` returns `NeedsPut` with an empty `StorageClass` for a
 genuinely missing row too, and `BlockReuseProbe` carries no `Found`, `IsStub` or
-claim id to separate them. PR-2 adds `RepairableStub` from the same metadata read;
-each funnel conditionally removes the released metadata-free row, then follows its
-ordinary `NeedsPut` store path. Active claims remain `BlockedByGC` and are handled by
-the worker/materialization fence. This avoids both an unconditional third read and
-an LWT on every brand-new block — see X7.
+claim id to separate them. PR-2 adds `RepairableStub` from the same metadata read.
+`created_at IS NULL` is the lifecycle discriminator; incidental `sha1` or
+`representation_id` backfilled by an earlier failed materialization do not make the
+stub complete. Each funnel conditionally removes the released stub and follows its
+ordinary `NeedsPut` store path only when that CAS applies. Active claims remain
+`BlockedByGC`; unexpected ownership state and failed CAS application fail closed.
+This avoids both an unconditional third read and an LWT on every brand-new block —
+see X7.
 
 **Why first among the code PRs:** it is the only one that fixes a state that can
 permanently break a block id, and it depends on nothing else.
@@ -107,6 +114,64 @@ side, and an upload that meets one succeeds instead of exhausting its retries. U
 tests must drive the real `store -> materialize` loop, not call the repair directly —
 the direct-call tests on the research branch could not catch that the repair was
 unreachable behind the probe.
+
+**Execution checklist:**
+
+1. Extend the existing probe read with `created_at`, `gc_claim_id` and
+   `gc_claimed_at`. Classify in this order: absent row -> existing orphan-fence check,
+   then `NeedsPut`; active deleting owner -> `BlockedByGC`; unexpected/stale ownership
+   -> error; non-null `created_at` plus blank class -> malformed-row error. For an
+   unowned row with null `created_at` and blank class, check `gc_s3_orphans` before
+   returning `RepairableStub`; an observed orphan remains `BlockedByGC`. Do not
+   require `sha1` or `representation_id` to be empty on a stub.
+2. Add `db.DeleteReleasedBlockStub(...)(bool, error)`, fenced on null `created_at`,
+   blank/absent canonical class and absent ownership. Add the narrower worker-side
+   `GCStore.DeleteClaimedBlockStub(...)(bool, error)`, fenced by claim id and the stub
+   lifecycle. Prove the exact null predicates against real Cassandra/Scylla rather
+   than relying only on mocks.
+3. Reject whitespace-only `storage_class` before issuing a metadata LWT. When the
+   first-writer insert does not apply, make metadata materialization recognize a
+   released stub, delete it conditionally and retry the insert. This is the race
+   backstop for a stub appearing after a probe and for the unprobed web-session
+   upload path; complete/malformed rows still fail closed.
+4. Extend the GC Store interface, Cassandra adapter and mock. In `processBlock`,
+   delete a re-referenced stub under the owned claim instead of releasing it; retain
+   the ordinary release behavior for a complete metadata row. A false CAS result is
+   a stale observation and must not be treated as success.
+5. Handle `RepairableStub` through one shared helper in all six existing upload probe
+   switches. `applied=true` continues through the exact existing `NeedsPut` branch;
+   `applied=false` or a Cassandra error performs no PUT and returns the existing
+   retryable fence error or fails closed. Do not add a read to the ordinary absent-row
+   path and do not import PR-3's new retry sentinels or metrics.
+6. Unit-test the full decision and race matrix: absent row (with/without orphan
+   fence), released PK-only and partially identity-backfilled stubs, released stub
+   with an orphan fence (no deletion and no PUT), active stub, complete active row,
+   malformed complete row, stale ownership, both successful deletions, lost CAS with
+   no PUT, worker stub-delete versus complete-row release, all six probe switches,
+   web-session materialization, and pre-LWT class validation. Assert `/blocks/check`
+   and `file_from_blocks` never advertise a stub as reusable.
+7. Keep the engine-observation test, but add deterministic real-Cassandra fixtures
+   using a primary-key-only INSERT for a released stub and explicit ownership columns
+   for an active stub. Verify the rows are visible, prove the conditional CQL, and run
+   a real probe -> repair -> store -> materialize -> reusable lifecycle that cannot
+   skip based on engine behavior.
+8. Run focused unit tests, `go test -race` for affected packages in Docker, build,
+   vet, integration-tag vet, and focused Cassandra integration regressions. Record
+   exact commands/results in the PR, but move only F2 and X7 to closed after PR-2
+   merges. X1/X2 remain open, later-PR behavior stays excluded and destructive GC
+   remains disabled.
+
+Planned verification commands (the full integration service retains its built-in
+health waits; do not override its command with a focused test invocation):
+
+```bash
+docker compose --profile test run --rm --build gotest go test -count=1 ./internal/db ./internal/gc ./internal/api/...
+docker compose --profile test run --rm --build gotest go test -race -count=1 ./internal/db ./internal/gc ./internal/api/...
+docker compose --profile test run --rm --build gotest go build ./...
+docker compose --profile test run --rm --build gotest go vet ./...
+docker compose --profile test run --rm --build gotest go vet -tags=integration ./...
+docker compose --profile test run --rm --build go-integration-test
+```
 
 ---
 
@@ -343,8 +408,9 @@ These stay open and keep destructive GC disabled:
 ## Verification debt carried by the whole series
 
 - `go test -race` has never run: the dev box has no gcc. Must run in Docker before
-  any PR that touches concurrency merges: **PR-3, PR-4, PR-5 and PR-9**. PR-4 in
-  particular introduces the concurrent canonical reader and must not merge without it.
+  any PR that touches concurrency or conditional lifecycle races merges: **PR-2,
+  PR-3, PR-4, PR-5 and PR-9**. PR-4 in particular introduces the concurrent
+  canonical reader and must not merge without it.
 - No end-to-end download tests against real Cassandra exist for the 404/503 contract.
 - No multi-DC test exercises any of the cross-DC reasoning; it is derived from the
   production consistency contract, not from a reproduction. The dedicated

--- a/docs/GC-UPLOAD-FENCE-PR-PLAN.md
+++ b/docs/GC-UPLOAD-FENCE-PR-PLAN.md
@@ -115,9 +115,13 @@ see X7.
 permanently break a block id, and it depends on nothing else.
 
 **Acceptance:** a stub left by a crashed or re-referenced claim is removed by either
-side, and an upload that meets one succeeds instead of exhausting its retries. Unit
-tests must drive the real `store -> materialize` loop, not call the repair directly —
-the direct-call tests on the research branch could not catch that the repair was
+side, and an upload that meets one on any of the six retry-wrapped funnels succeeds
+instead of exhausting its retries. The seventh (web-session) funnel is out of scope
+here: it stays fail-closed and returns `500` on a fence/contended-stub until PR-5
+gives it a re-probing `409` + `Retry-After` alongside the traffic/staging hoist — a
+characterization test pins that boundary so PR-5 must consciously flip it. Unit tests
+must drive the real `store -> materialize` loop, not call the repair directly — the
+direct-call tests on the research branch could not catch that the repair was
 unreachable behind the probe.
 
 **Execution checklist:**
@@ -171,7 +175,8 @@ unreachable behind the probe.
    stay reachable to self-heal a stuck deterministic repair token.
 6. Unit-test the full decision and race matrix: absent row (with/without orphan
    fence), released PK-only and partially identity-backfilled stubs, released stub
-   with an orphan fence (no deletion and no PUT), active stub, complete active row,
+   with an orphan fence (the repair removes its own `repairing_stub` token but leaves
+   the orphan fence intact and performs no PUT), active stub, complete active row,
    malformed complete row, stale ownership, both successful deletions, lost CAS with
    no PUT, worker stub-delete versus complete-row release, all six probe switches,
    web-session materialization, and pre-LWT class validation. Include the retryable

--- a/docs/GC-UPLOAD-FENCE-PR-PLAN.md
+++ b/docs/GC-UPLOAD-FENCE-PR-PLAN.md
@@ -149,17 +149,28 @@ unreachable behind the probe.
    release or delete an active claim. Writers wait/retry or fail closed.
 5. Handle `RepairableStub` through one shared helper in all six existing upload probe
    switches. A completed repair continues through the exact existing `NeedsPut`
-   branch; a lost claim, observed orphan, or Cassandra error performs no PUT and
-   returns the existing
-   retryable fence error or fails closed. Do not add a read to the ordinary absent-row
-   path and do not import PR-3's new retry sentinels or metrics.
+   branch. A **lost CAS or a reappeared orphan fence is a benign concurrency loss,
+   not a hard error**: `RepairReleasedBlockStub` returns `(false, nil)`, the funnel
+   performs no PUT and returns the existing retryable `ErrBlockDeleteInProgress` so
+   the materialization wrapper re-probes and converges to `Reusable` (a concurrent
+   uploader finished) or `BlockedByGC` (GC re-fenced). Only a genuine Cassandra error
+   fails closed as `UnknownError`. The metadata-upsert backstop applies the same rule:
+   a contended stub repair surfaces the `db.ErrBlockStubRepairContended` sentinel,
+   which `RegisterUploadedBlock` translates into the retryable fence signal rather
+   than a 500 — matching the acceptance criterion that meeting a stub succeeds instead
+   of exhausting retries. Do not add a read to the ordinary absent-row path and do not
+   import PR-3's new retry sentinels or metrics. Note: `BlockDeleteFenceActive` is
+   deliberately **not** extended to fence on `repairing_stub` — the upsert path must
+   stay reachable to self-heal a stuck deterministic repair token.
 6. Unit-test the full decision and race matrix: absent row (with/without orphan
    fence), released PK-only and partially identity-backfilled stubs, released stub
    with an orphan fence (no deletion and no PUT), active stub, complete active row,
    malformed complete row, stale ownership, both successful deletions, lost CAS with
    no PUT, worker stub-delete versus complete-row release, all six probe switches,
-   web-session materialization, and pre-LWT class validation. Assert `/blocks/check`
-   and `file_from_blocks` never advertise a stub as reusable.
+   web-session materialization, and pre-LWT class validation. Include the retryable
+   convergence: a lost-CAS repair re-probes and finishes as `Reusable`, and a
+   contended metadata-upsert backstop translates to the retryable fence signal.
+   Assert `/blocks/check` and `file_from_blocks` never advertise a stub as reusable.
 7. Keep the engine-observation test, but add deterministic real-Cassandra fixtures
    using a primary-key-only INSERT for a released stub and explicit ownership columns
    for an active stub. Verify the rows are visible, prove the conditional CQL, and run
@@ -187,6 +198,15 @@ All six commands passed. The first integration run found one stale fixture that 
 only `gc_state='deleting'`; it was corrected to seed the full claim identity and the
 complete integration suite then passed. The race run also exposed an unsynchronized
 test counter in `blocks_test.go`; the counter is now atomic and the rerun passed.
+
+Re-verified 2026-07-21 after reclassifying the benign lost stub-repair race as
+retryable (`RepairReleasedBlockStub` returns `(false, nil)`; the metadata-upsert
+backstop returns `db.ErrBlockStubRepairContended`, which `RegisterUploadedBlock`
+maps to the retryable fence signal). Build, vet, vet -tags=integration,
+`go test -race` for `./internal/db ./internal/gc ./internal/api/...`, and the full
+integration suite were re-run in Docker; the integration suite passed twice
+consecutively (~257–266s each), so the single earlier failure was a one-node-stack
+flake, not a regression.
 
 ---
 

--- a/docs/GC-UPLOAD-FENCE-PR-PLAN.md
+++ b/docs/GC-UPLOAD-FENCE-PR-PLAN.md
@@ -154,11 +154,18 @@ unreachable behind the probe.
    performs no PUT and returns the existing retryable `ErrBlockDeleteInProgress` so
    the materialization wrapper re-probes and converges to `Reusable` (a concurrent
    uploader finished) or `BlockedByGC` (GC re-fenced). Only a genuine Cassandra error
-   fails closed as `UnknownError`. The metadata-upsert backstop applies the same rule:
-   a contended stub repair surfaces the `db.ErrBlockStubRepairContended` sentinel,
-   which `RegisterUploadedBlock` translates into the retryable fence signal rather
-   than a 500 — matching the acceptance criterion that meeting a stub succeeds instead
-   of exhausting retries. Do not add a read to the ordinary absent-row path and do not
+   fails closed as `UnknownError`. The metadata-upsert backstop applies the same rule
+   at the helper boundary: a contended stub repair surfaces the
+   `db.ErrBlockStubRepairContended` sentinel, which `RegisterUploadedBlock` translates
+   into `ErrBlockDeleteInProgress`, so the six funnels wrapped in
+   `RetryUploadedBlockMaterialization` re-probe and converge instead of exhausting
+   retries. The unprobed web-session funnel (`v2/blocks.go UploadBlock`) still surfaces
+   that signal as a `500`: it has no retry wrapper and no `409` mapping yet, which is
+   **PR-5's job** (server `409 block_delete_in_progress` + `Retry-After`, landed with
+   the frontend soft-retry). This is pre-existing — `RegisterUploadedBlock` already
+   returned `ErrBlockDeleteInProgress` on a plain GC fence before PR-2 — so PR-2 only
+   makes the backstop's DB contract correct and does not change the web funnel's HTTP
+   surface. Do not add a read to the ordinary absent-row path and do not
    import PR-3's new retry sentinels or metrics. Note: `BlockDeleteFenceActive` is
    deliberately **not** extended to fence on `repairing_stub` — the upsert path must
    stay reachable to self-heal a stuck deterministic repair token.

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -1,6 +1,6 @@
 # Implementation Status - SesameFS
 
-**Last Updated**: 2026-05-20
+**Last Updated**: 2026-07-21
 
 ---
 
@@ -11,20 +11,20 @@
 | Area | Completeness | Notes |
 |------|--------------|-------|
 | Sync Protocol (Desktop) | ~90% | Functional sync scenarios pass, and the current hardening scope is baseline-verified for active-active HEAD-conflict recovery. Broader scenario coverage remains follow-up test debt. |
-| Core Backend API | ~98% | GC ✅, OIDC ✅, Library Settings ✅, Monitoring ✅, Quotas ✅, Plans/Permissions Phase 1+2 ✅, org storage policy backend base ✅ |
+| Core Backend API | ~98% | GC implementation exists but destructive GC is production-disabled pending X1/X2; OIDC ✅, Library Settings ✅, Monitoring ✅, Quotas ✅, Plans/Permissions Phase 1+2 ✅, org storage policy backend base ✅ |
 | Admin Panels | ~95% | Superadmin ✅, Org Admin ✅, both at parity. Audit logs pending |
 | Frontend UI | ~85% | All 122 modals migrated ✅, File History UI ✅, permission UI (~75% with granular flags), ~51 ModalPortal wrappers to clean up, Phase 3 quota/plan UI in progress |
 | Authentication | ~90% | OIDC Phase 1 complete, JWT revocation hardened (2026-03-31), and user API keys now cover desktop/CLI/automation auth in OIDC-only deployments. Device Flow and service-account flows remain future enhancements. |
-| Production Infrastructure | ✅ ~97% | GC ✅, Monitoring ✅, Health checks ✅, Structured logging ✅, Frontend/Backend separation ✅, Nginx production hardening ✅ |
+| Production Infrastructure | ~95% | Destructive GC blocked by X1/X2; Monitoring ✅, Health checks ✅, Structured logging ✅, Frontend/Backend separation ✅, Nginx production hardening ✅ |
 
 **Production Blockers (verified against code 2026-05-20)**:
 1. ~~OIDC Authentication~~ - ✅ COMPLETE (Phase 1 - Basic Login)
-2. ~~Garbage Collection~~ - ✅ COMPLETE (Queue worker + scanner + admin API)
+2. **Garbage Collection activation** - 🔴 BLOCKED: keep `GC_ENABLED=false` on every replica/DC until X1 physical-delete ABA and X2 cross-DC reference visibility both close
 3. ~~Monitoring/Health Checks~~ - ✅ COMPLETE (slog logging, `/health`, `/ready`, `/metrics`)
 4. ~~Frontend/Backend Separation~~ - ✅ COMPLETE (2026-03-30/31) — separate React/nginx container, bootstrap API, nginx production hardening
 5. ~~Programmatic Auth (PATs)~~ - ✅ COMPLETE — user API keys ship via `/api/v2.1/api-keys/`, and `/api2/auth-token/` now exchanges `email + API key` for desktop/CLI tokens. Device Flow remains optional future work.
 6. ~~Desktop sync active-active conflict recovery~~ - ✅ BASELINE VERIFIED for the current hardening scope. `PUT /seafhttp/repo/:repo_id/commit/HEAD` and `POST /seafhttp/repo/:repo_id/update-branch` now use parent-chain validation, CAS, bounded retry, ancestry-gated server-side auto-merge for safe stale siblings, and `503 + Retry-After` fail-closed responses for unsafe conflicts. `scripts/test-sync-active-active.sh` now proves both the non-overlapping concurrent-write race with observed `parent mismatch` plus `auto-merge`, and the same-path unsafe-conflict path with observed retry-budget `503` while both desktop clients preserve their divergent local edits. Broader scenario coverage remains follow-up test debt rather than a current blocker.
-7. **GC Multi-Instance Safety** - ✅ BASELINE HARDENED — GC now defaults off in YAML, activates explicitly via `GC_ENABLED=true`, and enabled replicas coordinate through a Cassandra LWT lease. Multi-region guidance still remains: enable GC in exactly one DC.
+7. **GC Multi-Instance Coordination** - ✅ Lease implemented, but activation remains 🔴 BLOCKED — the lease coordinates enabled replicas but cannot close X1/X2. Keep `GC_ENABLED=false` on every replica in every DC. Only after both close may designated replicas in one DC participate under the lease.
 8. ~~Quota Period Rollover~~ - ✅ COMPLETE — Period rollover job advances expired org quota periods and keeps monthly traffic enforcement moving
 9. **Production Multi-Region Topology** - ⚠️ PARTIAL — region-aware library selection/read/write routing is implemented and covered by focused integration tests, and org-level create-time residency policy now exists in the backend. The stock production config/compose files still ship as single-region examples, and per-region `classes`, `endpoint_regions`, ingress host preservation, rollout, migration, and frontend policy controls remain operator work.
 
@@ -76,7 +76,7 @@
 | **Search** | ✅ COMPLETE | Mostly stable | ❌ No | 2026-01-22 | Cassandra SASI implementation |
 | **OIDC Authentication** | ✅ COMPLETE | Mostly stable | ❌ No | 2026-04-03 | Phase 1 complete - SSO login working. JWT revocation hardened: revoked JWT tokens now checked against DB on cache miss (prevents re-authentication after logout/deactivation when `OIDC_JWT_SIGNING_KEY` is set). User API keys now cover non-browser auth and `/api2/auth-token/` exchange for desktop/CLI clients. |
 | **OIDC Group/Dept Sync** | ✅ COMPLETE | Mostly stable | ❌ No | 2026-02-02 | Claims extraction, sync on login, full sync mode |
-| **Garbage Collection** | ✅ COMPLETE | Mostly stable | ❌ No | 2026-03-18 | 9 item types (incl. `user_cascade`, `library_cascade`, `org_cascade`), 12 scanner phases, soft-delete cascades for users (7-day grace), libraries (30-day trash), orgs (30-day grace). Full artifact cleanup, atomic group deletion, audit log, health metrics |
+| **Garbage Collection** | 🟡 IMPLEMENTED / PROD DISABLED | Blocked by X1/X2 | ❌ No | 2026-07-21 | Worker/scanner/lease exist, but keep `GC_ENABLED=false` on every replica/DC until physical-delete ABA and cross-DC reference visibility both close. Afterward, only designated replicas in one DC may participate under the lease. |
 | **Admin Panel (Groups/Users)** | ✅ COMPLETE | Mostly stable | ❌ No | 2026-02-02 | 16 admin endpoints + OIDC group/dept sync, 29 tests |
 | **Admin Dashboard KPIs** | ✅ COMPLETE | Mostly stable | ❌ No | 2026-04-02 | Sysadmin and org-admin overview KPIs use real storage, file, active-user, and traffic data. Storage time-series uses `storage_daily_delta` for historical charts. Traffic stats use `traffic_counters` with per-type desglose. Remaining gaps: device counts unavailable, sysadmin license metadata stubbed. |
 | **Admin Library Management** | ✅ COMPLETE | Mostly stable | ❌ No | 2026-02-12 | 12 endpoints in admin.go + seafile-api.js methods + trash libraries |
@@ -497,11 +497,11 @@ These MUST be completed before production deployment:
 - **Provider**: https://t-accounts.sesamedisk.com/openid (test environment)
 - **Remaining (Phase 2-3)**: Org/tenant mapping, role synchronization
 
-### 2. ~~Garbage Collection~~ ✅ COMPLETE (2026-01-30)
-- **Impact**: ~~Storage costs grow forever~~ Now automatically cleaned up
-- **Status**: Fully implemented — queue worker + safety scanner + admin API
+### 2. Garbage Collection — implementation complete, production activation blocked
+- **Impact**: Reclamation is unavailable in production while the safety gate is active
+- **Status**: Worker, scanner, admin API, and LWT lease are implemented. Keep `GC_ENABLED=false` on every replica in every DC until X1/X2 both close; only then may designated replicas in one DC participate under the lease.
 - **Files**: `internal/gc/` — gc.go, queue.go, worker.go, scanner.go, store.go, store_mock.go, store_cassandra.go, gc_hooks.go, gc_adapter.go
-- **Tests**: 88 Go unit tests + 21 bash integration tests
+- **Tests**: Unit, race, and Docker integration coverage exists under `internal/gc/`, `internal/db/`, `internal/api/`, and `internal/integration/`
 - **Admin API**: `GET /api/v2.1/admin/gc/status`, `POST /api/v2.1/admin/gc/run`
 
 ### 3. ~~Monitoring/Health Checks~~ ✅ COMPLETE (2026-01-30)
@@ -585,7 +585,7 @@ These MUST be completed before production deployment:
 
 ## Metrics
 
-**Last Updated**: 2026-05-20
+**Last Updated**: 2026-07-21
 
 | Metric | Value | Notes |
 |--------|-------|-------|
@@ -607,8 +607,8 @@ These MUST be completed before production deployment:
 - ❌ TODO: ~2 components (audit logs, monitored-repos)
 
 **Production Readiness**:
-- Backend: ~98% for web/API surfaces (core auth blocker complete, both admin panels implemented; GC multi-instance safety still needs a real distributed lease beyond the temporary `GC_ENABLED` guard)
+- Backend: ~98% for web/API surfaces, but destructive GC is production-disabled pending X1/X2. The distributed lease exists; it coordinates designated participants only after both blockers close.
 - Desktop sync: not yet ready to call fully production-safe for active-active multi-node deployments until HEAD-conflict recovery is explicitly proven or hardened
 - Frontend: ~85% (modals done, granular permission flags enforced, missing: some permission UI edge cases, ~51 ModalPortal wrapper cleanup)
-- Infrastructure: ~95% (monitoring ✅, health checks ✅, GC ✅)
+- Infrastructure: ~95% (monitoring ✅, health checks ✅, GC implementation present but production activation blocked by X1/X2)
 - Documentation: ~85% (deployment, migration, testing, API, architecture, and feature docs exist; missing: end-user guides and operational admin runbooks)

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -51,7 +51,7 @@ This document tracks all known bugs, limitations, and issues in SesameFS.
 | **`blocks` Hot Partition by `org_id`** | ✅ Fixed (2026-05-26) | `blocks`, `gc_block_candidates`, `gc_s3_orphans`, and the block-id mapping tables now use per-block partitioning so no single org concentrates LWT traffic into one Cassandra partition. The GC scan and S3 orphan recovery paths walk per-day discovery projections instead of partition-scanning by org. See ISSUE-BLOCKS-HOT-PARTITION-01 below. |
 | **Soft-deleted Libraries Still Accept Star Mutations** | 🟡 Pending | `StarFile` still treats a library as live if the canonical row exists, even when `deleted_at` is set. That leaves a real post-soft-delete write window and can reopen cleanup drift during library cascade. See ISSUE-LIB-DELETED-FENCE-01 below. |
 | **Upload S3 PUT Serialized by Metadata Permit** | ✅ Fixed (2026-06-15) | `finalizeUploadBlockMetadataConcurrency = 1` was acquired around the full S3 block PUT, not just the Cassandra LWT. Fixed in `fix/upload-permit-unwrap-s3-put`. See ISSUE-UPLOAD-S3-PERMIT-01 below and `docs/UPLOAD-PERFORMANCE-SECURITY-2026-06.md`. |
-| **Double S3 RTT Per Block (Exists + PUT)** | ✅ Fixed for hot upload paths (2026-06-15) | S3 HEAD replaced by a Cassandra `ProbeBlockReuse` (reuse / direct-PUT / GC-fence) on the five server-side upload paths. NOT global: legacy `BlockStore` Exists+PUT methods remain for fallback + unmigrated callers, and the reuse path keeps a canonical-verify HEAD. Fixed in `perf/p2-cassandra-first-hot-reuse`. See ISSUE-UPLOAD-S3-DOUBLE-RTT-01 below and `docs/UPLOAD-PERFORMANCE-SECURITY-2026-06.md`. |
+| **Double S3 RTT Per Block (Exists + PUT)** | ✅ Fixed for hot upload paths (2026-06-15) | S3 HEAD replaced by a Cassandra `ProbeBlockReuse` (reuse / direct-PUT / GC-fence) on six server-side upload funnels. NOT global: legacy `BlockStore` Exists+PUT methods remain for unmigrated callers, and the reuse path keeps a canonical-verify HEAD. Fixed in `perf/p2-cassandra-first-hot-reuse`. See ISSUE-UPLOAD-S3-DOUBLE-RTT-01 below and `docs/UPLOAD-PERFORMANCE-SECURITY-2026-06.md`. |
 | **Read Paths Ignore `storage_key`** | ✅ Fixed by derived-key invariant | Reads, reuse/repair, normal GC delete, and orphan recovery derive the deterministic org-scoped key; reuse fails closed if a non-empty `storage_key` differs. The column is not an arbitrary locator, so non-derived layouts remain unsupported. See ISSUE-BLOCK-STORAGE-KEY-READS-01 below. |
 | **Chunked Upload Chunk State Is Node-Local** | 🟡 Pending — multi-node blocker | `chunkManager` stores upload state in a process-global in-memory map + temp files in `os.TempDir()`. Upload tokens are Cassandra-backed and multi-node safe; chunk state is not. Requires sticky sessions at LB or distributed chunk state. See ISSUE-UPLOAD-CHUNK-MULTINODE-01 below. |
 
@@ -930,9 +930,9 @@ and the `gc_s3_orphans` fence to return one of:
   exists (HEAD on the declared key) and repair it (direct PUT) only if missing
 - `BlockReuseNeedsPut` → `PutBlockAutoDirect` (direct PUT, no HEAD)
 - `BlockReuseBlockedByGC` → `ErrBlockDeleteInProgress` (retry/back-off)
-- `BlockReuseUnknownError` → fall open to the legacy Exists+PUT path
+- `BlockReuseUnknownError` → fail closed before S3 PUT
 
-Wired into all five upload paths. New blocks now pay ≤2 Cassandra reads (~1 ms each)
+Wired into all six upload funnels. New blocks now pay ≤2 Cassandra reads (~1 ms each)
 + 1 direct PUT, **no HEAD**; dedup hits pay 3 Cassandra reads + 1 canonical-verify
 HEAD (+ a repair PUT only when the object is actually missing).
 
@@ -942,8 +942,8 @@ This is fixed for the *server-side hot upload paths*, not across the whole repo:
 
 - The `BlockStore` methods `PutBlockAuto` / `PutBlock` / `PutBlockData`
   (`internal/storage/blocks.go`) still do `Exists` + `PutAuto`. They remain in use
-  as the probe-error fallback inside the migrated paths and by unmigrated callers
-  such as the `v2/blocks.go` `UploadBlock` handler (its own HEAD + `PutBlockData`).
+  by unmigrated callers such as the `v2/blocks.go` `UploadBlock` handler (its own
+  HEAD + `PutBlockData`); migrated funnels fail closed on probe errors.
 - The `Reusable` path does not skip S3: `EnsureReusableBlockPresent` adds a targeted
   HEAD on the canonical key (with repair-on-miss) so the upload never publishes a
   reference to a physically-missing object. This is a deliberate safety/perf trade —
@@ -955,10 +955,12 @@ GC-race safety derives from the *reference-first, then fence-check* protocol in
 `FSHelper.RegisterUploadedBlock` (`fs_helpers.go:1006–1034`) versus GC's
 *claim-then-verify-references* in `worker.go:processBlock` (L410–443) — a
 Dekker-style mutual flagging — not from the S3 PUT. The `gc_s3_orphans` fence is
-written before the S3 `DeleteObject` and cleared only after it, so any in-flight
-delete is always visible to both the probe and the materialize step. The probe is
-an optimization that fails safe in every non-reusable direction. The canonical
-verify/repair on the reuse path is an extra physical guarantee on top of this.
+written before the S3 `DeleteObject`, so probes can observe the normal in-flight
+delete window. This does **not** close X1: after a recoverer clears Cassandra state,
+an already-issued S3 DELETE can still arrive late, and Cassandra claim generations
+cannot revoke it. Only never-reused generational physical keys close that ABA. The
+canonical verify/repair on the reuse path is an additional check, not permission to
+enable destructive GC.
 
 The materialization retry loop (`retrySeafHTTPBlockMaterialization` and
 `v2.RetryUploadedBlockMaterialization`) now also retries when the `store` phase
@@ -1759,8 +1761,10 @@ An S3 delete already authorized for `blocks/<org>/<hash>` can complete after its
 visible Cassandra fence clears and after a writer stores byte-identical content at
 the same key. Content addressing makes ETag/value comparison unable to distinguish
 the old lifecycle from the new one. Claim-stub repair does not close this in-flight
-physical-delete ABA. Keep destructive GC disabled until the physical key or delete
-authorization carries a lifecycle generation that a stale delete cannot target.
+physical-delete ABA. Cassandra authorization generations or claim generations alone
+cannot revoke an S3 DELETE already in flight. X1 closes only when new bytes use
+never-reused generational physical keys, so a stale delete can target only the old
+key. Keep destructive GC disabled until that physical-key invariant is implemented.
 Design analysis: `UPLOAD-FENCE-FINDINGS-REGISTRY.md` X1.
 
 ---
@@ -1801,13 +1805,13 @@ PUT or a sweeper with a safe ownership proof. Tracking:
 
 ### ISSUE-GC-MULTIINSTANCE-01: Multi-instance GC coordination and split-brain hardening
 
-**Status**: 🟡 Pending with temporary prod workaround
+**Status**: 🟡 Lease implemented; destructive activation blocked independently by X1/X2
 **Discovered**: 2026-03-17
 **Priority**: 🟡 High — required before scaling to multiple replicas
 **Affected**: `internal/gc/worker.go`, `internal/gc/scanner.go`, `internal/gc/gc.go`
 
-**Problem:**
-The GC (worker + scanner) has no coordination mechanism between instances. If multiple server replicas are running, all of them execute the worker and scanner in parallel, causing:
+**Original problem (now coordinated by `gc_leases`):**
+Before the LWT lease, multiple server replicas could execute worker and scanner work in parallel, causing:
 
 1. **DequeueBatch without locking**: `SELECT ... LIMIT ?` returns the same items to all instances. Both process the same items simultaneously.
 2. **Scanner without leader election**: Multiple scanners enqueue the same orphans as duplicates (the PK includes `queued_at = time.Now()`, so each INSERT creates a distinct row).
@@ -1824,10 +1828,10 @@ the independent physical-delete ABA and cross-DC visibility blockers above:
 incorrect admin counters. This statement does not close or downgrade the independent
 destructive-GC blockers above.
 
-**Current operational decision (updated 2026-04-14):**
-- Keep `gc.enabled=false` in YAML and set `GC_ENABLED=true` only on the replicas that are allowed to run GC.
-- SesameFS now uses a Cassandra LWT lease (`gc_leases`) so if more than one enabled replica is up, only one runs worker/scanner/rollover work at a time.
-- In multi-region, still enable GC in exactly one DC. The lease protects overlap; it does not remove the cross-DC Paxos cost of competing leaders.
+**Current operational decision (updated 2026-07-21):**
+- Keep `gc.enabled=false` and `GC_ENABLED=false` on every replica in every DC while X1 or X2 remains open.
+- The Cassandra LWT lease (`gc_leases`) coordinates participants but does not close either blocker and is not permission to enable GC.
+- Only after both X1 and X2 close may designated replicas in one DC set `GC_ENABLED=true` and participate under the lease. Every replica in every other DC remains false.
 
 **Leader Election via LWT:**
 - Implemented with `gc_leases` and TTL-backed heartbeats.
@@ -1835,16 +1839,16 @@ destructive-GC blockers above.
 - If the leader dies or loses its lease, another enabled replica can take over automatically after lease expiry.
 
 **Recommended future direction:**
-- Keep the explicit `GC_ENABLED=true` activation model so GC stays opt-in by replica.
+- After X1/X2 close, keep the explicit `GC_ENABLED=true` activation model so only designated replicas in one DC opt in.
 - Consider exposing lease state/owner in admin status if operators want clearer observability during failover drills.
 
-**Multi-region deployment note (2026-04-10):**
-Running GC in a single DC is **critical** for multi-region deployments with Cassandra replication. Even though LWT operations use `SERIAL` consistency (global Paxos) by default, running GC on multiple DCs would cause:
+**Multi-region deployment note (updated 2026-07-21):**
+While X1/X2 remain open, running GC in even one DC is unsafe: keep it disabled in all DCs. After both close, restricting participants to a single DC is **critical**. Even though LWT operations use `SERIAL` consistency (global Paxos) by default, running GC on multiple DCs would cause:
 - `DequeueBatch` (non-LWT SELECT) returning the same items to workers in different DCs
 - Scanner in both DCs enqueueing duplicate orphans
 - Unnecessary cross-DC Paxos contention on every LWT
 
-The existing `GC_ENABLED=true` on exactly one DC / `GC_ENABLED=false` on all others remains the correct topology for multi-region. The lease now provides automatic failover among enabled replicas, but you should still avoid enabling GC in multiple DCs at once.
+Post-X1/X2 topology is `GC_ENABLED=true` only on designated replicas in one DC and `GC_ENABLED=false` everywhere else. Until both close, the topology is `GC_ENABLED=false` everywhere. The lease provides failover only among designated replicas in that one DC.
 
 Block-level conditional operations include first-writer metadata creation, GC claim,
 claim release/finalize, and orphan lifecycle transitions; production defaults these
@@ -4069,11 +4073,12 @@ canonical presence is expected.
 
 Per project posture (pre-production, empty server, no legacy-data preservation) there is no
 production orphan backlog to inherit, and the stop-the-world GC upgrade (see `docs/DEPLOY.md`)
-plus a queue/DLQ drain before re-enabling GC removes any transient rows.
+plus a queue/DLQ drain removes any transient rows. Re-enabling remains prohibited
+while X1/X2 are open; after both close, the backlog preflight is an additional gate.
 
 #### Options if a real backlog ever exists
 
-- A fail-closed preflight that refuses to re-enable GC while commit/fs_object rows exist with
+- After X1/X2 close, a fail-closed preflight that also refuses activation while commit/fs_object rows exist with
   `library_guard_mode IS NULL AND requires_library_deleted_check=false`.
 - A `legacy_unclassified` mode that is quarantined (never auto-executed) for operator triage.
 - A `work_source` / `queue_protocol_version` column so this ambiguity cannot recur.
@@ -4210,10 +4215,10 @@ genuinely open rather than brownfield-only.
 
 #### Problem
 
-The integration suite runs against a **shared** dev keyspace and MinIO bucket with no global
+**Historical non-production observation:** the integration suite ran against a **shared** dev keyspace and MinIO bucket with no global
 truncate/teardown; cleanup is only by ephemeral library name. Confirmed residue/interference:
 
-1. `TestMain` does not start/own the external `Service`, but the dev backend has GC enabled and
+1. `TestMain` did not start/own the external `Service`, but the dev backend had GC enabled and
    normal tests call global `/api/v2.1/admin/gc/run`; therefore "nothing drains" is false.
 2. `TestAdminIdentityProjectionRegression_HardDeleteOrganization` constructs a worker with
    `storage=nil` and calls global `ProcessOnce()`

--- a/docs/TECHNICAL-DEBT.md
+++ b/docs/TECHNICAL-DEBT.md
@@ -268,7 +268,7 @@ reusable / needs-put / blocked-by-GC / unknown-error. Needs-put blocks use
 `PutBlockAutoDirect` (no HEAD); reusable blocks run `EnsureReusableBlockPresent`
 (verify the canonical object via HEAD on the declared key, repair via direct PUT
 only if missing); blocked-by-GC returns `ErrBlockDeleteInProgress` to retry;
-unknown-error falls open to the legacy Exists+PUT. Wired into all five upload paths
+unknown-error fails closed before S3 PUT. Wired into all six upload funnels
 (`seafhttp.go` ×2, `sync.go`, `files.go` ×2, `onlyoffice.go`). Per-block cost: a
 new block now pays ≤2 Cassandra reads (~1 ms each) + 1 direct PUT and no HEAD;
 dedup hits keep one canonical-verify HEAD. Safety is unchanged — it rests on the
@@ -278,8 +278,8 @@ also retries `ErrBlockDeleteInProgress` from the `store` phase.
 
 **Scope (not global):** this fixes the server-side hot upload paths only. The
 `BlockStore` methods `PutBlockAuto` / `PutBlock` / `PutBlockData` still do
-`Exists` + `PutAuto` and remain in use as the probe-error fallback and by
-unmigrated callers (e.g. `v2/blocks.go` `UploadBlock`). The HEAD was not removed
+`Exists` + `PutAuto` and remain in use by unmigrated callers (e.g.
+`v2/blocks.go` `UploadBlock`). The HEAD was not removed
 from `BlockStore` globally.
 
 Tests: `ProbeBlockReuse` decision matrix (`block_references_test.go`),

--- a/docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md
+++ b/docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md
@@ -4,7 +4,8 @@
 **Origin:** eight successive audits of the GC upload-fence work, 2026-07-20/21.
 **Companion:** [GC-UPLOAD-FENCE-PR-PLAN.md](./GC-UPLOAD-FENCE-PR-PLAN.md) — which PR closes what.
 **Series progress:** PR-1 merged as [#137](https://github.com/Sesame-Disk/sesamefs/pull/137);
-PR-2 is active on `fix/gc-claim-stub-lifecycle`. No finding is closed by PR-2 yet.
+PR-2 is implemented and verified on `fix/gc-claim-stub-lifecycle`, pending review
+and merge. No finding is closed by PR-2 on `main` yet.
 
 Every row is verified against code at the cited location, except where the row
 explicitly identifies engine-dependent behavior that still needs a non-skipping
@@ -55,15 +56,19 @@ X1-X3, X5 and X6 are not closed by the immediate code PRs; X4 is deferred to PR-
 X7 is a design constraint that PR-2 must close without adding hot-path cost.
 Destructive GC stays disabled until X1 and X2 are resolved.
 
+PR-2 also removes writer-side active-claim release from `internal/api/v2/fs_helpers.go`.
+Only the GC owner may release or delete an active claim; writers must wait/retry or
+fail closed. This is part of F2's lifecycle fix, not deferred to PR-3.
+
 | # | Severity | Finding | Tracked as |
 |---|---|---|---|
-| X1 | Blocker | **Physical delete ABA.** `gc_s3_orphans` has no per-lifecycle claim or generation, so a previously authorized key-only S3 delete can still run after the visible orphan fence clears and after a re-upload has stored new bytes. Rematerialization does not fence it. | `ISSUE-GC-UPLOAD-FENCE-REMATERIALIZATION-01` |
+| X1 | Blocker | **Physical delete ABA.** A previously authorized key-only S3 delete can still run after the visible orphan fence clears and after a re-upload has stored new bytes. Rematerialization does not fence it. Cassandra authorization/claim generations alone cannot revoke a DELETE already in flight; X1 closes only with never-reused generational physical keys, so stale deletes can target only old keys. | `ISSUE-GC-UPLOAD-FENCE-REMATERIALIZATION-01` |
 | X2 | Blocker (multi-DC) | **Cross-DC reference visibility.** `block_references` are ordinary `LOCAL_QUORUM` writes that `SERIAL` does not cover. With RF 1 per DC the write and read quorums need not intersect, so GC in one DC can read zero references for a block that is live in another. The 1h grace period is mitigation, not a bound. | `ISSUE-GC-CROSS-DC-REFERENCE-VISIBILITY-01` |
 | X3 | Medium | **PUT precedes durable physical-object intent.** Upload paths write to S3 before recording GC-discoverable block metadata/reference or another durable row that identifies the physical object for reclamation. Session-mode staged accounting can already exist, but it does not close this discovery gap. A crash between PUT and registration leaves an object nothing can discover safely. Closing it needs durable physical-object intent before the PUT, or a safe physical sweeper. | `ISSUE-UPLOAD-PUT-BEFORE-INTENT-01` |
 | X4 | High (perf) | **One global Paxos round per block on every metadata-registering upload path.** The first-writer `INSERT ... IF NOT EXISTS` is a per-block LWT; under production `SERIAL` and multi-DC it is a global consensus round, ~128 cross-region rounds per GB at the 8 MB block size. **Correction:** an earlier revision said the legacy resumable path "does not pay this at all". That is false — `finalizeUploadStreaming` splits the file into 8 MB blocks and calls `RegisterUploadedBlock` → `UpsertBlockMetadata` per block, so resumable pays the same ~128 LWTs. The defective no-session path in F8 is the exception: it leaves only an S3 object and never registers metadata. This is a **shared** cost of the governed upload paths, not a block-upload disadvantage, and removing it benefits all of them. `main` also reads the `blocks` row twice per upload (`ProbeBlockReuse`, `BlockDeleteFenceActive`), **but those two are not redundant and must not be merged**: the probe reads before the PUT, the fence reads after the provisional reference is durable, and that ordering is the mutual exclusion the protocol depends on. Reusing the pre-PUT observation to authorize publication reintroduces F1. Only the LWT is removable here. **Pre-existing since `e3883aa5d` (2026-05-28)** — not introduced by this work; `13e01263a` only made it representation-aware. | P-4 in `UPLOAD-PERFORMANCE-SECURITY-2026-06.md`; PR-11 (deferred) |
 | X5 | Medium | **Canonical read fan-out unvalidated.** One Cassandra point read per unique block before the first byte. The existing benchmark substitutes an in-memory function for Cassandra, so it measures goroutines and allocations, not driver, pool, latency or cluster load. | `WEB-BLOCK-UPLOAD.md` pre-flag checklist |
 | X6 | Medium | **Read-after-write across DCs.** Canonical lookups retry a missing row 3×25 ms, which covers local lag but not cross-DC. Safe (fails closed) but an availability dependency: transient 404/503 after a remote upload, `check-blocks` reporting a block missing, needless re-uploads. | same as X2 |
-| X7 | Medium (perf) | **The research prototype adds a third unconditional read of the `blocks` row.** On `main` the stub-repair read (`GetBlockDeleteClaimInfo`) only fires when the delete fence is active. The research prototype calls `removeStaleUploadedBlockDeleteStub` on the unfenced path too, so every block upload pays an extra point read. **The obvious shortcut does not work:** an earlier revision proposed keying repair off "`NeedsPut` with an empty `StorageClass`", but a genuinely missing row has that same result. PR-2 will expose `RepairableStub` from the existing probe read, require a successful released-stub CAS before PUT, and add an unapplied-metadata-LWT repair backstop for the unprobed web-session path and probe/delete races. An absent row incurs neither the repair read nor repair LWT. | research branch `fs_helpers.go` `RegisterUploadedBlock`; `db.BlockReuseProbe`; PR-2 |
+| X7 | Medium (perf) | **The research prototype adds a third unconditional read of the `blocks` row.** On `main` the stub-repair read (`GetBlockDeleteClaimInfo`) only fires when the delete fence is active. The research prototype calls `removeStaleUploadedBlockDeleteStub` on the unfenced path too, so every block upload pays an extra point read. **The obvious shortcut does not work:** an earlier revision proposed keying repair off "`NeedsPut` with an empty `StorageClass`", but a genuinely missing row has that same result. PR-2 exposes `RepairableStub` from the existing probe read, acquires an upload-owned `repairing_stub` token, rechecks the orphan fence, and adds an unapplied-metadata-LWT repair backstop for the unprobed web-session path and probe/delete races. An absent first-writer row still incurs neither an extra read nor repair LWT. | research branch `fs_helpers.go` `RegisterUploadedBlock`; `db.BlockReuseProbe`; PR-2 |
 
 ## X1 design space — closing the physical-delete ABA
 
@@ -105,7 +110,8 @@ Candidate directions, none yet designed:
 2. **Per-lifecycle claim/generation on `gc_s3_orphans`.** The minimum needed to stop
    two recoverers acting on the same lifecycle. Necessary regardless of what else is
    chosen and probably the first increment, but it does **not** close the in-flight
-   case: Cassandra cannot revoke an S3 request already on the wire.
+   case and therefore cannot close X1: Cassandra cannot revoke an S3 request already
+   on the wire. Only never-reused generational physical keys close that ABA.
 3. **Fencing token with a bounded authorization window.** The recoverer's delete is
    valid only while its claim is unexpired, and writers refuse to publish until any
    outstanding claim has expired. Bounds the window rather than eliminating it; only
@@ -142,9 +148,9 @@ cluster. Destructive GC stays disabled until one lands.
 
 Applies to every PR in the series, not to any single finding.
 
-- **`go test -race` has never run.** The Windows dev box has no gcc. It must run in
-  Docker before PR-2, PR-3, PR-4, PR-5 and PR-9 merge — those change conditional
-  lifecycle races, goroutine behavior or channel semantics.
+- **PR-2 race validation passed in Docker on 2026-07-21.** PR-3, PR-4, PR-5 and
+  PR-9 must still run their own `go test -race` validation because they change
+  separate goroutine/channel or lifecycle behavior.
 - **No end-to-end download tests against real Cassandra** exist for the 404/503
   contract (F5, F13). The unit tests cover the classifier, not the handler.
 - **No multi-DC test** exercises X2 or X6. Both are reasoned from the production

--- a/docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md
+++ b/docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md
@@ -3,6 +3,8 @@
 **Date:** 2026-07-21
 **Origin:** eight successive audits of the GC upload-fence work, 2026-07-20/21.
 **Companion:** [GC-UPLOAD-FENCE-PR-PLAN.md](./GC-UPLOAD-FENCE-PR-PLAN.md) — which PR closes what.
+**Series progress:** PR-1 merged as [#137](https://github.com/Sesame-Disk/sesamefs/pull/137);
+PR-2 is active on `fix/gc-claim-stub-lifecycle`. No finding is closed by PR-2 yet.
 
 Every row is verified against code at the cited location, except where the row
 explicitly identifies engine-dependent behavior that still needs a non-skipping
@@ -47,10 +49,11 @@ out here so the decision is visible rather than implicit.
 | F13 | High | **Corrupt directory listings resolve, and 404/503 semantics are inverted for a deleted path.** High, not the Low it was first filed as: two of the cases below serve bytes from the wrong FS object. Not Blocker only because it needs an already-corrupt dirent — see the severity note above. The 404/503 half on its own would be Low. `findEntryInDir` returns a plain error, so a renamed or deleted file surfaces as 503 while an absent commit row gives 404. Related, and worse: a JSON-valid but corrupt listing resolves anyway. Structural cases (`null`, `[null]`, non-string name, missing id) parse and the bad entries are skipped, reporting a false absence; semantic cases (empty name, empty or non-40-hex id, duplicate names) resolve to a wrong or missing FS object; and `encoding/json` silently keeps the **last** value for a repeated key, so `{"id":"A","id":"B"}` serves B and `{"name":"a","name":"b"}` hides `a` entirely. Both of the last two can serve arbitrary bytes or report a present file as absent. | `seafhttp.go` `findEntryInDir` | PR-6 |
 | F14 | Low | **Retry metric mislabels write failures.** The SeafHTTP wrapper defaults every non-fence retry to `reason="probe"`, attributing Cassandra write errors to the read path. | `seafhttp.go` retry wrapper | PR-3 |
 
-## Open and out of scope for this series
+## Open, deferred, or constraining the series
 
-These are **not** closed by any PR in the plan. Destructive GC stays disabled until
-the first two are resolved.
+X1-X3, X5 and X6 are not closed by the immediate code PRs; X4 is deferred to PR-11;
+X7 is a design constraint that PR-2 must close without adding hot-path cost.
+Destructive GC stays disabled until X1 and X2 are resolved.
 
 | # | Severity | Finding | Tracked as |
 |---|---|---|---|
@@ -60,7 +63,7 @@ the first two are resolved.
 | X4 | High (perf) | **One global Paxos round per block on every metadata-registering upload path.** The first-writer `INSERT ... IF NOT EXISTS` is a per-block LWT; under production `SERIAL` and multi-DC it is a global consensus round, ~128 cross-region rounds per GB at the 8 MB block size. **Correction:** an earlier revision said the legacy resumable path "does not pay this at all". That is false — `finalizeUploadStreaming` splits the file into 8 MB blocks and calls `RegisterUploadedBlock` → `UpsertBlockMetadata` per block, so resumable pays the same ~128 LWTs. The defective no-session path in F8 is the exception: it leaves only an S3 object and never registers metadata. This is a **shared** cost of the governed upload paths, not a block-upload disadvantage, and removing it benefits all of them. `main` also reads the `blocks` row twice per upload (`ProbeBlockReuse`, `BlockDeleteFenceActive`), **but those two are not redundant and must not be merged**: the probe reads before the PUT, the fence reads after the provisional reference is durable, and that ordering is the mutual exclusion the protocol depends on. Reusing the pre-PUT observation to authorize publication reintroduces F1. Only the LWT is removable here. **Pre-existing since `e3883aa5d` (2026-05-28)** — not introduced by this work; `13e01263a` only made it representation-aware. | P-4 in `UPLOAD-PERFORMANCE-SECURITY-2026-06.md`; PR-11 (deferred) |
 | X5 | Medium | **Canonical read fan-out unvalidated.** One Cassandra point read per unique block before the first byte. The existing benchmark substitutes an in-memory function for Cassandra, so it measures goroutines and allocations, not driver, pool, latency or cluster load. | `WEB-BLOCK-UPLOAD.md` pre-flag checklist |
 | X6 | Medium | **Read-after-write across DCs.** Canonical lookups retry a missing row 3×25 ms, which covers local lag but not cross-DC. Safe (fails closed) but an availability dependency: transient 404/503 after a remote upload, `check-blocks` reporting a block missing, needless re-uploads. | same as X2 |
-| X7 | Medium (perf) | **The research prototype adds a third unconditional read of the `blocks` row.** On `main` the stub-repair read (`GetBlockDeleteClaimInfo`) only fires when the delete fence is active. The research prototype calls `removeStaleUploadedBlockDeleteStub` on the unfenced path too, so every block upload pays an extra point read. **The obvious shortcut does not work:** an earlier revision of this row proposed keying the repair off "`NeedsPut` with an empty `StorageClass`", but `ProbeBlockReuse` returns exactly that for a genuinely missing row *and* for a stub, and `BlockReuseProbe` carries no `Found`, `IsStub` or claim id to tell them apart. Driving a conditional delete off that signal would fire an LWT on **every brand-new block upload** — trading one extra read for one extra Paxos round, which is strictly worse and is precisely the cost X4 is about. PR-2 will instead expose `RepairableStub` from the existing probe read; each upload funnel will conditionally delete that released stub before following its ordinary `NeedsPut` store path. | research branch `fs_helpers.go` `RegisterUploadedBlock`; `db.BlockReuseProbe`; PR-2 |
+| X7 | Medium (perf) | **The research prototype adds a third unconditional read of the `blocks` row.** On `main` the stub-repair read (`GetBlockDeleteClaimInfo`) only fires when the delete fence is active. The research prototype calls `removeStaleUploadedBlockDeleteStub` on the unfenced path too, so every block upload pays an extra point read. **The obvious shortcut does not work:** an earlier revision proposed keying repair off "`NeedsPut` with an empty `StorageClass`", but a genuinely missing row has that same result. PR-2 will expose `RepairableStub` from the existing probe read, require a successful released-stub CAS before PUT, and add an unapplied-metadata-LWT repair backstop for the unprobed web-session path and probe/delete races. An absent row incurs neither the repair read nor repair LWT. | research branch `fs_helpers.go` `RegisterUploadedBlock`; `db.BlockReuseProbe`; PR-2 |
 
 ## X1 design space — closing the physical-delete ABA
 
@@ -140,8 +143,8 @@ cluster. Destructive GC stays disabled until one lands.
 Applies to every PR in the series, not to any single finding.
 
 - **`go test -race` has never run.** The Windows dev box has no gcc. It must run in
-  Docker before PR-3, PR-4, PR-5 and PR-9 merge — those change goroutine and channel
-  semantics.
+  Docker before PR-2, PR-3, PR-4, PR-5 and PR-9 merge — those change conditional
+  lifecycle races, goroutine behavior or channel semantics.
 - **No end-to-end download tests against real Cassandra** exist for the 404/503
   contract (F5, F13). The unit tests cover the classifier, not the handler.
 - **No multi-DC test** exercises X2 or X6. Both are reasoned from the production

--- a/docs/UPLOAD-PERFORMANCE-SECURITY-2026-06.md
+++ b/docs/UPLOAD-PERFORMANCE-SECURITY-2026-06.md
@@ -59,10 +59,10 @@ Cassandra probe — `DB.ProbeBlockReuse(orgID, blockID)` in
 | `BlockReuseReusable` | canonical metadata + live references, no GC fence    | `EnsureReusableBlockPresent`: verify the canonical object (HEAD on the declared key) and repair (direct PUT) only if missing |
 | `BlockReuseNeedsPut` | no metadata, or metadata with no live references     | `PutBlockAutoDirect` (no HEAD)|
 | `BlockReuseBlockedByGC` | `gc_state='deleting'` or a `gc_s3_orphans` fence  | return `ErrBlockDeleteInProgress` → retry/back-off |
-| `BlockReuseUnknownError` | Cassandra read failed / corrupt metadata         | fall open to legacy Exists+PUT |
+| `BlockReuseUnknownError` | Cassandra read failed / corrupt metadata         | fail closed before S3 PUT |
 
 `PutBlockAutoDirect` (`internal/storage/blocks.go`) issues a direct `PutAuto`
-without the prior HEAD. The probe is wired into all five upload paths:
+without the prior HEAD. The probe is wired into all six upload funnels:
 `HandleUpload` + `finalizeUploadStreaming` (`seafhttp.go`), `SyncHandler.PutBlock`
 (`sync.go`), `FileHandler.CreateFile` template + `UploadFile` (`files.go`), and
 `OnlyOffice.saveEditedDocument` (`onlyoffice.go`).
@@ -71,9 +71,9 @@ without the prior HEAD. The probe is wired into all five upload paths:
 upload paths* listed above. It is **not** a global removal of the S3 HEAD:
 - The `BlockStore` methods `PutBlockAuto` / `PutBlock` / `PutBlockData`
   (`internal/storage/blocks.go`) still perform `Exists` + `PutAuto`. They remain
-  in use as the probe-error fallback inside the migrated paths and by unmigrated
-  callers such as the `v2/blocks.go` `UploadBlock` handler (which still does its
-  own HEAD + `PutBlockData`).
+  in use by unmigrated callers such as the `v2/blocks.go` `UploadBlock` handler
+  (which still does its own HEAD + `PutBlockData`); migrated funnels fail closed
+  when the Cassandra probe is unavailable.
 - The `Reusable` path no longer skips S3 entirely. To avoid trusting Cassandra
   metadata for a physical object that could be missing (partial GC, external
   deletion, eventual consistency, bugs), `EnsureReusableBlockPresent` does a
@@ -93,11 +93,13 @@ the PUT. It derives from the *reference-first, then fence-check* protocol in
 `FSHelper.RegisterUploadedBlock` (`fs_helpers.go:1006–1034`) versus GC's
 *claim-then-verify-references* in `worker.go:processBlock` (L410–443) — a
 Dekker-style mutual flagging. The `gc_s3_orphans` fence is written *before* the S3
-`DeleteObject` and cleared only *after* it, so any in-flight delete is always
-visible to both the probe and the materialize step. The probe is an optimization
-layer that fails safe in all non-reusable directions (BlockedByGC → retry,
-UnknownError → legacy fallback, NeedsPut → direct PUT). See the audit thread for
-the full interleaving analysis.
+`DeleteObject` and cleared only *after* it, so deletes inside the durable orphan
+lifecycle are visible to both the probe and materialize step. The probe fails
+closed when ownership cannot be established (BlockedByGC → retry, UnknownError →
+error, NeedsPut → direct PUT). This does not close X1: a delayed same-key S3 delete
+can outlive its Cassandra authorization state. Keep GC disabled fleet-wide until
+generational physical keys close X1. See the audit thread for the full interleaving
+analysis.
 
 **Retry loop change:** `retrySeafHTTPBlockMaterialization` (and the shared
 `v2.RetryUploadedBlockMaterialization`) now treat `ErrBlockDeleteInProgress` from
@@ -115,7 +117,7 @@ a Cassandra-first probe can reject the block before any S3 work starts.
 - `internal/api/v2/upload_reuse_test.go` — `EnsureReusableBlockPresent` exists-skip
   (honors `probe.StorageKey`) and missing-repair (derives the key from the hash when
   `storage_key` is empty) paths.
-- `internal/api/v2/upload_reuse_test.go` — shared retry helper + fail-open probe.
+- `internal/api/v2/upload_reuse_test.go` — shared retry helper and probe errors.
 - `internal/api/handler_mapping_failure_test.go` — sync needs-put uses direct PUT,
   not the legacy Exists+PUT.
 

--- a/docs/V1-PRODUCTION-ROADMAP.md
+++ b/docs/V1-PRODUCTION-ROADMAP.md
@@ -1,7 +1,7 @@
 # SesameFS v1.0 — Production Readiness Roadmap
 
-**Last updated:** 2026-03-31
-**Current status:** ~82% production-ready (per `IMPLEMENTATION_STATUS.md`)
+**Last updated:** 2026-07-21
+**Current status:** GC production activation is blocked by X1/X2; see `IMPLEMENTATION_STATUS.md`
 
 This document identifies every blocker, high-priority item, and fast-follow task required before
 the v1.0 production launch. Items are classified by priority and include current state analysis,
@@ -92,7 +92,7 @@ handler files. `internal/models/` has only ~550 lines and only defines basic str
 The code is functional and all features work correctly. The large files create operational risk
 for incident response (harder to locate and fix bugs quickly), but this is a code quality issue,
 not a functional blocker. The real remaining launch-critical gaps are Accounts M2M provisioning,
-GC multi-instance safety, and the general security-hardening checklist.
+GC destructive-delete safety (X1/X2), and the general security-hardening checklist.
 Reorganization should happen post-launch when stability allows for large refactors.
 
 **Proposed structure (move code, do not rewrite):**
@@ -547,7 +547,7 @@ the launch on Glacier since it requires AWS Glacier infrastructure setup and tes
 | 12 | Cursor-based pagination | **P2** | Admin links done; library/group admin lists still pending | 2-4 days |
 | 13 | Cold storage / Glacier | **P2** | ~30% | 2–3 weeks |
 | **14** | **User-scoped programmatic auth (API keys)** | **✅ DONE** | **User API keys + `/api2/auth-token/` are live. 2026-04-04 hardening now propagates scope to derived sessions, caps effective role, and enforces central library/sync scope checks. Accounts can reuse the same API key system through a dedicated platform service account; the remaining work belongs to item #1.** | — |
-| **15** | **GC multi-instance safety** | **P0** | **Baseline landed: GC now defaults off in YAML, activates explicitly via `GC_ENABLED=true`, and enabled replicas coordinate through a Cassandra LWT lease (`gc_leases`). For multi-region: GC MUST still run in exactly one DC. LWT operations use `SERIAL` (global Paxos) — do NOT change to `LOCAL_SERIAL`. Two-phase block deletion now persists S3-pending recovery state before removing the canonical DB row.** | **follow-up: observability / crash-drill coverage** |
+| **15** | **GC destructive-delete safety and activation** | **P0** | **The LWT lease (`gc_leases`) is implemented, but X1 physical-delete ABA and X2 cross-DC reference visibility remain open. Keep `GC_ENABLED=false` on every replica in every DC. Only after both close may designated replicas in one DC participate under the lease; all other DCs remain disabled. `SERIAL` does not make ordinary `LOCAL_QUORUM` reference writes globally visible.** | **blockers: X1/X2; then observability / crash drills** |
 | 16 | Frontend Phase 3 cleanup | **P1** | Mostly done. Legacy `personalfree/business/pay_restricted*` removed. Remaining: pageOptions placeholders and minor cleanup | 2–3 days |
 
 ---
@@ -560,7 +560,7 @@ the launch on Glacier since it requires AWS Glacier infrastructure setup and tes
 - [#7] ✅ Enforcement Phase 2 wire-up — DONE (2026-03-28)
 
 ### Sprint 2 — Hard Blockers (CURRENT)
-- [#15] GC multi-instance safety — temporary `GC_ENABLED` guard is available; Cassandra LWT leader lease still pending
+- [#15] GC destructive-delete safety — lease coordination is implemented, but keep `GC_ENABLED=false` fleet-wide until X1/X2 both close; then activate designated replicas in one DC under the lease
 - [#9] Security hardening — small effort, high impact
 - [#1] Remaining Accounts integration — formalize service-account API key auth, provisioning endpoint, idempotency/audit
 

--- a/docs/diagrams/gc-flow.md
+++ b/docs/diagrams/gc-flow.md
@@ -8,6 +8,11 @@
 > and both the transient-error fail-open (P6a) and execution-time canonical revalidation gap
 > (P6b) are fixed. Markerless artifact discovery remains P7. Full audit:
 > [../GC-DELETE-CLEANUP-INVESTIGATION.md](../GC-DELETE-CLEANUP-INVESTIGATION.md).
+>
+> **Operator gate:** keep `GC_ENABLED=false` on every replica in every DC while X1
+> physical-delete ABA or X2 cross-DC reference visibility remains open. The lease
+> does not close either blocker. Only after both close may designated replicas in
+> one DC participate under the lease.
 
 ## 1. Worker loop
 
@@ -51,7 +56,7 @@ flowchart TD
     Mapping --> Clear[Clear orphan + candidate]
 ```
 
-The sequence above is safe **given correct upstream classification/reference ownership**. The P6
+The sequence above is conservative **up to S3 delete authorization**, given correct upstream classification/reference ownership. It does not close X1: Cassandra authorization/claim generations cannot revoke an S3 DELETE already in flight; only never-reused generational physical keys prevent a stale delete from targeting re-uploaded bytes. The P6
 fail-open path that could enqueue live fs_objects (causing GC itself to remove legitimate `fs:`
 refs before this block protocol runs) is now fixed: existence reads fail closed (1D).
 
@@ -88,11 +93,8 @@ flowchart TD
 
     Permanent[Direct permanent delete] --> Resolve[Resolve/validate representation]
     Resolve --> HardRows[Delete library/read models + stamp marker]
-    HardRows --> Route{caller}
-    Route -->|org-admin| NoImmediate[P1: no immediate content enqueue]
-    Route -->|superadmin| Async[P2: go fn content-only accelerator]
-    NoImmediate --> MarkerRescue[Marker retained; Phase 13 delayed]
-    Async --> MarkerRescue
+    HardRows --> Immediate[Best-effort immediate ItemLibraryCascade enqueue]
+    Immediate --> MarkerRescue[Durable purge marker retained for Phase 13 recovery]
     MarkerRescue --> LibCascade
 
     LibCascade --> Enumerate[Enqueue commits/fs_objects/artifacts]
@@ -100,8 +102,8 @@ flowchart TD
     Counter --> Final[Delete library marker + policy indexes]
 ```
 
-Roadmap 6A/6B adds `purge_requested_at` so permanent deletes become immediately Phase-13 eligible;
-the goroutine remains only an accelerator.
+Current code stamps `purge_requested_at` so permanent deletes are immediately Phase-13 eligible;
+the immediate enqueue is only an accelerator and the durable marker is the recovery path.
 
 ## 5. Scanner phases and known boundaries
 

--- a/internal/api/handler_mapping_failure_test.go
+++ b/internal/api/handler_mapping_failure_test.go
@@ -15,18 +15,23 @@ import (
 )
 
 func TestSeafHTTPHandleUploadMappingFailureReturns500(t *testing.T) {
-	oldPutAuto := putUploadedBlockAutoFn
+	oldPutDirect := putUploadedBlockAutoDirectForUploadFn
+	oldProbe := probeUploadedBlockReuseForUploadFn
 	oldRegister := registerUploadedBlockAndMappingForUploadFn
 	oldQuota := checkUploadStorageQuotaForCurrentHeadFn
 	oldEncrypted := lookupLibraryEncryptedForUploadFn
 	t.Cleanup(func() {
-		putUploadedBlockAutoFn = oldPutAuto
+		putUploadedBlockAutoDirectForUploadFn = oldPutDirect
+		probeUploadedBlockReuseForUploadFn = oldProbe
 		registerUploadedBlockAndMappingForUploadFn = oldRegister
 		checkUploadStorageQuotaForCurrentHeadFn = oldQuota
 		lookupLibraryEncryptedForUploadFn = oldEncrypted
 	})
 
-	putUploadedBlockAutoFn = func(ctx context.Context, blockStore *storage.BlockStore, hash string, data []byte) (string, error) {
+	probeUploadedBlockReuseForUploadFn = func(*db.DB, string, string) (db.BlockReuseProbe, error) {
+		return db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut}, nil
+	}
+	putUploadedBlockAutoDirectForUploadFn = func(ctx context.Context, blockStore *storage.BlockStore, hash string, data []byte) (string, error) {
 		return hash, nil
 	}
 	checkUploadStorageQuotaForCurrentHeadFn = func(h *SeafHTTPHandler, orgID, repoID, userID, parentDir, filename string, fileSize int64, replace bool) (int64, int64, error) {
@@ -99,12 +104,14 @@ func TestSeafHTTPHandleUploadFailsClosedWhenEncryptionStatusLookupFails(t *testi
 func TestSyncPutBlockMappingFailureReturns500(t *testing.T) {
 	oldExists := syncBlockExistsFn
 	oldPut := syncPutBlockDataFn
+	oldPutDirect := syncPutBlockAutoDirectFn
 	oldProbe := syncProbeUploadedBlockReuseFn
 	oldRegister := registerUploadedBlockAndMappingForSyncFn
 	oldLookupClass := lookupLibraryStorageClassForSyncFn
 	t.Cleanup(func() {
 		syncBlockExistsFn = oldExists
 		syncPutBlockDataFn = oldPut
+		syncPutBlockAutoDirectFn = oldPutDirect
 		syncProbeUploadedBlockReuseFn = oldProbe
 		registerUploadedBlockAndMappingForSyncFn = oldRegister
 		lookupLibraryStorageClassForSyncFn = oldLookupClass
@@ -115,6 +122,12 @@ func TestSyncPutBlockMappingFailureReturns500(t *testing.T) {
 	}
 	syncPutBlockDataFn = func(ctx context.Context, blockStore *storage.BlockStore, block *storage.BlockData) (string, error) {
 		return block.Hash, nil
+	}
+	syncProbeUploadedBlockReuseFn = func(*db.DB, string, string) (db.BlockReuseProbe, error) {
+		return db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut}, nil
+	}
+	syncPutBlockAutoDirectFn = func(ctx context.Context, blockStore *storage.BlockStore, hash string, data []byte) (string, error) {
+		return hash, nil
 	}
 	registerUploadedBlockAndMappingForSyncFn = func(database *db.DB, orgID, repoID, internalBlockID, operationID string, sizeBytes int, storageClass, storageKey, externalBlockID string) error {
 		return fmt.Errorf("mapping failed: %w", v2.ErrBlockMappingWriteFailed)

--- a/internal/api/seafhttp.go
+++ b/internal/api/seafhttp.go
@@ -1513,9 +1513,6 @@ const (
 
 var finalizeUploadBlockMetadataPermits = make(chan struct{}, finalizeUploadBlockMetadataConcurrency)
 var chunkedUploadLibraryFinalizePermits sync.Map
-var putUploadedBlockAutoFn = func(ctx context.Context, blockStore *storage.BlockStore, hash string, data []byte) (string, error) {
-	return blockStore.PutBlockAuto(ctx, hash, data)
-}
 var putUploadedBlockAutoDirectForUploadFn = func(ctx context.Context, blockStore *storage.BlockStore, hash string, data []byte) (string, error) {
 	return blockStore.PutBlockAutoDirect(ctx, hash, data)
 }

--- a/internal/api/seafhttp.go
+++ b/internal/api/seafhttp.go
@@ -1520,6 +1520,7 @@ var putUploadedBlockAutoDirectForUploadFn = func(ctx context.Context, blockStore
 	return blockStore.PutBlockAutoDirect(ctx, hash, data)
 }
 var probeUploadedBlockReuseForUploadFn = v2.ProbeUploadedBlockReuse
+var prepareUploadedBlockProbeForUploadFn = v2.PrepareUploadedBlockProbe
 var ensureReusableBlockPresentForUploadFn = v2.EnsureReusableBlockPresent
 var registerUploadedBlockAndMappingForUploadFn = v2.RegisterUploadedBlockAndMapping
 var resolveSeafHTTPStoredBlockIDsFn = func(fsHelper *v2.FSHelper, orgID, repoID string, blockIDs []string) ([]string, error) {
@@ -2159,32 +2160,30 @@ func (h *SeafHTTPHandler) HandleUpload(c *gin.Context) {
 	}
 	storeUploadedBlock := func() error {
 		probe, probeErr := probeUploadedBlockReuseForUploadFn(h.db, token.OrgID, sha256ID)
-		if probeErr == nil {
-			switch probe.Decision {
-			case db.BlockReuseReusable:
-				if _, ensureErr := ensureReusableBlockPresentForUploadFn(ctx, sha256ID, probe, storedContent, h.storageManager, blockStore, actualStorageClass, token.OrgID); ensureErr != nil {
-					return ensureErr
-				}
-				log.Printf("[HandleUpload] Reused canonical block %s (SHA-256: %s) after physical verification", fileID[:16], sha256ID[:16])
-				return nil
-			case db.BlockReuseNeedsPut:
-				_, putErr := putUploadedBlockAutoDirectForUploadFn(ctx, blockStore, sha256ID, storedContent)
-				if putErr == nil {
-					log.Printf("[HandleUpload] Stored block %s (SHA-256: %s) via direct PUT", fileID[:16], sha256ID[:16])
-				}
-				return putErr
-			case db.BlockReuseBlockedByGC:
-				return v2.ErrBlockDeleteInProgress
+		if probeErr != nil {
+			return fmt.Errorf("probe block reuse for %s: %w", sha256ID, probeErr)
+		}
+		probe, probeErr = prepareUploadedBlockProbeForUploadFn(h.db, token.OrgID, sha256ID, probe)
+		if probeErr != nil {
+			return probeErr
+		}
+		switch probe.Decision {
+		case db.BlockReuseReusable:
+			if _, ensureErr := ensureReusableBlockPresentForUploadFn(ctx, sha256ID, probe, storedContent, h.storageManager, blockStore, actualStorageClass, token.OrgID); ensureErr != nil {
+				return ensureErr
 			}
-		} else {
-			log.Printf("[HandleUpload] Block reuse probe unavailable for block %s; falling back to legacy Exists+PUT path: %v", sha256ID[:16], probeErr)
+			log.Printf("[HandleUpload] Reused canonical block %s (SHA-256: %s) after physical verification", fileID[:16], sha256ID[:16])
+			return nil
+		case db.BlockReuseNeedsPut:
+			_, putErr := putUploadedBlockAutoDirectForUploadFn(ctx, blockStore, sha256ID, storedContent)
+			if putErr == nil {
+				log.Printf("[HandleUpload] Stored block %s (SHA-256: %s) via direct PUT", fileID[:16], sha256ID[:16])
+			}
+			return putErr
+		case db.BlockReuseBlockedByGC:
+			return v2.ErrBlockDeleteInProgress
 		}
-
-		_, putErr := putUploadedBlockAutoFn(ctx, blockStore, sha256ID, storedContent)
-		if putErr == nil {
-			log.Printf("[HandleUpload] Stored block %s (SHA-256: %s) via legacy Exists+PUT fallback", fileID[:16], sha256ID[:16])
-		}
-		return putErr
+		return fmt.Errorf("unexpected block reuse decision %d for %s", probe.Decision, sha256ID)
 	}
 
 	// Register block metadata + a provisional reference (kept alive by TTL until
@@ -2657,29 +2656,27 @@ readLoop:
 			if blkErr := upload.AccountBlockOnce(blockIndexLocal, sha256ID, func() error {
 				return retrySeafHTTPBlockMaterialization("finalizeUploadStreaming", sha256ID, func() error {
 					probe, probeErr := probeUploadedBlockReuseForUploadFn(h.db, token.OrgID, sha256ID)
-					if probeErr == nil {
-						switch probe.Decision {
-						case db.BlockReuseReusable:
-							_, ensureErr := ensureReusableBlockPresentForUploadFn(egCtx, sha256ID, probe, storedBlock, h.storageManager, blockStore, actualStorageClass, token.OrgID)
-							return ensureErr
-						case db.BlockReuseNeedsPut:
-							_, putErr := putUploadedBlockAutoDirectForUploadFn(egCtx, blockStore, sha256ID, storedBlock)
-							if putErr != nil {
-								return fmt.Errorf("failed to store block: %w", putErr)
-							}
-							return nil
-						case db.BlockReuseBlockedByGC:
-							return v2.ErrBlockDeleteInProgress
+					if probeErr != nil {
+						return fmt.Errorf("probe block reuse for %s: %w", sha256ID, probeErr)
+					}
+					probe, probeErr = prepareUploadedBlockProbeForUploadFn(h.db, token.OrgID, sha256ID, probe)
+					if probeErr != nil {
+						return probeErr
+					}
+					switch probe.Decision {
+					case db.BlockReuseReusable:
+						_, ensureErr := ensureReusableBlockPresentForUploadFn(egCtx, sha256ID, probe, storedBlock, h.storageManager, blockStore, actualStorageClass, token.OrgID)
+						return ensureErr
+					case db.BlockReuseNeedsPut:
+						_, putErr := putUploadedBlockAutoDirectForUploadFn(egCtx, blockStore, sha256ID, storedBlock)
+						if putErr != nil {
+							return fmt.Errorf("failed to store block: %w", putErr)
 						}
-					} else {
-						log.Printf("[finalizeUploadStreaming] Block reuse probe unavailable for block %s; falling back to legacy Exists+PUT path: %v", sha256ID[:16], probeErr)
+						return nil
+					case db.BlockReuseBlockedByGC:
+						return v2.ErrBlockDeleteInProgress
 					}
-
-					_, putErr := putUploadedBlockAutoFn(egCtx, blockStore, sha256ID, storedBlock)
-					if putErr != nil {
-						return fmt.Errorf("failed to store block: %w", putErr)
-					}
-					return nil
+					return fmt.Errorf("unexpected block reuse decision %d for %s", probe.Decision, sha256ID)
 				}, func() error {
 					// Cassandra materialization: serialized process-wide after the
 					// S3 PUT so provisional refs + metadata/mapping writes do not

--- a/internal/api/seafhttp_test.go
+++ b/internal/api/seafhttp_test.go
@@ -2908,7 +2908,8 @@ func TestFinalizeUploadStreamingEncryptedLibraryWithoutDecryptSessionReturnsSent
 
 	originalQuota := checkUploadStorageQuotaForCurrentHeadFn
 	originalEncrypted := lookupLibraryEncryptedForUploadFn
-	originalPut := putUploadedBlockAutoFn
+	originalPut := putUploadedBlockAutoDirectForUploadFn
+	originalProbe := probeUploadedBlockReuseForUploadFn
 	originalDirectPut := putUploadedBlockAutoDirectForUploadFn
 	originalEnsureReusable := ensureReusableBlockPresentForUploadFn
 	originalRegister := registerUploadedBlockAndMappingForUploadFn
@@ -2916,7 +2917,8 @@ func TestFinalizeUploadStreamingEncryptedLibraryWithoutDecryptSessionReturnsSent
 	t.Cleanup(func() {
 		checkUploadStorageQuotaForCurrentHeadFn = originalQuota
 		lookupLibraryEncryptedForUploadFn = originalEncrypted
-		putUploadedBlockAutoFn = originalPut
+		putUploadedBlockAutoDirectForUploadFn = originalPut
+		probeUploadedBlockReuseForUploadFn = originalProbe
 		putUploadedBlockAutoDirectForUploadFn = originalDirectPut
 		ensureReusableBlockPresentForUploadFn = originalEnsureReusable
 		registerUploadedBlockAndMappingForUploadFn = originalRegister
@@ -3015,7 +3017,10 @@ func TestFinalizeUploadStreamingDoesNotWrapS3PutInMetadataPermit(t *testing.T) {
 	}
 
 	putStarted := make(chan struct{})
-	putUploadedBlockAutoFn = func(_ context.Context, _ *storage.BlockStore, hash string, data []byte) (string, error) {
+	probeUploadedBlockReuseForUploadFn = func(*db.DB, string, string) (db.BlockReuseProbe, error) {
+		return db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut}, nil
+	}
+	putUploadedBlockAutoDirectForUploadFn = func(_ context.Context, _ *storage.BlockStore, hash string, data []byte) (string, error) {
 		close(putStarted)
 		return hash, nil
 	}
@@ -3112,7 +3117,7 @@ func TestFinalizeUploadStreamingDoesNotWrapS3PutInMetadataPermit(t *testing.T) {
 // Exists+PUT path (putUploadedBlockAutoFn) is the only one that issues the
 // old upload-backend HEAD, so a zero count there proves the reusable/needs-put
 // logic stayed off that legacy path.
-func finalizeUploadStreamingReuseFixture(t *testing.T, decision db.BlockReuseProbe) (legacyPuts, directPuts, reusableChecks, registerCalls *atomic.Int32, run func() (string, error)) {
+func finalizeUploadStreamingReuseFixture(t *testing.T, decision db.BlockReuseProbe) (legacyPuts, directPuts, reusableChecks, repairCalls, registerCalls *atomic.Int32, run func() (string, error)) {
 	t.Helper()
 
 	cm, _ := newTestChunkManager(t)
@@ -3129,6 +3134,7 @@ func finalizeUploadStreamingReuseFixture(t *testing.T, decision db.BlockReusePro
 	}
 
 	originalProbe := probeUploadedBlockReuseForUploadFn
+	originalPrepare := prepareUploadedBlockProbeForUploadFn
 	originalLegacyPut := putUploadedBlockAutoFn
 	originalDirectPut := putUploadedBlockAutoDirectForUploadFn
 	originalEnsureReusable := ensureReusableBlockPresentForUploadFn
@@ -3138,6 +3144,7 @@ func finalizeUploadStreamingReuseFixture(t *testing.T, decision db.BlockReusePro
 	originalCommit := commitSeafHTTPUploadedFileMultiBlockFn
 	t.Cleanup(func() {
 		probeUploadedBlockReuseForUploadFn = originalProbe
+		prepareUploadedBlockProbeForUploadFn = originalPrepare
 		putUploadedBlockAutoFn = originalLegacyPut
 		putUploadedBlockAutoDirectForUploadFn = originalDirectPut
 		ensureReusableBlockPresentForUploadFn = originalEnsureReusable
@@ -3160,7 +3167,15 @@ func finalizeUploadStreamingReuseFixture(t *testing.T, decision db.BlockReusePro
 	legacyPuts = &atomic.Int32{}
 	directPuts = &atomic.Int32{}
 	reusableChecks = &atomic.Int32{}
+	repairCalls = &atomic.Int32{}
 	registerCalls = &atomic.Int32{}
+	prepareUploadedBlockProbeForUploadFn = func(_ *db.DB, _, _ string, probe db.BlockReuseProbe) (db.BlockReuseProbe, error) {
+		if probe.Decision == db.BlockReuseRepairableStub {
+			repairCalls.Add(1)
+			probe.Decision = db.BlockReuseNeedsPut
+		}
+		return probe, nil
+	}
 
 	putUploadedBlockAutoFn = func(_ context.Context, _ *storage.BlockStore, hash string, _ []byte) (string, error) {
 		legacyPuts.Add(1)
@@ -3192,7 +3207,7 @@ func finalizeUploadStreamingReuseFixture(t *testing.T, decision db.BlockReusePro
 		fileID, _, _, _, err := handler.finalizeUploadStreaming(c, token, upload, "/", "test.bin", "", 5, false)
 		return fileID, err
 	}
-	return legacyPuts, directPuts, reusableChecks, registerCalls, run
+	return legacyPuts, directPuts, reusableChecks, repairCalls, registerCalls, run
 }
 
 func TestSeafHTTPHandlerUploadChunkedEncryptedLibraryWithoutDecryptSessionReturnsUnlockContract(t *testing.T) {
@@ -3289,7 +3304,7 @@ func TestSeafHTTPHandlerUploadChunkedEncryptedLibraryUnlockRetryReusesTrackerAnd
 	originalQuota := checkUploadStorageQuotaForCurrentHeadFn
 	originalEncrypted := lookupLibraryEncryptedForUploadFn
 	originalProbe := probeUploadedBlockReuseForUploadFn
-	originalPut := putUploadedBlockAutoFn
+	originalPut := putUploadedBlockAutoDirectForUploadFn
 	originalRegister := registerUploadedBlockAndMappingForUploadFn
 	originalCommit := commitSeafHTTPUploadedFileMultiBlockFn
 	originalReleaseRefs := releaseUploadedBlockRefsFn
@@ -3297,7 +3312,7 @@ func TestSeafHTTPHandlerUploadChunkedEncryptedLibraryUnlockRetryReusesTrackerAnd
 		checkUploadStorageQuotaForCurrentHeadFn = originalQuota
 		lookupLibraryEncryptedForUploadFn = originalEncrypted
 		probeUploadedBlockReuseForUploadFn = originalProbe
-		putUploadedBlockAutoFn = originalPut
+		putUploadedBlockAutoDirectForUploadFn = originalPut
 		registerUploadedBlockAndMappingForUploadFn = originalRegister
 		commitSeafHTTPUploadedFileMultiBlockFn = originalCommit
 		releaseUploadedBlockRefsFn = originalReleaseRefs
@@ -3310,11 +3325,11 @@ func TestSeafHTTPHandlerUploadChunkedEncryptedLibraryUnlockRetryReusesTrackerAnd
 		return true, nil
 	}
 	probeUploadedBlockReuseForUploadFn = func(database *db.DB, orgID, blockID string) (db.BlockReuseProbe, error) {
-		return db.BlockReuseProbe{}, errors.New("probe unavailable in test")
+		return db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut}, nil
 	}
 
 	var putCalls, registerCalls, commitCalls atomic.Int32
-	putUploadedBlockAutoFn = func(_ context.Context, _ *storage.BlockStore, hash string, data []byte) (string, error) {
+	putUploadedBlockAutoDirectForUploadFn = func(_ context.Context, _ *storage.BlockStore, hash string, data []byte) (string, error) {
 		putCalls.Add(1)
 		return hash, nil
 	}
@@ -3425,7 +3440,7 @@ func TestSeafHTTPHandlerUploadChunkedEncryptedLibraryUnlockRetryReusesTrackerAnd
 // declared canonical key, with repair-on-miss) is exercised by the unit tests in
 // internal/api/v2/upload_reuse_test.go.
 func TestFinalizeUploadStreamingReusableVerifiesCanonicalNotLegacyPut(t *testing.T) {
-	legacyPuts, directPuts, reusableChecks, registerCalls, run := finalizeUploadStreamingReuseFixture(t,
+	legacyPuts, directPuts, reusableChecks, _, registerCalls, run := finalizeUploadStreamingReuseFixture(t,
 		db.BlockReuseProbe{Decision: db.BlockReuseReusable, StorageClass: "hot"})
 
 	expectedSHA1 := sha1.Sum([]byte("hello"))
@@ -3456,7 +3471,7 @@ func TestFinalizeUploadStreamingReusableVerifiesCanonicalNotLegacyPut(t *testing
 // reports the block needs storing, finalization performs exactly one direct PUT
 // (no S3 HEAD via the legacy path) and registers the block reference + mapping.
 func TestFinalizeUploadStreamingNeedsPutUsesDirectPut(t *testing.T) {
-	legacyPuts, directPuts, reusableChecks, registerCalls, run := finalizeUploadStreamingReuseFixture(t,
+	legacyPuts, directPuts, reusableChecks, _, registerCalls, run := finalizeUploadStreamingReuseFixture(t,
 		db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut, StorageClass: "hot"})
 
 	expectedSHA1 := sha1.Sum([]byte("hello"))
@@ -3480,6 +3495,39 @@ func TestFinalizeUploadStreamingNeedsPutUsesDirectPut(t *testing.T) {
 	}
 	if got := registerCalls.Load(); got != 1 {
 		t.Errorf("register ref/mapping calls = %d, want 1", got)
+	}
+}
+
+func TestFinalizeUploadStreamingRepairableStubRepairsBeforeDirectPut(t *testing.T) {
+	legacyPuts, directPuts, reusableChecks, repairCalls, registerCalls, run := finalizeUploadStreamingReuseFixture(t,
+		db.BlockReuseProbe{Decision: db.BlockReuseRepairableStub})
+
+	if _, err := run(); err != nil {
+		t.Fatalf("finalizeUploadStreaming error = %v, want nil", err)
+	}
+	if got := repairCalls.Load(); got != 1 {
+		t.Fatalf("stub repair calls = %d, want 1", got)
+	}
+	if got := directPuts.Load(); got != 1 {
+		t.Fatalf("direct PUT calls = %d, want 1 after repair", got)
+	}
+	if legacyPuts.Load() != 0 || reusableChecks.Load() != 0 || registerCalls.Load() != 1 {
+		t.Fatalf("legacy/reusable/register = %d/%d/%d, want 0/0/1", legacyPuts.Load(), reusableChecks.Load(), registerCalls.Load())
+	}
+}
+
+func TestFinalizeUploadStreamingRepairRaceDoesNotPut(t *testing.T) {
+	legacyPuts, directPuts, _, _, registerCalls, run := finalizeUploadStreamingReuseFixture(t,
+		db.BlockReuseProbe{Decision: db.BlockReuseRepairableStub})
+	prepareUploadedBlockProbeForUploadFn = func(_ *db.DB, _, blockID string, _ db.BlockReuseProbe) (db.BlockReuseProbe, error) {
+		return db.BlockReuseProbe{Decision: db.BlockReuseBlockedByGC}, fmt.Errorf("%w: %s repair race", v2.ErrBlockDeleteInProgress, blockID)
+	}
+
+	if _, err := run(); !errors.Is(err, v2.ErrBlockDeleteInProgress) {
+		t.Fatalf("finalizeUploadStreaming error = %v, want ErrBlockDeleteInProgress", err)
+	}
+	if legacyPuts.Load() != 0 || directPuts.Load() != 0 || registerCalls.Load() != 0 {
+		t.Fatalf("legacy/direct/register = %d/%d/%d, want 0/0/0", legacyPuts.Load(), directPuts.Load(), registerCalls.Load())
 	}
 }
 

--- a/internal/api/seafhttp_test.go
+++ b/internal/api/seafhttp_test.go
@@ -2933,10 +2933,6 @@ func TestFinalizeUploadStreamingEncryptedLibraryWithoutDecryptSessionReturnsSent
 	}
 
 	var storeCalls atomic.Int32
-	putUploadedBlockAutoFn = func(_ context.Context, _ *storage.BlockStore, hash string, _ []byte) (string, error) {
-		storeCalls.Add(1)
-		return hash, nil
-	}
 	putUploadedBlockAutoDirectForUploadFn = func(_ context.Context, _ *storage.BlockStore, hash string, _ []byte) (string, error) {
 		storeCalls.Add(1)
 		return hash, nil
@@ -2996,13 +2992,11 @@ func TestFinalizeUploadStreamingDoesNotWrapS3PutInMetadataPermit(t *testing.T) {
 		}
 	}()
 
-	originalPut := putUploadedBlockAutoFn
 	originalRegister := registerUploadedBlockAndMappingForUploadFn
 	originalQuota := checkUploadStorageQuotaForCurrentHeadFn
 	originalEncrypted := lookupLibraryEncryptedForUploadFn
 	originalCommit := commitSeafHTTPUploadedFileMultiBlockFn
 	t.Cleanup(func() {
-		putUploadedBlockAutoFn = originalPut
 		registerUploadedBlockAndMappingForUploadFn = originalRegister
 		checkUploadStorageQuotaForCurrentHeadFn = originalQuota
 		lookupLibraryEncryptedForUploadFn = originalEncrypted
@@ -3113,11 +3107,10 @@ func TestFinalizeUploadStreamingDoesNotWrapS3PutInMetadataPermit(t *testing.T) {
 }
 
 // finalizeUploadStreamingReuseFixture wires the common mocks for the
-// Cassandra-first reuse tests below and returns call counters. The legacy
-// Exists+PUT path (putUploadedBlockAutoFn) is the only one that issues the
-// old upload-backend HEAD, so a zero count there proves the reusable/needs-put
-// logic stayed off that legacy path.
-func finalizeUploadStreamingReuseFixture(t *testing.T, decision db.BlockReuseProbe) (legacyPuts, directPuts, reusableChecks, repairCalls, registerCalls *atomic.Int32, run func() (string, error)) {
+// Cassandra-first reuse tests below and returns call counters. The migrated
+// funnel no longer has a legacy Exists+PUT fallback, so the counters prove the
+// reuse/needs-put logic drives only the direct PUT and reusable-verify paths.
+func finalizeUploadStreamingReuseFixture(t *testing.T, decision db.BlockReuseProbe) (directPuts, reusableChecks, repairCalls, registerCalls *atomic.Int32, run func() (string, error)) {
 	t.Helper()
 
 	cm, _ := newTestChunkManager(t)
@@ -3135,7 +3128,6 @@ func finalizeUploadStreamingReuseFixture(t *testing.T, decision db.BlockReusePro
 
 	originalProbe := probeUploadedBlockReuseForUploadFn
 	originalPrepare := prepareUploadedBlockProbeForUploadFn
-	originalLegacyPut := putUploadedBlockAutoFn
 	originalDirectPut := putUploadedBlockAutoDirectForUploadFn
 	originalEnsureReusable := ensureReusableBlockPresentForUploadFn
 	originalRegister := registerUploadedBlockAndMappingForUploadFn
@@ -3145,7 +3137,6 @@ func finalizeUploadStreamingReuseFixture(t *testing.T, decision db.BlockReusePro
 	t.Cleanup(func() {
 		probeUploadedBlockReuseForUploadFn = originalProbe
 		prepareUploadedBlockProbeForUploadFn = originalPrepare
-		putUploadedBlockAutoFn = originalLegacyPut
 		putUploadedBlockAutoDirectForUploadFn = originalDirectPut
 		ensureReusableBlockPresentForUploadFn = originalEnsureReusable
 		registerUploadedBlockAndMappingForUploadFn = originalRegister
@@ -3164,7 +3155,6 @@ func finalizeUploadStreamingReuseFixture(t *testing.T, decision db.BlockReusePro
 		return decision, nil
 	}
 
-	legacyPuts = &atomic.Int32{}
 	directPuts = &atomic.Int32{}
 	reusableChecks = &atomic.Int32{}
 	repairCalls = &atomic.Int32{}
@@ -3177,10 +3167,6 @@ func finalizeUploadStreamingReuseFixture(t *testing.T, decision db.BlockReusePro
 		return probe, nil
 	}
 
-	putUploadedBlockAutoFn = func(_ context.Context, _ *storage.BlockStore, hash string, _ []byte) (string, error) {
-		legacyPuts.Add(1)
-		return hash, nil
-	}
 	putUploadedBlockAutoDirectForUploadFn = func(_ context.Context, _ *storage.BlockStore, hash string, _ []byte) (string, error) {
 		directPuts.Add(1)
 		return hash, nil
@@ -3207,7 +3193,7 @@ func finalizeUploadStreamingReuseFixture(t *testing.T, decision db.BlockReusePro
 		fileID, _, _, _, err := handler.finalizeUploadStreaming(c, token, upload, "/", "test.bin", "", 5, false)
 		return fileID, err
 	}
-	return legacyPuts, directPuts, reusableChecks, repairCalls, registerCalls, run
+	return directPuts, reusableChecks, repairCalls, registerCalls, run
 }
 
 func TestSeafHTTPHandlerUploadChunkedEncryptedLibraryWithoutDecryptSessionReturnsUnlockContract(t *testing.T) {
@@ -3440,7 +3426,7 @@ func TestSeafHTTPHandlerUploadChunkedEncryptedLibraryUnlockRetryReusesTrackerAnd
 // declared canonical key, with repair-on-miss) is exercised by the unit tests in
 // internal/api/v2/upload_reuse_test.go.
 func TestFinalizeUploadStreamingReusableVerifiesCanonicalNotLegacyPut(t *testing.T) {
-	legacyPuts, directPuts, reusableChecks, _, registerCalls, run := finalizeUploadStreamingReuseFixture(t,
+	directPuts, reusableChecks, _, registerCalls, run := finalizeUploadStreamingReuseFixture(t,
 		db.BlockReuseProbe{Decision: db.BlockReuseReusable, StorageClass: "hot"})
 
 	expectedSHA1 := sha1.Sum([]byte("hello"))
@@ -3452,9 +3438,6 @@ func TestFinalizeUploadStreamingReusableVerifiesCanonicalNotLegacyPut(t *testing
 	}
 	if fileID != expectedBlockID {
 		t.Fatalf("fileID = %s, want %s", fileID, expectedBlockID)
-	}
-	if got := legacyPuts.Load(); got != 0 {
-		t.Errorf("legacy Exists+PUT (HEAD) calls = %d, want 0 for a reusable block", got)
 	}
 	if got := directPuts.Load(); got != 0 {
 		t.Errorf("direct PUT calls = %d, want 0 for a reusable block", got)
@@ -3469,9 +3452,9 @@ func TestFinalizeUploadStreamingReusableVerifiesCanonicalNotLegacyPut(t *testing
 
 // TestFinalizeUploadStreamingNeedsPutUsesDirectPut verifies that when the probe
 // reports the block needs storing, finalization performs exactly one direct PUT
-// (no S3 HEAD via the legacy path) and registers the block reference + mapping.
+// and registers the block reference + mapping.
 func TestFinalizeUploadStreamingNeedsPutUsesDirectPut(t *testing.T) {
-	legacyPuts, directPuts, reusableChecks, _, registerCalls, run := finalizeUploadStreamingReuseFixture(t,
+	directPuts, reusableChecks, _, registerCalls, run := finalizeUploadStreamingReuseFixture(t,
 		db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut, StorageClass: "hot"})
 
 	expectedSHA1 := sha1.Sum([]byte("hello"))
@@ -3483,9 +3466,6 @@ func TestFinalizeUploadStreamingNeedsPutUsesDirectPut(t *testing.T) {
 	}
 	if fileID != expectedBlockID {
 		t.Fatalf("fileID = %s, want %s", fileID, expectedBlockID)
-	}
-	if got := legacyPuts.Load(); got != 0 {
-		t.Errorf("legacy Exists+PUT (HEAD) calls = %d, want 0 (needs_put must use the direct PUT)", got)
 	}
 	if got := directPuts.Load(); got != 1 {
 		t.Errorf("direct PUT calls = %d, want 1", got)
@@ -3499,7 +3479,7 @@ func TestFinalizeUploadStreamingNeedsPutUsesDirectPut(t *testing.T) {
 }
 
 func TestFinalizeUploadStreamingRepairableStubRepairsBeforeDirectPut(t *testing.T) {
-	legacyPuts, directPuts, reusableChecks, repairCalls, registerCalls, run := finalizeUploadStreamingReuseFixture(t,
+	directPuts, reusableChecks, repairCalls, registerCalls, run := finalizeUploadStreamingReuseFixture(t,
 		db.BlockReuseProbe{Decision: db.BlockReuseRepairableStub})
 
 	if _, err := run(); err != nil {
@@ -3511,13 +3491,13 @@ func TestFinalizeUploadStreamingRepairableStubRepairsBeforeDirectPut(t *testing.
 	if got := directPuts.Load(); got != 1 {
 		t.Fatalf("direct PUT calls = %d, want 1 after repair", got)
 	}
-	if legacyPuts.Load() != 0 || reusableChecks.Load() != 0 || registerCalls.Load() != 1 {
-		t.Fatalf("legacy/reusable/register = %d/%d/%d, want 0/0/1", legacyPuts.Load(), reusableChecks.Load(), registerCalls.Load())
+	if reusableChecks.Load() != 0 || registerCalls.Load() != 1 {
+		t.Fatalf("reusable/register = %d/%d, want 0/1", reusableChecks.Load(), registerCalls.Load())
 	}
 }
 
 func TestFinalizeUploadStreamingRepairRaceDoesNotPut(t *testing.T) {
-	legacyPuts, directPuts, _, _, registerCalls, run := finalizeUploadStreamingReuseFixture(t,
+	directPuts, _, _, registerCalls, run := finalizeUploadStreamingReuseFixture(t,
 		db.BlockReuseProbe{Decision: db.BlockReuseRepairableStub})
 	prepareUploadedBlockProbeForUploadFn = func(_ *db.DB, _, blockID string, _ db.BlockReuseProbe) (db.BlockReuseProbe, error) {
 		return db.BlockReuseProbe{Decision: db.BlockReuseBlockedByGC}, fmt.Errorf("%w: %s repair race", v2.ErrBlockDeleteInProgress, blockID)
@@ -3526,8 +3506,8 @@ func TestFinalizeUploadStreamingRepairRaceDoesNotPut(t *testing.T) {
 	if _, err := run(); !errors.Is(err, v2.ErrBlockDeleteInProgress) {
 		t.Fatalf("finalizeUploadStreaming error = %v, want ErrBlockDeleteInProgress", err)
 	}
-	if legacyPuts.Load() != 0 || directPuts.Load() != 0 || registerCalls.Load() != 0 {
-		t.Fatalf("legacy/direct/register = %d/%d/%d, want 0/0/0", legacyPuts.Load(), directPuts.Load(), registerCalls.Load())
+	if directPuts.Load() != 0 || registerCalls.Load() != 0 {
+		t.Fatalf("direct/register = %d/%d, want 0/0", directPuts.Load(), registerCalls.Load())
 	}
 }
 
@@ -3541,13 +3521,13 @@ func TestFinalizeUploadBlockMetadataPermitDoesNotBlockS3Put(t *testing.T) {
 		t.Fatalf("failed to pre-acquire metadata permit: %v", err)
 	}
 
-	originalPut := putUploadedBlockAutoFn
+	originalPut := putUploadedBlockAutoDirectForUploadFn
 	putStarted := make(chan struct{})
-	putUploadedBlockAutoFn = func(_ context.Context, _ *storage.BlockStore, _ string, _ []byte) (string, error) {
+	putUploadedBlockAutoDirectForUploadFn = func(_ context.Context, _ *storage.BlockStore, _ string, _ []byte) (string, error) {
 		close(putStarted)
 		return "key", nil
 	}
-	t.Cleanup(func() { putUploadedBlockAutoFn = originalPut })
+	t.Cleanup(func() { putUploadedBlockAutoDirectForUploadFn = originalPut })
 
 	originalRegister := registerUploadedBlockAndMappingForUploadFn
 	registerUploadedBlockAndMappingForUploadFn = func(_ *db.DB, _, _, _, _ string, _ int, _, _, _ string) error {
@@ -3559,7 +3539,7 @@ func TestFinalizeUploadBlockMetadataPermitDoesNotBlockS3Put(t *testing.T) {
 	go func() {
 		done <- retrySeafHTTPBlockMaterialization("test", "sha256-block",
 			func() error {
-				_, putErr := putUploadedBlockAutoFn(context.Background(), nil, "sha256-block", []byte("data"))
+				_, putErr := putUploadedBlockAutoDirectForUploadFn(context.Background(), nil, "sha256-block", []byte("data"))
 				return putErr
 			},
 			func() error {
@@ -3602,12 +3582,12 @@ func TestFinalizeUploadS3PutPrecedesPermitRelease(t *testing.T) {
 	var seq atomic.Int64
 	var putSeq, permitReleaseSeq int64
 
-	originalPut := putUploadedBlockAutoFn
-	putUploadedBlockAutoFn = func(_ context.Context, _ *storage.BlockStore, _ string, _ []byte) (string, error) {
+	originalPut := putUploadedBlockAutoDirectForUploadFn
+	putUploadedBlockAutoDirectForUploadFn = func(_ context.Context, _ *storage.BlockStore, _ string, _ []byte) (string, error) {
 		putSeq = seq.Add(1)
 		return "key", nil
 	}
-	t.Cleanup(func() { putUploadedBlockAutoFn = originalPut })
+	t.Cleanup(func() { putUploadedBlockAutoDirectForUploadFn = originalPut })
 
 	originalRegister := registerUploadedBlockAndMappingForUploadFn
 	registerUploadedBlockAndMappingForUploadFn = func(_ *db.DB, _, _, _, _ string, _ int, _, _, _ string) error {
@@ -3628,7 +3608,7 @@ func TestFinalizeUploadS3PutPrecedesPermitRelease(t *testing.T) {
 	go func() {
 		done <- retrySeafHTTPBlockMaterialization("test", "sha256-block",
 			func() error {
-				_, putErr := putUploadedBlockAutoFn(context.Background(), nil, "sha256-block", []byte("data"))
+				_, putErr := putUploadedBlockAutoDirectForUploadFn(context.Background(), nil, "sha256-block", []byte("data"))
 				close(putInvoked)
 				return putErr
 			},

--- a/internal/api/seafhttp_test.go
+++ b/internal/api/seafhttp_test.go
@@ -2996,11 +2996,15 @@ func TestFinalizeUploadStreamingDoesNotWrapS3PutInMetadataPermit(t *testing.T) {
 	originalQuota := checkUploadStorageQuotaForCurrentHeadFn
 	originalEncrypted := lookupLibraryEncryptedForUploadFn
 	originalCommit := commitSeafHTTPUploadedFileMultiBlockFn
+	originalProbe := probeUploadedBlockReuseForUploadFn
+	originalDirectPut := putUploadedBlockAutoDirectForUploadFn
 	t.Cleanup(func() {
 		registerUploadedBlockAndMappingForUploadFn = originalRegister
 		checkUploadStorageQuotaForCurrentHeadFn = originalQuota
 		lookupLibraryEncryptedForUploadFn = originalEncrypted
 		commitSeafHTTPUploadedFileMultiBlockFn = originalCommit
+		probeUploadedBlockReuseForUploadFn = originalProbe
+		putUploadedBlockAutoDirectForUploadFn = originalDirectPut
 	})
 
 	checkUploadStorageQuotaForCurrentHeadFn = func(h *SeafHTTPHandler, orgID, repoID, userID, parentDir, filename string, fileSize int64, replace bool) (int64, int64, error) {

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -375,6 +375,7 @@ var syncPutBlockAutoDirectFn = func(ctx context.Context, blockStore *storage.Blo
 	return blockStore.PutBlockAutoDirect(ctx, hash, data)
 }
 var syncProbeUploadedBlockReuseFn = v2.ProbeUploadedBlockReuse
+var syncPrepareUploadedBlockProbeFn = v2.PrepareUploadedBlockProbe
 var registerUploadedBlockAndMappingForSyncFn = v2.RegisterUploadedBlockAndMapping
 
 // formatRelativeTimeHTML delegates to httputil.FormatRelativeTimeHTML.
@@ -1306,45 +1307,32 @@ func (h *SyncHandler) PutBlock(c *gin.Context) {
 		// error or the response will be written twice on retry.
 		if err := v2.RetryUploadedBlockMaterialization("PutBlock", internalID, func() error {
 			probe, probeErr := syncProbeUploadedBlockReuseFn(h.db, orgID, internalID)
-			if probeErr == nil {
-				switch probe.Decision {
-				case db.BlockReuseReusable:
-					_, ensureErr := v2.EnsureReusableBlockPresent(c.Request.Context(), internalID, probe, data, h.storageManager, blockStore, storageClass, orgID)
-					return ensureErr
-				case db.BlockReuseNeedsPut:
-					if checker := getAPIQuotaChecker(); checker != nil {
-						if qs, _ := checker.CheckStorageQuota(orgID, userID, int64(len(data))); !qs.Allowed {
-							c.JSON(http.StatusForbidden, gin.H{"error": "storage quota exceeded"})
-							return errSyncStorageQuotaExceeded
-						}
-					}
-					if _, putErr := syncPutBlockAutoDirectFn(c.Request.Context(), blockStore, internalID, data); putErr != nil {
-						return fmt.Errorf("%w: %v", errSyncStoreBackend, putErr)
-					}
-					return nil
-				case db.BlockReuseBlockedByGC:
-					return v2.ErrBlockDeleteInProgress
-				}
-			} else {
-				log.Printf("PutBlock: block reuse probe unavailable for block %s; falling back to legacy Exists+PUT path: %v\n", internalID, probeErr)
+			if probeErr != nil {
+				return fmt.Errorf("probe block reuse for %s: %w", internalID, probeErr)
 			}
-
-			exists, existsErr := syncBlockExistsFn(c.Request.Context(), blockStore, internalID)
-			if existsErr != nil {
-				return fmt.Errorf("%w: %v", errSyncBlockExistenceCheck, existsErr)
+			probe, probeErr = syncPrepareUploadedBlockProbeFn(h.db, orgID, internalID, probe)
+			if probeErr != nil {
+				return probeErr
 			}
-			if !exists {
+			switch probe.Decision {
+			case db.BlockReuseReusable:
+				_, ensureErr := v2.EnsureReusableBlockPresent(c.Request.Context(), internalID, probe, data, h.storageManager, blockStore, storageClass, orgID)
+				return ensureErr
+			case db.BlockReuseNeedsPut:
 				if checker := getAPIQuotaChecker(); checker != nil {
 					if qs, _ := checker.CheckStorageQuota(orgID, userID, int64(len(data))); !qs.Allowed {
 						c.JSON(http.StatusForbidden, gin.H{"error": "storage quota exceeded"})
 						return errSyncStorageQuotaExceeded
 					}
 				}
-				if _, putErr := syncPutBlockDataFn(c.Request.Context(), blockStore, blockData); putErr != nil {
+				if _, putErr := syncPutBlockAutoDirectFn(c.Request.Context(), blockStore, internalID, data); putErr != nil {
 					return fmt.Errorf("%w: %v", errSyncStoreBackend, putErr)
 				}
+				return nil
+			case db.BlockReuseBlockedByGC:
+				return v2.ErrBlockDeleteInProgress
 			}
-			return nil
+			return fmt.Errorf("unexpected block reuse decision %d for %s", probe.Decision, internalID)
 		}, func() error {
 			return registerUploadedBlockAndMappingForSyncFn(h.db, orgID, repoID, internalID, operationID, len(data), storageClass, "", externalMappingID)
 		}, nil, nil); err != nil {

--- a/internal/api/v2/blocks.go
+++ b/internal/api/v2/blocks.go
@@ -704,6 +704,29 @@ func (h *BlockHandler) materializeUploadedBlock(session db.BlockUploadSession, s
 	return nil
 }
 
+// respondBlockMaterializeError maps a materializeUploadedBlock failure to the web
+// funnel's HTTP response and reports whether it wrote one (the caller must return
+// when it did). It is the single place the two UploadBlock materialize sites share.
+//
+// A verified external→different-internal mapping conflict is a permanent 409. Every
+// other error — including ErrBlockDeleteInProgress, which the metadata-upsert backstop
+// now raises on a lost stub-repair race — is a fail-closed 500. This is the deliberate
+// PR-2 boundary: unlike the six funnels wrapped in RetryUploadedBlockMaterialization,
+// this unprobed web-session funnel has no bounded retry yet. PR-5 must consciously
+// change ErrBlockDeleteInProgress here to a 409 + Retry-After once traffic accounting
+// and the staged-block reservation are hoisted so a retry cannot double-charge.
+func respondBlockMaterializeError(c *gin.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, db.ErrBlockIDMappingConflict) {
+		c.JSON(http.StatusConflict, gin.H{"error": "block id mapping conflict"})
+		return true
+	}
+	c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to register block"})
+	return true
+}
+
 // CheckBlocksRequest is the request body for checking blocks
 type CheckBlocksRequest struct {
 	Hashes []string `json:"hashes" binding:"required"`
@@ -939,12 +962,7 @@ func (h *BlockHandler) UploadBlock(c *gin.Context) {
 		// GOVERN the block (metadata + provisional ref) so the session can commit
 		// it and GC can reclaim it, not merely to store bytes.
 		if resolution == uploadSessionValid {
-			if err := h.materializeUploadedBlock(session, hash, sha1Hash, len(data), storageClass, false); err != nil {
-				if errors.Is(err, db.ErrBlockIDMappingConflict) {
-					c.JSON(http.StatusConflict, gin.H{"error": "block id mapping conflict"})
-					return
-				}
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to register block"})
+			if respondBlockMaterializeError(c, h.materializeUploadedBlock(session, hash, sha1Hash, len(data), storageClass, false)) {
 				return
 			}
 		}
@@ -1039,12 +1057,7 @@ func (h *BlockHandler) UploadBlock(c *gin.Context) {
 
 	// R9: govern the freshly stored block under the session.
 	if resolution == uploadSessionValid {
-		if err := h.materializeUploadedBlock(session, hash, sha1Hash, len(data), storageClass, true); err != nil {
-			if errors.Is(err, db.ErrBlockIDMappingConflict) {
-				c.JSON(http.StatusConflict, gin.H{"error": "block id mapping conflict"})
-				return
-			}
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to register block"})
+		if respondBlockMaterializeError(c, h.materializeUploadedBlock(session, hash, sha1Hash, len(data), storageClass, true)) {
 			return
 		}
 	}

--- a/internal/api/v2/blocks_test.go
+++ b/internal/api/v2/blocks_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -381,11 +382,14 @@ func TestCheckBlocksReusableCandidatesParallel_ProbesMetadataFirst(t *testing.T)
 		checkBlocksProbeReuseFn = origProbe
 	}()
 
-	var probeCalls int
+	var probeCalls atomic.Int32
 	checkBlocksProbeReuseFn = func(database *db.DB, orgID, hash string) (db.BlockReuseProbe, error) {
-		probeCalls++
+		probeCalls.Add(1)
 		if hash == "reusable" {
 			return db.BlockReuseProbe{Decision: db.BlockReuseReusable}, nil
+		}
+		if hash == "stub" {
+			return db.BlockReuseProbe{Decision: db.BlockReuseRepairableStub}, nil
 		}
 		return db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut}, nil
 	}
@@ -394,17 +398,20 @@ func TestCheckBlocksReusableCandidatesParallel_ProbesMetadataFirst(t *testing.T)
 		context.Background(),
 		nil,
 		"org",
-		[]string{"new", "reusable"},
+		[]string{"new", "stub", "reusable"},
 		2,
 	)
 	if err != nil {
 		t.Fatalf("checkBlocksReusableCandidatesParallel returned error: %v", err)
 	}
-	if probeCalls != 2 {
-		t.Fatalf("probeCalls = %d, want 2 (probe all hashes in metadata plane first)", probeCalls)
+	if probeCalls.Load() != 3 {
+		t.Fatalf("probeCalls = %d, want 3 (probe all hashes in metadata plane first)", probeCalls.Load())
 	}
 	if reusableByHash["new"] {
 		t.Fatal("non-reusable block reported reusable")
+	}
+	if reusableByHash["stub"] {
+		t.Fatal("repairable stub reported reusable")
 	}
 	if !reusableByHash["reusable"] {
 		t.Fatal("reusable block not reported reusable")

--- a/internal/api/v2/blocks_test.go
+++ b/internal/api/v2/blocks_test.go
@@ -601,18 +601,68 @@ func TestUploadBlock_NoContentLength(t *testing.T) {
 	}
 }
 
-// TestUploadBlockMaterializeSurfacesFenceUntilPR5 pins the current PR-2 boundary of
-// the seventh (web-session) funnel. Unlike the six funnels wrapped in
-// RetryUploadedBlockMaterialization, UploadBlock calls materializeUploadedBlock
-// directly with no retry wrapper, so a GC fence / contended-stub signal
-// (ErrBlockDeleteInProgress, which the metadata-upsert backstop now produces on a
-// lost stub-repair race) propagates straight out and UploadBlock maps it to a 500 —
-// it is NOT reclassified as a mapping conflict and NOT retried here. Turning this
-// into a re-probing 409 + Retry-After is PR-5's job, together with hoisting traffic
-// accounting and the staged-block reservation so a retry cannot double-charge. If
-// this test changes, the PR-2/PR-5 scope notes in GC-UPLOAD-FENCE-PR-PLAN.md must
-// change with it.
-func TestUploadBlockMaterializeSurfacesFenceUntilPR5(t *testing.T) {
+// TestRespondBlockMaterializeError_FenceIs500UntilPR5 pins the current PR-2 boundary
+// of the seventh (web-session) funnel through the exact error->status mapping the
+// UploadBlock handler uses. Both UploadBlock materialize sites route through
+// respondBlockMaterializeError, so this drives the real HTTP decision, not a stand-in.
+//
+// Unlike the six funnels wrapped in RetryUploadedBlockMaterialization, this funnel has
+// no bounded retry, so a GC fence / contended-stub signal (ErrBlockDeleteInProgress,
+// which the metadata-upsert backstop now raises on a lost stub-repair race) is a
+// fail-closed 500 — NOT reclassified as a 409 mapping conflict and NOT retried. PR-5
+// must consciously change this expectation to 409 + Retry-After once traffic and the
+// staged-block reservation are hoisted so a retry cannot double-charge. If this test
+// changes, the PR-2/PR-5 scope notes in GC-UPLOAD-FENCE-PR-PLAN.md must change with it.
+func TestRespondBlockMaterializeError_FenceIs500UntilPR5(t *testing.T) {
+	newCtx := func() (*gin.Context, *httptest.ResponseRecorder) {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		return c, w
+	}
+
+	t.Run("nil error writes no response and does not stop the handler", func(t *testing.T) {
+		c, w := newCtx()
+		if respondBlockMaterializeError(c, nil) {
+			t.Fatal("respondBlockMaterializeError(nil) = true, want false")
+		}
+		if w.Code != http.StatusOK { // untouched recorder default
+			t.Fatalf("status = %d, want %d (no response written)", w.Code, http.StatusOK)
+		}
+	})
+
+	t.Run("GC fence / contended stub is a fail-closed 500 (PR-5 flips to 409)", func(t *testing.T) {
+		c, w := newCtx()
+		fenceErr := fmt.Errorf("%w: block fenced during web-session materialize", ErrBlockDeleteInProgress)
+		if !respondBlockMaterializeError(c, fenceErr) {
+			t.Fatal("respondBlockMaterializeError(fence) = false, want true (response written, caller returns)")
+		}
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want %d — PR-5 changes this to 409 + Retry-After", w.Code, http.StatusInternalServerError)
+		}
+		if strings.Contains(w.Body.String(), "block id mapping conflict") {
+			t.Fatalf("fence 500 must not read as a mapping conflict; body = %s", w.Body.String())
+		}
+	})
+
+	t.Run("verified mapping conflict is a permanent 409", func(t *testing.T) {
+		c, w := newCtx()
+		if !respondBlockMaterializeError(c, fmt.Errorf("remap: %w", db.ErrBlockIDMappingConflict)) {
+			t.Fatal("respondBlockMaterializeError(conflict) = false, want true")
+		}
+		if w.Code != http.StatusConflict {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusConflict)
+		}
+		if !strings.Contains(w.Body.String(), "block id mapping conflict") {
+			t.Fatalf("409 body = %s, want block id mapping conflict", w.Body.String())
+		}
+	})
+}
+
+// TestUploadBlockMaterializePropagatesFence keeps the seam honest at the
+// materializeUploadedBlock boundary: it must propagate ErrBlockDeleteInProgress
+// unchanged (never swallow it or reshape it into a mapping conflict) so the handler
+// mapping above sees the real signal.
+func TestUploadBlockMaterializePropagatesFence(t *testing.T) {
 	old := registerUploadedBlockForMaterializationFn
 	t.Cleanup(func() { registerUploadedBlockForMaterializationFn = old })
 	registerUploadedBlockForMaterializationFn = func(_ *db.DB, _, _, _, _ string, _ int, _, _, _ string) error {
@@ -626,7 +676,7 @@ func TestUploadBlockMaterializeSurfacesFenceUntilPR5(t *testing.T) {
 		t.Fatalf("materializeUploadedBlock err = %v, want ErrBlockDeleteInProgress propagated", err)
 	}
 	if errors.Is(err, db.ErrBlockIDMappingConflict) {
-		t.Fatal("fence error must not masquerade as a mapping conflict (that would wrongly 409 today)")
+		t.Fatal("fence error must not masquerade as a mapping conflict")
 	}
 }
 

--- a/internal/api/v2/blocks_test.go
+++ b/internal/api/v2/blocks_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -597,6 +598,35 @@ func TestUploadBlock_NoContentLength(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+// TestUploadBlockMaterializeSurfacesFenceUntilPR5 pins the current PR-2 boundary of
+// the seventh (web-session) funnel. Unlike the six funnels wrapped in
+// RetryUploadedBlockMaterialization, UploadBlock calls materializeUploadedBlock
+// directly with no retry wrapper, so a GC fence / contended-stub signal
+// (ErrBlockDeleteInProgress, which the metadata-upsert backstop now produces on a
+// lost stub-repair race) propagates straight out and UploadBlock maps it to a 500 —
+// it is NOT reclassified as a mapping conflict and NOT retried here. Turning this
+// into a re-probing 409 + Retry-After is PR-5's job, together with hoisting traffic
+// accounting and the staged-block reservation so a retry cannot double-charge. If
+// this test changes, the PR-2/PR-5 scope notes in GC-UPLOAD-FENCE-PR-PLAN.md must
+// change with it.
+func TestUploadBlockMaterializeSurfacesFenceUntilPR5(t *testing.T) {
+	old := registerUploadedBlockForMaterializationFn
+	t.Cleanup(func() { registerUploadedBlockForMaterializationFn = old })
+	registerUploadedBlockForMaterializationFn = func(_ *db.DB, _, _, _, _ string, _ int, _, _, _ string) error {
+		return fmt.Errorf("%w: block fenced during web-session materialize", ErrBlockDeleteInProgress)
+	}
+
+	h := &BlockHandler{}
+	session := db.BlockUploadSession{SessionID: "sess-1", OrgID: "org-1", RepoID: "repo-1"}
+	err := h.materializeUploadedBlock(session, strings.Repeat("a", 64), strings.Repeat("b", 40), 5, "hot", true)
+	if !errors.Is(err, ErrBlockDeleteInProgress) {
+		t.Fatalf("materializeUploadedBlock err = %v, want ErrBlockDeleteInProgress propagated", err)
+	}
+	if errors.Is(err, db.ErrBlockIDMappingConflict) {
+		t.Fatal("fence error must not masquerade as a mapping conflict (that would wrongly 409 today)")
 	}
 }
 

--- a/internal/api/v2/files.go
+++ b/internal/api/v2/files.go
@@ -1334,33 +1334,31 @@ func (h *FileHandler) CreateFile(c *gin.Context) {
 					return nil
 				}
 				probe, probeErr := probeUploadedBlockReuseFn(h.db, orgID, templateBlockData.Hash)
-				if probeErr == nil {
-					switch probe.Decision {
-					case db.BlockReuseReusable:
-						if _, ensureErr := EnsureReusableBlockPresent(c.Request.Context(), templateBlockData.Hash, probe, templateBlockData.Data, h.storageManager, templateBlockStore, templateStorageClass, orgID); ensureErr != nil {
-							return fmt.Errorf("failed to verify reusable template block: %w", ensureErr)
-						}
-						templateBlockStored = true
-						return nil
-					case db.BlockReuseNeedsPut:
-						if _, err := putUploadedBlockAutoDirectFn(c.Request.Context(), templateBlockStore, templateBlockData.Hash, templateBlockData.Data); err != nil {
-							return fmt.Errorf("failed to store file content: %w", err)
-						}
-						templateBlockStored = true
-						log.Printf("[CreateFile] Created Office file %s with template size %d bytes", fileName, fileSize)
-						return nil
-					case db.BlockReuseBlockedByGC:
-						return ErrBlockDeleteInProgress
+				if probeErr != nil {
+					return fmt.Errorf("probe template block reuse for %s: %w", templateBlockData.Hash, probeErr)
+				}
+				probe, probeErr = prepareUploadedBlockProbeFn(h.db, orgID, templateBlockData.Hash, probe)
+				if probeErr != nil {
+					return probeErr
+				}
+				switch probe.Decision {
+				case db.BlockReuseReusable:
+					if _, ensureErr := EnsureReusableBlockPresent(c.Request.Context(), templateBlockData.Hash, probe, templateBlockData.Data, h.storageManager, templateBlockStore, templateStorageClass, orgID); ensureErr != nil {
+						return fmt.Errorf("failed to verify reusable template block: %w", ensureErr)
 					}
-				} else {
-					log.Printf("[CreateFile] Block reuse probe unavailable for template block %s; falling back to legacy Exists+PUT path: %v", templateBlockData.Hash[:16], probeErr)
+					templateBlockStored = true
+					return nil
+				case db.BlockReuseNeedsPut:
+					if _, err := putUploadedBlockAutoDirectFn(c.Request.Context(), templateBlockStore, templateBlockData.Hash, templateBlockData.Data); err != nil {
+						return fmt.Errorf("failed to store file content: %w", err)
+					}
+					templateBlockStored = true
+					log.Printf("[CreateFile] Created Office file %s with template size %d bytes", fileName, fileSize)
+					return nil
+				case db.BlockReuseBlockedByGC:
+					return ErrBlockDeleteInProgress
 				}
-				if _, err := templateBlockStore.PutBlockData(c.Request.Context(), templateBlockData); err != nil {
-					return fmt.Errorf("failed to store file content: %w", err)
-				}
-				templateBlockStored = true
-				log.Printf("[CreateFile] Created Office file %s with template size %d bytes", fileName, fileSize)
-				return nil
+				return fmt.Errorf("unexpected template block reuse decision %d for %s", probe.Decision, templateBlockData.Hash)
 			}, func() error {
 				// Keep the freshly stored template block alive and respect the GC
 				// delete fence until publish-attempt refs take over below. Use the
@@ -3433,26 +3431,26 @@ func (h *FileHandler) UploadFile(c *gin.Context) {
 	}
 	if err := RetryUploadedBlockMaterialization("UploadFile", sha256ID, func() error {
 		probe, probeErr := probeUploadedBlockReuseFn(h.db, orgID, sha256ID)
-		if probeErr == nil {
-			switch probe.Decision {
-			case db.BlockReuseReusable:
-				_, ensureErr := EnsureReusableBlockPresent(c.Request.Context(), sha256ID, probe, storedContent, h.storageManager, blockStore, storageClass, orgID)
-				return ensureErr
-			case db.BlockReuseNeedsPut:
-				if _, putErr := putUploadedBlockAutoDirectFn(c.Request.Context(), blockStore, sha256ID, storedContent); putErr != nil {
-					return fmt.Errorf("failed to store block: %w", putErr)
-				}
-				return nil
-			case db.BlockReuseBlockedByGC:
-				return ErrBlockDeleteInProgress
+		if probeErr != nil {
+			return fmt.Errorf("probe block reuse for %s: %w", sha256ID, probeErr)
+		}
+		probe, probeErr = prepareUploadedBlockProbeFn(h.db, orgID, sha256ID, probe)
+		if probeErr != nil {
+			return probeErr
+		}
+		switch probe.Decision {
+		case db.BlockReuseReusable:
+			_, ensureErr := EnsureReusableBlockPresent(c.Request.Context(), sha256ID, probe, storedContent, h.storageManager, blockStore, storageClass, orgID)
+			return ensureErr
+		case db.BlockReuseNeedsPut:
+			if _, putErr := putUploadedBlockAutoDirectFn(c.Request.Context(), blockStore, sha256ID, storedContent); putErr != nil {
+				return fmt.Errorf("failed to store block: %w", putErr)
 			}
-		} else {
-			log.Printf("[UploadFile] Block reuse probe unavailable for block %s; falling back to legacy Exists+PUT path: %v", sha256ID[:16], probeErr)
+			return nil
+		case db.BlockReuseBlockedByGC:
+			return ErrBlockDeleteInProgress
 		}
-		if _, putErr := blockStore.PutBlockAuto(c.Request.Context(), sha256ID, storedContent); putErr != nil {
-			return fmt.Errorf("failed to store block: %w", putErr)
-		}
-		return nil
+		return fmt.Errorf("unexpected block reuse decision %d for %s", probe.Decision, sha256ID)
 	}, func() error {
 		// Register block metadata + a provisional reference (kept alive by TTL until
 		// the fs_object commit below creates the permanent reference), then write the

--- a/internal/api/v2/fs_helpers.go
+++ b/internal/api/v2/fs_helpers.go
@@ -1008,6 +1008,12 @@ func (h *FSHelper) RegisterUploadedBlock(orgID, libraryID, blockID, operationID 
 		}
 		if !deleteFenceActive {
 			if err := registerUploadedBlockUpsertMetadataFn(h, orgID, libraryID, blockID, sha1ID, sizeBytes, storageClass, storageKey); err != nil {
+				// A contended stub repair is a transient race (concurrent completion or
+				// a reappeared GC orphan fence), not a permanent failure. Surface it as
+				// the retryable GC-fence signal so the materialization wrapper re-probes.
+				if errors.Is(err, db.ErrBlockStubRepairContended) {
+					return fmt.Errorf("%w: block %s stub repair lost a race", ErrBlockDeleteInProgress, blockID)
+				}
 				return fmt.Errorf("upsert block metadata for %s: %w", blockID, err)
 			}
 			return nil

--- a/internal/api/v2/fs_helpers.go
+++ b/internal/api/v2/fs_helpers.go
@@ -85,14 +85,6 @@ var registerUploadedBlockFenceActiveFn = func(h *FSHelper, orgID, blockID string
 	return h.db.BlockDeleteFenceActive(orgID, blockID)
 }
 
-var registerUploadedBlockClaimInfoFn = func(h *FSHelper, orgID, blockID string) (db.BlockDeleteClaimInfo, bool, error) {
-	return h.db.GetBlockDeleteClaimInfo(orgID, blockID)
-}
-
-var registerUploadedBlockReleaseClaimFn = func(h *FSHelper, orgID, blockID, claimID string) (bool, error) {
-	return h.db.ReleaseBlockDeleteClaim(orgID, blockID, claimID)
-}
-
 var registerUploadedBlockUpsertMetadataFn = func(h *FSHelper, orgID, libraryID, blockID, sha1ID string, sizeBytes int, storageClass, storageKey string) error {
 	representationID, err := db.ResolveBlockRepresentationID(h.db.Session(), orgID, libraryID)
 	if err != nil {
@@ -991,31 +983,6 @@ func (h *FSHelper) ResolveStoredBlockIDs(orgID, libraryID string, blockIDs []str
 // the current operation. Only if the fence never clears inside the bounded
 // retry budget do we roll back our own provisional ref and re-enqueue any
 // newly-zero-ref block for GC before returning a retryable error.
-func (h *FSHelper) releaseStaleUploadedBlockDeleteClaim(orgID, blockID string) (bool, error) {
-	if h == nil || h.db == nil {
-		return false, nil
-	}
-	claimInfo, found, err := registerUploadedBlockClaimInfoFn(h, orgID, blockID)
-	if err != nil {
-		return false, fmt.Errorf("load block delete claim for %s: %w", blockID, err)
-	}
-	if !found || claimInfo.GCState != db.BlockGCStateDeleting {
-		return false, nil
-	}
-	if strings.TrimSpace(claimInfo.StorageClass) != "" || strings.TrimSpace(claimInfo.GCClaimID) == "" {
-		return false, nil
-	}
-
-	released, err := registerUploadedBlockReleaseClaimFn(h, orgID, blockID, claimInfo.GCClaimID)
-	if err != nil {
-		return false, fmt.Errorf("release stale delete claim for %s: %w", blockID, err)
-	}
-	if released {
-		log.Printf("[RegisterUploadedBlock] released stale GC delete claim for block %s with empty storage class", blockID)
-	}
-	return released, nil
-}
-
 func (h *FSHelper) RegisterUploadedBlock(orgID, libraryID, blockID, operationID string, sizeBytes int, storageClass, storageKey, sha1ID string) error {
 	referrer := db.BlockReferrerForUpload(operationID)
 	expiresAt := time.Now().UTC().Add(time.Duration(db.ProvisionalBlockReferenceTTLSeconds) * time.Second)
@@ -1045,12 +1012,6 @@ func (h *FSHelper) RegisterUploadedBlock(orgID, libraryID, blockID, operationID 
 			}
 			return nil
 		}
-		if released, err := h.releaseStaleUploadedBlockDeleteClaim(orgID, blockID); err != nil {
-			return err
-		} else if released {
-			continue
-		}
-
 		if attempt == attempts {
 			zeroRefBlocks := registerUploadedBlockReleaseRefsFn(h, orgID, libraryID, operationID, []string{blockID})
 			registerUploadedBlockEnqueueZeroRefFn(orgID, zeroRefBlocks, storageClass)

--- a/internal/api/v2/fs_helpers_test.go
+++ b/internal/api/v2/fs_helpers_test.go
@@ -162,8 +162,6 @@ func TestRegisterUploadedBlock_RetriesFenceWithoutDroppingProvisionalRef(t *test
 	helper := &FSHelper{}
 	oldAdd := registerUploadedBlockAddReferenceFn
 	oldFence := registerUploadedBlockFenceActiveFn
-	oldClaimInfo := registerUploadedBlockClaimInfoFn
-	oldReleaseClaim := registerUploadedBlockReleaseClaimFn
 	oldUpsert := registerUploadedBlockUpsertMetadataFn
 	oldUpsertExpiry := registerUploadedBlockUpsertProvisionalExpiryFn
 	oldRelease := registerUploadedBlockReleaseRefsFn
@@ -173,8 +171,6 @@ func TestRegisterUploadedBlock_RetriesFenceWithoutDroppingProvisionalRef(t *test
 	t.Cleanup(func() {
 		registerUploadedBlockAddReferenceFn = oldAdd
 		registerUploadedBlockFenceActiveFn = oldFence
-		registerUploadedBlockClaimInfoFn = oldClaimInfo
-		registerUploadedBlockReleaseClaimFn = oldReleaseClaim
 		registerUploadedBlockUpsertMetadataFn = oldUpsert
 		registerUploadedBlockUpsertProvisionalExpiryFn = oldUpsertExpiry
 		registerUploadedBlockReleaseRefsFn = oldRelease
@@ -202,14 +198,6 @@ func TestRegisterUploadedBlock_RetriesFenceWithoutDroppingProvisionalRef(t *test
 		fenceChecks++
 		calls = append(calls, fmt.Sprintf("fence-%d", fenceChecks))
 		return fenceChecks == 1, nil
-	}
-	registerUploadedBlockClaimInfoFn = func(h *FSHelper, orgID, blockID string) (db.BlockDeleteClaimInfo, bool, error) {
-		t.Fatal("stale claim lookup should not run for a normal retrying fence")
-		return db.BlockDeleteClaimInfo{}, false, nil
-	}
-	registerUploadedBlockReleaseClaimFn = func(h *FSHelper, orgID, blockID, claimID string) (bool, error) {
-		t.Fatal("stale claim release should not run for a normal retrying fence")
-		return false, nil
 	}
 	registerUploadedBlockUpsertMetadataFn = func(h *FSHelper, orgID, libraryID, blockID, sha1ID string, sizeBytes int, storageClass, storageKey string) error {
 		calls = append(calls, "upsert")
@@ -249,91 +237,6 @@ func TestRegisterUploadedBlock_RetriesFenceWithoutDroppingProvisionalRef(t *test
 		t.Fatalf("RegisterUploadedBlock() error = %v, want nil", err)
 	}
 	want := []string{"add", "expiry", "fence-1", "backoff-1", "sleep-1ms", "fence-2", "upsert"}
-	if len(calls) != len(want) {
-		t.Fatalf("calls = %#v, want %#v", calls, want)
-	}
-	for i := range want {
-		if calls[i] != want[i] {
-			t.Fatalf("calls[%d] = %q, want %q (full=%#v)", i, calls[i], want[i], calls)
-		}
-	}
-}
-
-func TestRegisterUploadedBlock_ReleasesStaleDeleteClaimWithEmptyStorageClass(t *testing.T) {
-	helper := &FSHelper{db: &db.DB{}}
-	oldAdd := registerUploadedBlockAddReferenceFn
-	oldFence := registerUploadedBlockFenceActiveFn
-	oldClaimInfo := registerUploadedBlockClaimInfoFn
-	oldReleaseClaim := registerUploadedBlockReleaseClaimFn
-	oldUpsert := registerUploadedBlockUpsertMetadataFn
-	oldUpsertExpiry := registerUploadedBlockUpsertProvisionalExpiryFn
-	oldRelease := registerUploadedBlockReleaseRefsFn
-	oldBackoff := registerUploadedBlockRetryBackoffFn
-	oldSleep := registerUploadedBlockSleepFn
-	t.Cleanup(func() {
-		registerUploadedBlockAddReferenceFn = oldAdd
-		registerUploadedBlockFenceActiveFn = oldFence
-		registerUploadedBlockClaimInfoFn = oldClaimInfo
-		registerUploadedBlockReleaseClaimFn = oldReleaseClaim
-		registerUploadedBlockUpsertMetadataFn = oldUpsert
-		registerUploadedBlockUpsertProvisionalExpiryFn = oldUpsertExpiry
-		registerUploadedBlockReleaseRefsFn = oldRelease
-		registerUploadedBlockRetryBackoffFn = oldBackoff
-		registerUploadedBlockSleepFn = oldSleep
-	})
-
-	var calls []string
-	registerUploadedBlockAddReferenceFn = func(h *FSHelper, orgID, blockID, referrer, libraryID string, ttlSeconds int) error {
-		calls = append(calls, "add")
-		return nil
-	}
-	fenceChecks := 0
-	registerUploadedBlockFenceActiveFn = func(h *FSHelper, orgID, blockID string) (bool, error) {
-		fenceChecks++
-		calls = append(calls, fmt.Sprintf("fence-%d", fenceChecks))
-		return fenceChecks == 1, nil
-	}
-	registerUploadedBlockClaimInfoFn = func(h *FSHelper, orgID, blockID string) (db.BlockDeleteClaimInfo, bool, error) {
-		calls = append(calls, "claim-info")
-		return db.BlockDeleteClaimInfo{GCState: db.BlockGCStateDeleting, GCClaimID: "claim-1"}, true, nil
-	}
-	registerUploadedBlockReleaseClaimFn = func(h *FSHelper, orgID, blockID, claimID string) (bool, error) {
-		calls = append(calls, "release-claim")
-		if claimID != "claim-1" {
-			t.Fatalf("claimID = %q, want claim-1", claimID)
-		}
-		return true, nil
-	}
-	registerUploadedBlockUpsertMetadataFn = func(h *FSHelper, orgID, libraryID, blockID, sha1ID string, sizeBytes int, storageClass, storageKey string) error {
-		calls = append(calls, "upsert")
-		if libraryID != "lib-1" {
-			t.Fatalf("libraryID = %q, want lib-1", libraryID)
-		}
-		if sha1ID != "sha1-1" {
-			t.Fatalf("sha1ID = %q, want sha1-1", sha1ID)
-		}
-		return nil
-	}
-	registerUploadedBlockUpsertProvisionalExpiryFn = func(h *FSHelper, orgID, blockID, referrer, storageClass string, expiresAt time.Time) error {
-		calls = append(calls, "expiry")
-		return nil
-	}
-	registerUploadedBlockReleaseRefsFn = func(h *FSHelper, orgID, libraryID, operationID string, blockIDs []string) []string {
-		t.Fatal("release refs should not run when stale claim release succeeds")
-		return nil
-	}
-	registerUploadedBlockRetryBackoffFn = func(attempt int) time.Duration {
-		t.Fatal("backoff should not run when stale claim release succeeds")
-		return 0
-	}
-	registerUploadedBlockSleepFn = func(delay time.Duration) {
-		t.Fatalf("sleep should not run when stale claim release succeeds, got %s", delay)
-	}
-
-	if err := helper.RegisterUploadedBlock("org-1", "lib-1", "block-1", "op-1", 123, "hot", "key-1", "sha1-1"); err != nil {
-		t.Fatalf("RegisterUploadedBlock() error = %v, want nil", err)
-	}
-	want := []string{"add", "expiry", "fence-1", "claim-info", "release-claim", "fence-2", "upsert"}
 	if len(calls) != len(want) {
 		t.Fatalf("calls = %#v, want %#v", calls, want)
 	}

--- a/internal/api/v2/fs_helpers_test.go
+++ b/internal/api/v2/fs_helpers_test.go
@@ -247,6 +247,45 @@ func TestRegisterUploadedBlock_RetriesFenceWithoutDroppingProvisionalRef(t *test
 	}
 }
 
+// TestRegisterUploadedBlock_TranslatesContendedStubRepairToRetryableFence proves
+// that a benign lost stub-repair race inside the metadata upsert (the backstop for
+// the unprobed web-session funnel) surfaces as the retryable ErrBlockDeleteInProgress
+// signal rather than a hard error, so the materialization wrapper re-probes.
+func TestRegisterUploadedBlock_TranslatesContendedStubRepairToRetryableFence(t *testing.T) {
+	helper := &FSHelper{}
+	oldAdd := registerUploadedBlockAddReferenceFn
+	oldFence := registerUploadedBlockFenceActiveFn
+	oldUpsert := registerUploadedBlockUpsertMetadataFn
+	oldUpsertExpiry := registerUploadedBlockUpsertProvisionalExpiryFn
+	oldRelease := registerUploadedBlockReleaseRefsFn
+	oldAttempts := registerUploadedBlockRetryAttemptsFn
+	t.Cleanup(func() {
+		registerUploadedBlockAddReferenceFn = oldAdd
+		registerUploadedBlockFenceActiveFn = oldFence
+		registerUploadedBlockUpsertMetadataFn = oldUpsert
+		registerUploadedBlockUpsertProvisionalExpiryFn = oldUpsertExpiry
+		registerUploadedBlockReleaseRefsFn = oldRelease
+		registerUploadedBlockRetryAttemptsFn = oldAttempts
+	})
+
+	registerUploadedBlockAddReferenceFn = func(*FSHelper, string, string, string, string, int) error { return nil }
+	registerUploadedBlockUpsertProvisionalExpiryFn = func(*FSHelper, string, string, string, string, time.Time) error { return nil }
+	registerUploadedBlockFenceActiveFn = func(*FSHelper, string, string) (bool, error) { return false, nil }
+	registerUploadedBlockRetryAttemptsFn = func() int { return 1 }
+	registerUploadedBlockReleaseRefsFn = func(*FSHelper, string, string, string, []string) []string {
+		t.Fatal("provisional ref must survive a transient contended-stub error for the retry")
+		return nil
+	}
+	registerUploadedBlockUpsertMetadataFn = func(*FSHelper, string, string, string, string, int, string, string) error {
+		return fmt.Errorf("%w: block block-1 changed before stub repair", db.ErrBlockStubRepairContended)
+	}
+
+	err := helper.RegisterUploadedBlock("org-1", "lib-1", "block-1", "op-1", 123, "hot", "key-1", "sha1-1")
+	if !errors.Is(err, ErrBlockDeleteInProgress) {
+		t.Fatalf("RegisterUploadedBlock() error = %v, want ErrBlockDeleteInProgress", err)
+	}
+}
+
 func TestRegisterUploadedBlock_RecordsProvisionalExpiryAtTTL(t *testing.T) {
 	helper := &FSHelper{}
 	oldAdd := registerUploadedBlockAddReferenceFn

--- a/internal/api/v2/onlyoffice.go
+++ b/internal/api/v2/onlyoffice.go
@@ -1210,35 +1210,29 @@ func (h *OnlyOfficeHandler) saveEditedDocument(ctx context.Context, repoID, file
 	var storageKey string
 	if err := RetryUploadedBlockMaterialization("OnlyOffice", internalBlockID, func() error {
 		probe, probeErr := probeUploadedBlockReuseFn(h.db, orgID, internalBlockID)
-		if probeErr == nil {
-			switch probe.Decision {
-			case db.BlockReuseReusable:
-				var ensureErr error
-				storageKey, ensureErr = EnsureReusableBlockPresent(ctx, internalBlockID, probe, content, h.storageManager, blockStore, storageClass, orgID)
-				return ensureErr
-			case db.BlockReuseNeedsPut:
-				var putErr error
-				storageKey, putErr = putUploadedBlockAutoDirectFn(ctx, blockStore, internalBlockID, content)
-				if putErr != nil {
-					return fmt.Errorf("failed to store block: %w", putErr)
-				}
-				return nil
-			case db.BlockReuseBlockedByGC:
-				return ErrBlockDeleteInProgress
+		if probeErr != nil {
+			return fmt.Errorf("probe block reuse for %s: %w", internalBlockID, probeErr)
+		}
+		probe, probeErr = prepareUploadedBlockProbeFn(h.db, orgID, internalBlockID, probe)
+		if probeErr != nil {
+			return probeErr
+		}
+		switch probe.Decision {
+		case db.BlockReuseReusable:
+			var ensureErr error
+			storageKey, ensureErr = EnsureReusableBlockPresent(ctx, internalBlockID, probe, content, h.storageManager, blockStore, storageClass, orgID)
+			return ensureErr
+		case db.BlockReuseNeedsPut:
+			var putErr error
+			storageKey, putErr = putUploadedBlockAutoDirectFn(ctx, blockStore, internalBlockID, content)
+			if putErr != nil {
+				return fmt.Errorf("failed to store block: %w", putErr)
 			}
-		} else {
-			log.Printf("OnlyOffice: block reuse probe unavailable for block %s; falling back to legacy Exists+PUT path: %v", internalBlockID[:16], probeErr)
+			return nil
+		case db.BlockReuseBlockedByGC:
+			return ErrBlockDeleteInProgress
 		}
-		blockKey, putErr := blockStore.PutBlockData(ctx, &storage.BlockData{
-			Hash: internalBlockID,
-			Data: content,
-			Size: int64(len(content)),
-		})
-		if putErr != nil {
-			return fmt.Errorf("failed to store block: %w", putErr)
-		}
-		storageKey = blockKey
-		return nil
+		return fmt.Errorf("unexpected block reuse decision %d for %s", probe.Decision, internalBlockID)
 	}, func() error {
 		// Materialize block metadata/provisional ref first and then the sync mapping.
 		// Keep the pending-cleanup row on mapping failure so the reconciler can finish

--- a/internal/api/v2/upload_reuse.go
+++ b/internal/api/v2/upload_reuse.go
@@ -12,9 +12,13 @@ import (
 )
 
 var probeUploadedBlockReuseFn = ProbeUploadedBlockReuse
+var prepareUploadedBlockProbeFn = PrepareUploadedBlockProbe
 
 var putUploadedBlockAutoDirectFn = func(ctx context.Context, blockStore *storage.BlockStore, hash string, data []byte) (string, error) {
 	return blockStore.PutBlockAutoDirect(ctx, hash, data)
+}
+var repairReleasedBlockStubForUploadFn = func(database *db.DB, orgID, blockID string) (bool, error) {
+	return database.RepairReleasedBlockStub(orgID, blockID)
 }
 var resolveCanonicalBlockStoreFn = ResolveCanonicalBlockStore
 var reusableCanonicalObjectExistsFn = func(ctx context.Context, blockStore *storage.BlockStore, storageKey string) (bool, error) {
@@ -24,13 +28,34 @@ var repairCanonicalBlockDirectFn = func(ctx context.Context, blockStore *storage
 	return blockStore.PutObjectAutoDirect(ctx, storageKey, data)
 }
 
-// ProbeUploadedBlockReuse wraps the DB probe so callers can fail open to legacy
-// storage behavior when no Cassandra session is available.
+// ProbeUploadedBlockReuse wraps the DB probe. Upload callers fail closed when
+// Cassandra cannot establish whether GC owns the physical object.
 func ProbeUploadedBlockReuse(database *db.DB, orgID, blockID string) (db.BlockReuseProbe, error) {
 	if database == nil || database.Session() == nil {
 		return db.BlockReuseProbe{Decision: db.BlockReuseUnknownError}, fmt.Errorf("block reuse probe unavailable for %s: database session is nil", blockID)
 	}
 	return database.ProbeBlockReuse(orgID, blockID)
+}
+
+// PrepareUploadedBlockProbe repairs a released GC claim stub before the caller
+// enters its existing NeedsPut branch. A lost CAS is retryable, but the caller
+// must not PUT based on the stale probe.
+func PrepareUploadedBlockProbe(database *db.DB, orgID, blockID string, probe db.BlockReuseProbe) (db.BlockReuseProbe, error) {
+	if probe.Decision != db.BlockReuseRepairableStub {
+		return probe, nil
+	}
+	if database == nil {
+		return db.BlockReuseProbe{Decision: db.BlockReuseUnknownError}, fmt.Errorf("block stub repair unavailable for %s: database is nil", blockID)
+	}
+	repaired, err := repairReleasedBlockStubForUploadFn(database, orgID, blockID)
+	if err != nil {
+		return db.BlockReuseProbe{Decision: db.BlockReuseUnknownError}, fmt.Errorf("repair released block stub for %s: %w", blockID, err)
+	}
+	if !repaired {
+		return db.BlockReuseProbe{Decision: db.BlockReuseBlockedByGC}, fmt.Errorf("%w: block %s changed before stub repair", ErrBlockDeleteInProgress, blockID)
+	}
+	probe.Decision = db.BlockReuseNeedsPut
+	return probe, nil
 }
 
 // ResolveCanonicalBlockStore resolves the exact canonical backend for a block.

--- a/internal/api/v2/upload_reuse_test.go
+++ b/internal/api/v2/upload_reuse_test.go
@@ -115,6 +115,86 @@ func TestPrepareUploadedBlockProbeLeavesOtherDecisionsUntouched(t *testing.T) {
 	}
 }
 
+// TestRetryUploadedBlockMaterializationConvergesAfterLostStubRepairCAS proves the
+// acceptance property behind the lost-CAS reclassification: when a repairable stub
+// loses its conditional delete to a concurrent actor, the store phase surfaces a
+// retryable ErrBlockDeleteInProgress, the wrapper re-runs probe -> prepare -> store,
+// and the second probe (now Reusable, as another uploader finished) completes the
+// upload instead of returning a hard error.
+func TestRetryUploadedBlockMaterializationConvergesAfterLostStubRepairCAS(t *testing.T) {
+	oldDelay := libraryHeadMutationRetryDelay
+	oldMaxDelay := libraryHeadMutationRetryMaxDelay
+	oldJitter := libraryHeadMutationRetryJitter
+	oldSleep := registerUploadedBlockSleepFn
+	oldRepair := repairReleasedBlockStubForUploadFn
+	t.Cleanup(func() {
+		libraryHeadMutationRetryDelay = oldDelay
+		libraryHeadMutationRetryMaxDelay = oldMaxDelay
+		libraryHeadMutationRetryJitter = oldJitter
+		registerUploadedBlockSleepFn = oldSleep
+		repairReleasedBlockStubForUploadFn = oldRepair
+	})
+	libraryHeadMutationRetryDelay = time.Millisecond
+	libraryHeadMutationRetryMaxDelay = time.Millisecond
+	libraryHeadMutationRetryJitter = 0
+	registerUploadedBlockSleepFn = func(time.Duration) {}
+
+	// First attempt: repair loses the CAS (row changed under us) -> false, nil.
+	repairReleasedBlockStubForUploadFn = func(*db.DB, string, string) (bool, error) { return false, nil }
+
+	probeCalls := 0
+	reuseChecks := 0
+	puts := 0
+	materializeCalls := 0
+	store := func() error {
+		probeCalls++
+		var probe db.BlockReuseProbe
+		if probeCalls == 1 {
+			probe = db.BlockReuseProbe{Decision: db.BlockReuseRepairableStub}
+		} else {
+			// The concurrent actor finished materializing the block; a fresh probe
+			// now sees it as reusable and repair must not run again.
+			repairReleasedBlockStubForUploadFn = func(*db.DB, string, string) (bool, error) {
+				t.Fatal("repair must not run once the block is reusable")
+				return false, nil
+			}
+			probe = db.BlockReuseProbe{Decision: db.BlockReuseReusable}
+		}
+		prepared, prepErr := PrepareUploadedBlockProbe(&db.DB{}, "org-1", "block-1", probe)
+		if prepErr != nil {
+			return prepErr
+		}
+		switch prepared.Decision {
+		case db.BlockReuseReusable:
+			reuseChecks++
+			return nil
+		case db.BlockReuseNeedsPut:
+			puts++
+			return nil
+		case db.BlockReuseBlockedByGC:
+			return ErrBlockDeleteInProgress
+		}
+		return errors.New("unexpected decision")
+	}
+
+	err := RetryUploadedBlockMaterialization("UploadFile", "block-1", store, func() error {
+		materializeCalls++
+		return nil
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("RetryUploadedBlockMaterialization() error = %v, want nil", err)
+	}
+	if probeCalls != 2 {
+		t.Fatalf("probeCalls = %d, want 2 (retry re-probes)", probeCalls)
+	}
+	if reuseChecks != 1 || puts != 0 {
+		t.Fatalf("reuseChecks/puts = %d/%d, want 1/0 (converged to reusable, no PUT)", reuseChecks, puts)
+	}
+	if materializeCalls != 1 {
+		t.Fatalf("materializeCalls = %d, want 1", materializeCalls)
+	}
+}
+
 func TestRetryUploadedBlockMaterializationReturnsNonRetryableStoreError(t *testing.T) {
 	wantErr := errors.New("boom")
 	err := RetryUploadedBlockMaterialization("UploadFile", "block-1", func() error {

--- a/internal/api/v2/upload_reuse_test.go
+++ b/internal/api/v2/upload_reuse_test.go
@@ -66,6 +66,55 @@ func TestProbeUploadedBlockReuseReturnsUnknownErrorWithoutSession(t *testing.T) 
 	}
 }
 
+func TestPrepareUploadedBlockProbeRepairsReleasedStub(t *testing.T) {
+	oldRepair := repairReleasedBlockStubForUploadFn
+	t.Cleanup(func() { repairReleasedBlockStubForUploadFn = oldRepair })
+	deleteCalls := 0
+	repairReleasedBlockStubForUploadFn = func(database *db.DB, orgID, blockID string) (bool, error) {
+		deleteCalls++
+		if orgID != "org-1" || blockID != "block-1" {
+			t.Fatalf("delete args = %s/%s", orgID, blockID)
+		}
+		return true, nil
+	}
+
+	probe, err := PrepareUploadedBlockProbe(&db.DB{}, "org-1", "block-1", db.BlockReuseProbe{Decision: db.BlockReuseRepairableStub})
+	if err != nil {
+		t.Fatalf("PrepareUploadedBlockProbe() error = %v, want nil", err)
+	}
+	if probe.Decision != db.BlockReuseNeedsPut || deleteCalls != 1 {
+		t.Fatalf("decision/deleteCalls = %v/%d, want NeedsPut/1", probe.Decision, deleteCalls)
+	}
+}
+
+func TestPrepareUploadedBlockProbeLostCASStopsStore(t *testing.T) {
+	oldRepair := repairReleasedBlockStubForUploadFn
+	t.Cleanup(func() { repairReleasedBlockStubForUploadFn = oldRepair })
+	repairReleasedBlockStubForUploadFn = func(*db.DB, string, string) (bool, error) { return false, nil }
+
+	probe, err := PrepareUploadedBlockProbe(&db.DB{}, "org-1", "block-1", db.BlockReuseProbe{Decision: db.BlockReuseRepairableStub})
+	if !errors.Is(err, ErrBlockDeleteInProgress) {
+		t.Fatalf("PrepareUploadedBlockProbe() error = %v, want ErrBlockDeleteInProgress", err)
+	}
+	if probe.Decision != db.BlockReuseBlockedByGC {
+		t.Fatalf("decision = %v, want BlockReuseBlockedByGC", probe.Decision)
+	}
+}
+
+func TestPrepareUploadedBlockProbeLeavesOtherDecisionsUntouched(t *testing.T) {
+	oldRepair := repairReleasedBlockStubForUploadFn
+	t.Cleanup(func() { repairReleasedBlockStubForUploadFn = oldRepair })
+	repairReleasedBlockStubForUploadFn = func(*db.DB, string, string) (bool, error) {
+		t.Fatal("delete must not run for NeedsPut")
+		return false, nil
+	}
+
+	probe, err := PrepareUploadedBlockProbe(&db.DB{}, "org-1", "block-1", db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut})
+	if err != nil || probe.Decision != db.BlockReuseNeedsPut {
+		t.Fatalf("PrepareUploadedBlockProbe() = %v, %v", probe.Decision, err)
+	}
+}
+
 func TestRetryUploadedBlockMaterializationReturnsNonRetryableStoreError(t *testing.T) {
 	wantErr := errors.New("boom")
 	err := RetryUploadedBlockMaterialization("UploadFile", "block-1", func() error {

--- a/internal/db/block_references.go
+++ b/internal/db/block_references.go
@@ -50,6 +50,13 @@ const (
 // closed instead of overwriting such a row.
 var ErrBlockIDMappingConflict = errors.New("block id mapping conflict")
 
+// ErrBlockStubRepairContended indicates a metadata upsert could not repair a
+// released claim stub because the row changed under it — another uploader
+// finished materializing, or GC re-fenced the block. It is a benign concurrency
+// loss, not corruption: callers should re-probe and retry rather than surface a
+// hard error. Upload funnels translate it into their retryable GC-fence signal.
+var ErrBlockStubRepairContended = errors.New("block stub repair contended")
+
 type BlockReuseDecision int
 
 const (
@@ -575,7 +582,10 @@ func (db *DB) UpsertBlockMetadataWithRepresentationAndSHA1(orgID, representation
 				return fmt.Errorf("repair released block metadata stub for %s: %w", blockID, repairErr)
 			}
 			if !repaired {
-				return fmt.Errorf("block metadata for %s changed before stub repair", blockID)
+				// The stub changed under us (a concurrent uploader completed it, or a
+				// GC orphan fence reappeared). Both are transient: signal the retryable
+				// sentinel so the funnel re-probes instead of failing the upload.
+				return fmt.Errorf("%w: block %s changed before stub repair", ErrBlockStubRepairContended, blockID)
 			}
 			continue
 		}
@@ -691,7 +701,12 @@ func (db *DB) RepairReleasedBlockStub(orgID, blockID string) (bool, error) {
 		return false, fmt.Errorf("remove block stub repair claim: %w", deleteErr)
 	}
 	if !deleted {
-		return false, errors.New("block stub repair claim changed before delete")
+		// The row changed under us (another uploader finished materializing, or GC
+		// stole the claim with its `IF gc_state != 'deleting'` LWT). This is a benign
+		// concurrency loss, not corruption: nothing was deleted and the CAS stayed
+		// closed. Report it as retryable so the caller re-probes and converges to
+		// Reusable or BlockedByGC instead of surfacing a hard 500.
+		return false, nil
 	}
 	if orphanErr != nil {
 		return false, fmt.Errorf("recheck S3 orphan fence during stub repair: %w", orphanErr)

--- a/internal/db/block_references.go
+++ b/internal/db/block_references.go
@@ -15,8 +15,8 @@ import (
 // A block is alive iff at least one row exists in block_references for it. Adding
 // a reference is an idempotent INSERT, removing one an idempotent DELETE — neither
 // needs LWT, so concurrent uploads/deletes in different regions no longer collide
-// on a shared mutable counter. Expensive Paxos is reserved for the GC worker's
-// claim just before the irreversible S3 delete (see the gc store's claim path).
+// on a shared mutable counter. Separate LWTs still protect first-writer canonical
+// metadata and conditional GC/stub lifecycle transitions.
 
 const (
 	blockReferrerFSObjectPrefix = "fs:"
@@ -40,6 +40,9 @@ const (
 	// BlockGCStateDeleting marks a block row claimed by the GC worker for an
 	// imminent S3 delete. Writers that observe it must back off and retry.
 	BlockGCStateDeleting = "deleting"
+	// BlockGCStateRepairingStub is a short-lived upload-owned claim used only to
+	// remove a released metadata-free claim stub. Other readers fail closed on it.
+	BlockGCStateRepairingStub = "repairing_stub"
 )
 
 // ErrBlockIDMappingConflict indicates an external SHA-1 already maps to a
@@ -54,6 +57,7 @@ const (
 	BlockReuseReusable
 	BlockReuseNeedsPut
 	BlockReuseBlockedByGC
+	BlockReuseRepairableStub
 )
 
 type BlockReuseProbe struct {
@@ -65,11 +69,26 @@ type BlockReuseProbe struct {
 }
 
 type blockReuseMetadataRow struct {
-	Sha1         string
-	SizeBytes    int
-	StorageClass string
-	StorageKey   string
-	GCState      string
+	Sha1                string
+	SizeBytes           int
+	StorageClass        string
+	StorageClassPresent bool
+	StorageKey          string
+	GCState             string
+	GCClaimID           string
+	GCClaimedAt         *time.Time
+	CreatedAt           *time.Time
+}
+
+type blockIdentityRepairRow struct {
+	RepresentationID    string
+	Sha1                string
+	StorageClass        string
+	StorageClassPresent bool
+	GCState             string
+	GCClaimID           string
+	GCClaimedAt         *time.Time
+	CreatedAt           *time.Time
 }
 
 // BlockReferrerForFSObject builds the permanent referrer for a block referenced
@@ -132,21 +151,78 @@ var upsertBlockMetadataInsertWithRepresentationFn = func(database *DB, orgID, bl
 	`, orgID, blockID, representationID, sha1, sizeBytes, storageClass, storageKey, now, now).MapScanCAS(map[string]interface{}{})
 }
 
-var readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (string, string, bool, error) {
-	var representationID string
-	var sha1 string
+var readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (blockIdentityRepairRow, bool, error) {
+	var row blockIdentityRepairRow
+	var storageClass *string
 	err := database.Session().Query(`
-		SELECT representation_id, sha1
+		SELECT representation_id, sha1, storage_class, gc_state, gc_claim_id, gc_claimed_at, created_at
 		FROM blocks
 		WHERE org_id = ? AND block_id = ?
-	`, orgID, blockID).Scan(&representationID, &sha1)
+	`, orgID, blockID).Scan(
+		&row.RepresentationID,
+		&row.Sha1,
+		&storageClass,
+		&row.GCState,
+		&row.GCClaimID,
+		&row.GCClaimedAt,
+		&row.CreatedAt,
+	)
 	if err != nil {
 		if errors.Is(err, gocql.ErrNotFound) {
-			return "", "", false, nil
+			return blockIdentityRepairRow{}, false, nil
 		}
-		return "", "", false, err
+		return blockIdentityRepairRow{}, false, err
 	}
-	return representationID, sha1, true, nil
+	if storageClass != nil {
+		row.StorageClass = *storageClass
+		row.StorageClassPresent = true
+	}
+	return row, true, nil
+}
+
+var claimReleasedBlockStubForRepairFn = func(database *DB, orgID, blockID, repairID string, claimedAt time.Time) (bool, error) {
+	return database.Session().Query(`
+		UPDATE blocks
+		SET gc_state = ?, gc_claim_id = ?, gc_claimed_at = ?
+		WHERE org_id = ? AND block_id = ?
+		IF created_at = null
+		AND storage_class = null
+		AND gc_state = null
+		AND gc_claim_id = null
+		AND gc_claimed_at = null
+	`, BlockGCStateRepairingStub, repairID, claimedAt, orgID, blockID).MapScanCAS(map[string]interface{}{})
+}
+
+var deleteRepairClaimedBlockStubFn = func(database *DB, orgID, blockID, repairID string) (bool, error) {
+	return database.Session().Query(`
+		DELETE FROM blocks
+		WHERE org_id = ? AND block_id = ?
+		IF created_at = null
+		AND storage_class = null
+		AND gc_state = ?
+		AND gc_claim_id = ?
+		AND gc_claimed_at != null
+	`, orgID, blockID, BlockGCStateRepairingStub, repairID).MapScanCAS(map[string]interface{}{})
+}
+
+var blockStubRepairIDFn = func(orgID, blockID string) string {
+	return "upload-repair:" + orgID + ":" + blockID
+}
+
+var repairReleasedBlockStubForUpsertFn = func(database *DB, orgID, blockID string) (bool, error) {
+	return database.RepairReleasedBlockStub(orgID, blockID)
+}
+
+var deleteClaimedBlockStubFn = func(database *DB, orgID, blockID, claimID string) (bool, error) {
+	return database.Session().Query(`
+		DELETE FROM blocks
+		WHERE org_id = ? AND block_id = ?
+		IF created_at = null
+		AND storage_class = null
+		AND gc_state = ?
+		AND gc_claim_id = ?
+		AND gc_claimed_at != null
+	`, orgID, blockID, BlockGCStateDeleting, claimID).MapScanCAS(map[string]interface{}{})
 }
 
 // backfillBlockSHA1Fn fills in a missing sha1 with a compare-and-set against the
@@ -458,46 +534,78 @@ func (db *DB) UpsertBlockMetadataWithRepresentationAndSHA1(orgID, representation
 	if err := ValidateBlockRepresentationID(representationID); err != nil {
 		return err
 	}
+	storageClass = strings.TrimSpace(storageClass)
+	if storageClass == "" {
+		return fmt.Errorf("missing canonical storage class for block %s", blockID)
+	}
 	sha1 = NormalizeBlockID(sha1)
 	if sha1 != "" && !isHexN(sha1, 40) {
 		return fmt.Errorf("invalid block sha1 for %s", blockID)
 	}
 	now := time.Now().UTC()
-	insertFn := upsertBlockMetadataInsertWithRepresentationFn
-	if representationID == PlainBlockRepresentationID {
-		applied, err := upsertBlockMetadataInsertFn(db, orgID, blockID, sha1, sizeBytes, storageClass, storageKey, now)
+	insert := func() (bool, error) {
+		if representationID == PlainBlockRepresentationID {
+			return upsertBlockMetadataInsertFn(db, orgID, blockID, sha1, sizeBytes, storageClass, storageKey, now)
+		}
+		return upsertBlockMetadataInsertWithRepresentationFn(db, orgID, blockID, representationID, sha1, sizeBytes, storageClass, storageKey, now)
+	}
+
+	for attempt := 0; attempt < 2; attempt++ {
+		applied, err := insert()
 		if err != nil {
 			return err
 		}
 		if applied {
 			return nil
 		}
-		return db.ensureBlockIdentity(orgID, blockID, representationID, sha1)
+
+		row, found, err := readBlockIdentityForRepairFn(db, orgID, blockID)
+		if err != nil {
+			return fmt.Errorf("read block identity for %s: %w", blockID, err)
+		}
+		if !found {
+			return fmt.Errorf("block metadata for %s disappeared before identity repair", blockID)
+		}
+		if isRepairableBlockStub(orgID, blockID, row.CreatedAt, row.StorageClassPresent, row.GCState, row.GCClaimID, row.GCClaimedAt) {
+			if attempt > 0 {
+				return fmt.Errorf("block metadata stub for %s persisted after repair", blockID)
+			}
+			repaired, repairErr := repairReleasedBlockStubForUpsertFn(db, orgID, blockID)
+			if repairErr != nil {
+				return fmt.Errorf("repair released block metadata stub for %s: %w", blockID, repairErr)
+			}
+			if !repaired {
+				return fmt.Errorf("block metadata for %s changed before stub repair", blockID)
+			}
+			continue
+		}
+		return db.ensureBlockIdentityRow(orgID, blockID, representationID, sha1, row)
 	}
-	applied, err := insertFn(db, orgID, blockID, representationID, sha1, sizeBytes, storageClass, storageKey, now)
-	if err != nil {
-		return err
-	}
-	// Hot path: when this call created the row it already holds our sha1, and when
-	// the caller has no sha1 there is nothing to add — either way return without an
-	// extra read or a second LWT. The read + IF EXISTS repair below only runs when a
-	// PRE-EXISTING row (dedup) might be missing its sha1.
-	if applied {
-		return nil
-	}
-	return db.ensureBlockIdentity(orgID, blockID, representationID, sha1)
+	return fmt.Errorf("exhausted metadata stub repair for block %s", blockID)
 }
 
 func (db *DB) ensureBlockIdentity(orgID, blockID, representationID, sha1 string) error {
-	currentRepresentationID, currentSHA1, found, err := readBlockIdentityForRepairFn(db, orgID, blockID)
+	row, found, err := readBlockIdentityForRepairFn(db, orgID, blockID)
 	if err != nil {
 		return fmt.Errorf("read block identity for %s: %w", blockID, err)
 	}
 	if !found {
 		return fmt.Errorf("block metadata for %s disappeared before identity repair", blockID)
 	}
-	currentRepresentationID = strings.TrimSpace(currentRepresentationID)
-	currentSHA1 = strings.TrimSpace(currentSHA1)
+	return db.ensureBlockIdentityRow(orgID, blockID, representationID, sha1, row)
+}
+
+func (db *DB) ensureBlockIdentityRow(orgID, blockID, representationID, sha1 string, row blockIdentityRepairRow) error {
+	activeClaim, repairClaim, ownershipErr := classifyBlockClaimOwnership(row.GCState, row.GCClaimID, row.GCClaimedAt)
+	if ownershipErr != nil {
+		return fmt.Errorf("block %s has malformed GC ownership: %w", blockID, ownershipErr)
+	}
+	if activeClaim || repairClaim || row.CreatedAt == nil || !row.StorageClassPresent || strings.TrimSpace(row.StorageClass) == "" {
+		return fmt.Errorf("block %s has incomplete canonical metadata", blockID)
+	}
+
+	currentRepresentationID := strings.TrimSpace(row.RepresentationID)
+	currentSHA1 := strings.TrimSpace(row.Sha1)
 	if currentRepresentationID != "" && currentRepresentationID != representationID {
 		return fmt.Errorf("block %s already has conflicting representation id %s", blockID, currentRepresentationID)
 	}
@@ -529,6 +637,114 @@ func (db *DB) ensureBlockIdentity(orgID, blockID, representationID, sha1 string)
 	return nil
 }
 
+func classifyBlockClaimOwnership(gcState, claimID string, claimedAt *time.Time) (bool, bool, error) {
+	gcState = strings.TrimSpace(gcState)
+	claimID = strings.TrimSpace(claimID)
+	if gcState == "" {
+		if claimID != "" || claimedAt != nil {
+			return false, false, errors.New("claim identity exists without lifecycle state")
+		}
+		return false, false, nil
+	}
+	if gcState != BlockGCStateDeleting && gcState != BlockGCStateRepairingStub {
+		return false, false, fmt.Errorf("unknown gc_state %q", gcState)
+	}
+	if claimID == "" || claimedAt == nil {
+		return false, false, errors.New("lifecycle state is missing claim identity")
+	}
+	return gcState == BlockGCStateDeleting, gcState == BlockGCStateRepairingStub, nil
+}
+
+func isRepairableBlockStub(orgID, blockID string, createdAt *time.Time, storageClassPresent bool, gcState, claimID string, claimedAt *time.Time) bool {
+	if createdAt != nil || storageClassPresent {
+		return false
+	}
+	active, repairing, err := classifyBlockClaimOwnership(gcState, claimID, claimedAt)
+	if err != nil || active {
+		return false
+	}
+	return !repairing || strings.TrimSpace(claimID) == blockStubRepairIDFn(orgID, blockID)
+}
+
+func (db *DB) RepairReleasedBlockStub(orgID, blockID string) (bool, error) {
+	repairID := blockStubRepairIDFn(orgID, blockID)
+	claimed, err := claimReleasedBlockStubForRepairFn(db, orgID, blockID, repairID, time.Now().UTC())
+	if err != nil {
+		owned, _, confirmErr := db.blockStubRepairClaimStatus(orgID, blockID, repairID)
+		if confirmErr != nil || !owned {
+			return false, err
+		}
+	}
+	if !claimed {
+		owned, _, confirmErr := db.blockStubRepairClaimStatus(orgID, blockID, repairID)
+		if confirmErr != nil {
+			return false, confirmErr
+		}
+		if !owned {
+			return false, nil
+		}
+	}
+
+	hasOrphan, orphanErr := probeBlockReuseHasS3OrphanFn(db, orgID, blockID)
+	deleted, deleteErr := db.deleteOwnedBlockStubRepairClaim(orgID, blockID, repairID)
+	if deleteErr != nil {
+		return false, fmt.Errorf("remove block stub repair claim: %w", deleteErr)
+	}
+	if !deleted {
+		return false, errors.New("block stub repair claim changed before delete")
+	}
+	if orphanErr != nil {
+		return false, fmt.Errorf("recheck S3 orphan fence during stub repair: %w", orphanErr)
+	}
+	if hasOrphan {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (db *DB) deleteOwnedBlockStubRepairClaim(orgID, blockID, repairID string) (bool, error) {
+	deleted, err := deleteRepairClaimedBlockStubFn(db, orgID, blockID, repairID)
+	if err == nil && deleted {
+		return true, nil
+	}
+	owned, found, confirmErr := db.blockStubRepairClaimStatus(orgID, blockID, repairID)
+	if confirmErr != nil {
+		return false, confirmErr
+	}
+	if !found {
+		return true, nil
+	}
+	if !owned {
+		return false, nil
+	}
+	deleted, retryErr := deleteRepairClaimedBlockStubFn(db, orgID, blockID, repairID)
+	if retryErr != nil {
+		return false, retryErr
+	}
+	return deleted, nil
+}
+
+func (db *DB) blockStubRepairClaimStatus(orgID, blockID, repairID string) (bool, bool, error) {
+	row, found, err := readBlockIdentityForRepairFn(db, orgID, blockID)
+	if err != nil || !found {
+		return false, found, err
+	}
+	_, repairing, ownershipErr := classifyBlockClaimOwnership(row.GCState, row.GCClaimID, row.GCClaimedAt)
+	if ownershipErr != nil {
+		return false, true, ownershipErr
+	}
+	owned := repairing && row.CreatedAt == nil && !row.StorageClassPresent && strings.TrimSpace(row.GCClaimID) == repairID
+	return owned, true, nil
+}
+
+func (db *DB) DeleteClaimedBlockStub(orgID, blockID, claimID string) (bool, error) {
+	claimID = strings.TrimSpace(claimID)
+	if claimID == "" {
+		return false, errors.New("missing block delete claim id")
+	}
+	return deleteClaimedBlockStubFn(db, orgID, blockID, claimID)
+}
+
 func isHexN(s string, n int) bool {
 	if len(s) != n {
 		return false
@@ -543,16 +759,30 @@ func isHexN(s string, n int) bool {
 
 var probeBlockReuseMetadataFn = func(database *DB, orgID, blockID string) (blockReuseMetadataRow, bool, error) {
 	var row blockReuseMetadataRow
+	var storageClass *string
 	err := database.Session().Query(`
-		SELECT sha1, size_bytes, storage_class, storage_key, gc_state
+		SELECT sha1, size_bytes, storage_class, storage_key, gc_state, gc_claim_id, gc_claimed_at, created_at
 		FROM blocks
 		WHERE org_id = ? AND block_id = ?
-	`, orgID, blockID).Scan(&row.Sha1, &row.SizeBytes, &row.StorageClass, &row.StorageKey, &row.GCState)
+	`, orgID, blockID).Scan(
+		&row.Sha1,
+		&row.SizeBytes,
+		&storageClass,
+		&row.StorageKey,
+		&row.GCState,
+		&row.GCClaimID,
+		&row.GCClaimedAt,
+		&row.CreatedAt,
+	)
 	if err != nil {
 		if errors.Is(err, gocql.ErrNotFound) {
 			return blockReuseMetadataRow{}, false, nil
 		}
 		return blockReuseMetadataRow{}, false, err
+	}
+	if storageClass != nil {
+		row.StorageClass = *storageClass
+		row.StorageClassPresent = true
 	}
 	return row, true, nil
 }
@@ -593,16 +823,40 @@ func (db *DB) ProbeBlockReuse(orgID, blockID string) (BlockReuseProbe, error) {
 		return BlockReuseProbe{Decision: BlockReuseNeedsPut}, nil
 	}
 
+	activeClaim, repairClaim, ownershipErr := classifyBlockClaimOwnership(metadata.GCState, metadata.GCClaimID, metadata.GCClaimedAt)
+	if ownershipErr != nil {
+		return BlockReuseProbe{Decision: BlockReuseUnknownError}, fmt.Errorf("block %s has malformed GC ownership: %w", blockID, ownershipErr)
+	}
+	if metadata.CreatedAt == nil {
+		if metadata.StorageClassPresent {
+			return BlockReuseProbe{Decision: BlockReuseUnknownError}, fmt.Errorf("block %s has storage class without canonical creation timestamp", blockID)
+		}
+		if activeClaim {
+			return BlockReuseProbe{Decision: BlockReuseBlockedByGC}, nil
+		}
+		if repairClaim && strings.TrimSpace(metadata.GCClaimID) != blockStubRepairIDFn(orgID, blockID) {
+			return BlockReuseProbe{Decision: BlockReuseBlockedByGC}, nil
+		}
+		hasOrphan, orphanErr := probeBlockReuseHasS3OrphanFn(db, orgID, blockID)
+		if orphanErr != nil {
+			return BlockReuseProbe{Decision: BlockReuseUnknownError}, fmt.Errorf("read S3 orphan fence for %s: %w", blockID, orphanErr)
+		}
+		if hasOrphan {
+			return BlockReuseProbe{Decision: BlockReuseBlockedByGC}, nil
+		}
+		return BlockReuseProbe{Decision: BlockReuseRepairableStub}, nil
+	}
+
 	probe := BlockReuseProbe{
 		Sha1:         strings.TrimSpace(metadata.Sha1),
 		SizeBytes:    metadata.SizeBytes,
 		StorageClass: strings.TrimSpace(metadata.StorageClass),
 		StorageKey:   strings.TrimSpace(metadata.StorageKey),
 	}
-	if probe.StorageClass == "" {
+	if !metadata.StorageClassPresent || probe.StorageClass == "" {
 		return BlockReuseProbe{Decision: BlockReuseUnknownError}, fmt.Errorf("block %s has empty canonical storage class", blockID)
 	}
-	if metadata.GCState == BlockGCStateDeleting {
+	if activeClaim || repairClaim {
 		probe.Decision = BlockReuseBlockedByGC
 		return probe, nil
 	}

--- a/internal/db/block_references_test.go
+++ b/internal/db/block_references_test.go
@@ -326,8 +326,8 @@ func TestUpsertBlockMetadataStopsWhenReleasedStubDeleteLosesRace(t *testing.T) {
 	repairReleasedBlockStubForUpsertFn = func(*DB, string, string) (bool, error) { return false, nil }
 
 	err := database.UpsertBlockMetadata("org-1", "block-1", 1, "hot", "key")
-	if err == nil || !strings.Contains(err.Error(), "changed before stub repair") {
-		t.Fatalf("UpsertBlockMetadata() error = %v, want lost-race error", err)
+	if !errors.Is(err, ErrBlockStubRepairContended) {
+		t.Fatalf("UpsertBlockMetadata() error = %v, want ErrBlockStubRepairContended (retryable)", err)
 	}
 	if insertCalls != 1 {
 		t.Fatalf("insertCalls = %d, want 1", insertCalls)
@@ -471,9 +471,12 @@ func TestRepairReleasedBlockStubDoesNotSucceedWhenClaimedRowChanges(t *testing.T
 		return completeIdentityRepairRow(PlainBlockRepresentationID, strings.Repeat("a", 40)), true, nil
 	}
 
+	// The row was completed by another actor before our conditional delete. That is
+	// a benign lost race, so the repair reports (false, nil) — retryable, not a hard
+	// error — and the caller re-probes to converge on Reusable/BlockedByGC.
 	repaired, err := (&DB{}).RepairReleasedBlockStub("org-1", "block-1")
-	if err == nil || repaired {
-		t.Fatalf("RepairReleasedBlockStub() = %v, %v, want false/lost-race error", repaired, err)
+	if err != nil || repaired {
+		t.Fatalf("RepairReleasedBlockStub() = %v, %v, want false/nil (retryable lost race)", repaired, err)
 	}
 }
 

--- a/internal/db/block_references_test.go
+++ b/internal/db/block_references_test.go
@@ -7,6 +7,26 @@ import (
 	"time"
 )
 
+func completeIdentityRepairRow(representationID, sha1 string) blockIdentityRepairRow {
+	createdAt := time.Now().UTC()
+	return blockIdentityRepairRow{
+		RepresentationID:    representationID,
+		Sha1:                sha1,
+		StorageClass:        "hot",
+		StorageClassPresent: true,
+		CreatedAt:           &createdAt,
+	}
+}
+
+func completeProbeMetadataRow(storageClass string) blockReuseMetadataRow {
+	createdAt := time.Now().UTC()
+	return blockReuseMetadataRow{
+		StorageClass:        storageClass,
+		StorageClassPresent: true,
+		CreatedAt:           &createdAt,
+	}
+}
+
 func TestUpsertBlockMetadataWithSHA1_BackfillsEmptyExistingSHA1(t *testing.T) {
 	database := &DB{}
 	oldInsert := upsertBlockMetadataInsertFn
@@ -26,9 +46,9 @@ func TestUpsertBlockMetadataWithSHA1_BackfillsEmptyExistingSHA1(t *testing.T) {
 		}
 		return false, nil // row already existed -> proceed to read + backfill
 	}
-	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (string, string, bool, error) {
+	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (blockIdentityRepairRow, bool, error) {
 		calls = append(calls, "read")
-		return PlainBlockRepresentationID, "", true, nil
+		return completeIdentityRepairRow(PlainBlockRepresentationID, ""), true, nil
 	}
 	backfillBlockSHA1Fn = func(database *DB, orgID, blockID, sha1, expectedCurrent string) (bool, error) {
 		calls = append(calls, "backfill")
@@ -71,9 +91,9 @@ func TestUpsertBlockMetadataWithSHA1_FirstWriterSkipsReadAndBackfill(t *testing.
 	upsertBlockMetadataInsertFn = func(database *DB, orgID, blockID, sha1 string, sizeBytes int, storageClass, storageKey string, now time.Time) (bool, error) {
 		return true, nil // first writer created the row with this sha1
 	}
-	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (string, string, bool, error) {
+	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (blockIdentityRepairRow, bool, error) {
 		t.Fatal("read should not run when the INSERT applied")
-		return "", "", false, nil
+		return blockIdentityRepairRow{}, false, nil
 	}
 	backfillBlockSHA1Fn = func(database *DB, orgID, blockID, sha1, expectedCurrent string) (bool, error) {
 		t.Fatal("backfill should not run when the INSERT applied")
@@ -99,8 +119,8 @@ func TestUpsertBlockMetadataWithSHA1_FailsWhenRowChangesBeforeBackfill(t *testin
 	upsertBlockMetadataInsertFn = func(database *DB, orgID, blockID, sha1 string, sizeBytes int, storageClass, storageKey string, now time.Time) (bool, error) {
 		return false, nil // row already existed -> proceed to read/ensure
 	}
-	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (string, string, bool, error) {
-		return PlainBlockRepresentationID, "", true, nil
+	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (blockIdentityRepairRow, bool, error) {
+		return completeIdentityRepairRow(PlainBlockRepresentationID, ""), true, nil
 	}
 	// The conditional backfill does not apply: another writer (or GC) changed the
 	// row between read and write. The CAS reports applied=false and the caller must
@@ -132,8 +152,8 @@ func TestUpsertBlockMetadataWithSHA1_LeavesMatchingSHA1Untouched(t *testing.T) {
 	upsertBlockMetadataInsertFn = func(database *DB, orgID, blockID, sha1 string, sizeBytes int, storageClass, storageKey string, now time.Time) (bool, error) {
 		return false, nil // row already existed -> proceed to read/ensure
 	}
-	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (string, string, bool, error) {
-		return PlainBlockRepresentationID, strings.Repeat("b", 40), true, nil
+	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (blockIdentityRepairRow, bool, error) {
+		return completeIdentityRepairRow(PlainBlockRepresentationID, strings.Repeat("b", 40)), true, nil
 	}
 	backfillBlockSHA1Fn = func(database *DB, orgID, blockID, sha1, expectedCurrent string) (bool, error) {
 		t.Fatal("backfill should not run when the stored sha1 already matches")
@@ -159,8 +179,8 @@ func TestUpsertBlockMetadataWithSHA1_RejectsConflictingExistingSHA1(t *testing.T
 	upsertBlockMetadataInsertFn = func(database *DB, orgID, blockID, sha1 string, sizeBytes int, storageClass, storageKey string, now time.Time) (bool, error) {
 		return false, nil // row already existed -> proceed to read/ensure
 	}
-	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (string, string, bool, error) {
-		return PlainBlockRepresentationID, strings.Repeat("c", 40), true, nil
+	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (blockIdentityRepairRow, bool, error) {
+		return completeIdentityRepairRow(PlainBlockRepresentationID, strings.Repeat("c", 40)), true, nil
 	}
 	backfillBlockSHA1Fn = func(database *DB, orgID, blockID, sha1, expectedCurrent string) (bool, error) {
 		t.Fatal("backfill should not run when the stored sha1 conflicts")
@@ -186,14 +206,274 @@ func TestUpsertBlockMetadataWithSHA1_RejectsMalformedInputSHA1(t *testing.T) {
 		t.Fatal("insert should not run for malformed sha1 input")
 		return false, nil
 	}
-	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (string, string, bool, error) {
+	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (blockIdentityRepairRow, bool, error) {
 		t.Fatal("read should not run for malformed sha1 input")
-		return "", "", false, nil
+		return blockIdentityRepairRow{}, false, nil
 	}
 
 	err := database.UpsertBlockMetadataWithSHA1("org-1", "block-1", "not-a-sha1", 123, "hot", "key")
 	if err == nil || !strings.Contains(err.Error(), "invalid block sha1") {
 		t.Fatalf("UpsertBlockMetadataWithSHA1() error = %v, want invalid block sha1", err)
+	}
+}
+
+func TestUpsertBlockMetadataRejectsEmptyStorageClassBeforeInsert(t *testing.T) {
+	oldPlainInsert := upsertBlockMetadataInsertFn
+	oldRepresentationInsert := upsertBlockMetadataInsertWithRepresentationFn
+	t.Cleanup(func() {
+		upsertBlockMetadataInsertFn = oldPlainInsert
+		upsertBlockMetadataInsertWithRepresentationFn = oldRepresentationInsert
+	})
+	upsertBlockMetadataInsertFn = func(*DB, string, string, string, int, string, string, time.Time) (bool, error) {
+		t.Fatal("plain insert must not run with an empty storage class")
+		return false, nil
+	}
+	upsertBlockMetadataInsertWithRepresentationFn = func(*DB, string, string, string, string, int, string, string, time.Time) (bool, error) {
+		t.Fatal("representation insert must not run with an empty storage class")
+		return false, nil
+	}
+
+	if err := (&DB{}).UpsertBlockMetadata("org-1", "block-1", 1, "   ", "key"); err == nil {
+		t.Fatal("UpsertBlockMetadata() error = nil, want empty storage class error")
+	}
+}
+
+func TestUpsertBlockMetadataRepairsReleasedStubAndRetriesInsert(t *testing.T) {
+	database := &DB{}
+	oldInsert := upsertBlockMetadataInsertFn
+	oldRead := readBlockIdentityForRepairFn
+	oldRepair := repairReleasedBlockStubForUpsertFn
+	t.Cleanup(func() {
+		upsertBlockMetadataInsertFn = oldInsert
+		readBlockIdentityForRepairFn = oldRead
+		repairReleasedBlockStubForUpsertFn = oldRepair
+	})
+
+	insertCalls := 0
+	upsertBlockMetadataInsertFn = func(*DB, string, string, string, int, string, string, time.Time) (bool, error) {
+		insertCalls++
+		return insertCalls == 2, nil
+	}
+	readBlockIdentityForRepairFn = func(*DB, string, string) (blockIdentityRepairRow, bool, error) {
+		return blockIdentityRepairRow{RepresentationID: PlainBlockRepresentationID, Sha1: strings.Repeat("a", 40)}, true, nil
+	}
+	repairCalls := 0
+	repairReleasedBlockStubForUpsertFn = func(*DB, string, string) (bool, error) {
+		repairCalls++
+		return true, nil
+	}
+
+	if err := database.UpsertBlockMetadataWithSHA1("org-1", "block-1", strings.Repeat("a", 40), 1, "hot", "key"); err != nil {
+		t.Fatalf("UpsertBlockMetadataWithSHA1() error = %v, want nil", err)
+	}
+	if insertCalls != 2 || repairCalls != 1 {
+		t.Fatalf("insert/repair calls = %d/%d, want 2/1", insertCalls, repairCalls)
+	}
+}
+
+func TestUpsertRepresentationMetadataRepairsReleasedStubAndRetriesInsert(t *testing.T) {
+	database := &DB{}
+	oldInsert := upsertBlockMetadataInsertWithRepresentationFn
+	oldRead := readBlockIdentityForRepairFn
+	oldRepair := repairReleasedBlockStubForUpsertFn
+	t.Cleanup(func() {
+		upsertBlockMetadataInsertWithRepresentationFn = oldInsert
+		readBlockIdentityForRepairFn = oldRead
+		repairReleasedBlockStubForUpsertFn = oldRepair
+	})
+	representationID := EncryptedLibraryBlockRepresentationID("library-1")
+	insertCalls := 0
+	upsertBlockMetadataInsertWithRepresentationFn = func(*DB, string, string, string, string, int, string, string, time.Time) (bool, error) {
+		insertCalls++
+		return insertCalls == 2, nil
+	}
+	readBlockIdentityForRepairFn = func(*DB, string, string) (blockIdentityRepairRow, bool, error) {
+		return blockIdentityRepairRow{RepresentationID: representationID}, true, nil
+	}
+	repairCalls := 0
+	repairReleasedBlockStubForUpsertFn = func(*DB, string, string) (bool, error) {
+		repairCalls++
+		return true, nil
+	}
+
+	if err := database.UpsertBlockMetadataWithRepresentationAndSHA1("org-1", representationID, "block-1", "", 1, "hot", "key"); err != nil {
+		t.Fatalf("UpsertBlockMetadataWithRepresentationAndSHA1() error = %v", err)
+	}
+	if insertCalls != 2 || repairCalls != 1 {
+		t.Fatalf("insert/repair calls = %d/%d, want 2/1", insertCalls, repairCalls)
+	}
+}
+
+func TestUpsertBlockMetadataStopsWhenReleasedStubDeleteLosesRace(t *testing.T) {
+	database := &DB{}
+	oldInsert := upsertBlockMetadataInsertFn
+	oldRead := readBlockIdentityForRepairFn
+	oldRepair := repairReleasedBlockStubForUpsertFn
+	t.Cleanup(func() {
+		upsertBlockMetadataInsertFn = oldInsert
+		readBlockIdentityForRepairFn = oldRead
+		repairReleasedBlockStubForUpsertFn = oldRepair
+	})
+
+	insertCalls := 0
+	upsertBlockMetadataInsertFn = func(*DB, string, string, string, int, string, string, time.Time) (bool, error) {
+		insertCalls++
+		return false, nil
+	}
+	readBlockIdentityForRepairFn = func(*DB, string, string) (blockIdentityRepairRow, bool, error) {
+		return blockIdentityRepairRow{}, true, nil
+	}
+	repairReleasedBlockStubForUpsertFn = func(*DB, string, string) (bool, error) { return false, nil }
+
+	err := database.UpsertBlockMetadata("org-1", "block-1", 1, "hot", "key")
+	if err == nil || !strings.Contains(err.Error(), "changed before stub repair") {
+		t.Fatalf("UpsertBlockMetadata() error = %v, want lost-race error", err)
+	}
+	if insertCalls != 1 {
+		t.Fatalf("insertCalls = %d, want 1", insertCalls)
+	}
+}
+
+func TestRepairReleasedBlockStubClaimsRechecksOrphanAndDeletes(t *testing.T) {
+	oldClaim := claimReleasedBlockStubForRepairFn
+	oldDelete := deleteRepairClaimedBlockStubFn
+	oldOrphan := probeBlockReuseHasS3OrphanFn
+	oldID := blockStubRepairIDFn
+	t.Cleanup(func() {
+		claimReleasedBlockStubForRepairFn = oldClaim
+		deleteRepairClaimedBlockStubFn = oldDelete
+		probeBlockReuseHasS3OrphanFn = oldOrphan
+		blockStubRepairIDFn = oldID
+	})
+	blockStubRepairIDFn = func(string, string) string { return "repair-1" }
+	claimReleasedBlockStubForRepairFn = func(_ *DB, orgID, blockID, repairID string, claimedAt time.Time) (bool, error) {
+		if orgID != "org-1" || blockID != "block-1" || repairID != "repair-1" || claimedAt.IsZero() {
+			t.Fatalf("claim args = %s/%s/%s/%v", orgID, blockID, repairID, claimedAt)
+		}
+		return true, nil
+	}
+	probeBlockReuseHasS3OrphanFn = func(*DB, string, string) (bool, error) { return false, nil }
+	deleteRepairClaimedBlockStubFn = func(_ *DB, orgID, blockID, repairID string) (bool, error) {
+		if repairID != "repair-1" {
+			t.Fatalf("repairID = %q", repairID)
+		}
+		return true, nil
+	}
+
+	repaired, err := (&DB{}).RepairReleasedBlockStub("org-1", "block-1")
+	if err != nil || !repaired {
+		t.Fatalf("RepairReleasedBlockStub() = %v, %v, want true/nil", repaired, err)
+	}
+}
+
+func TestRepairReleasedBlockStubStopsWhenOrphanFenceAppears(t *testing.T) {
+	oldClaim := claimReleasedBlockStubForRepairFn
+	oldDelete := deleteRepairClaimedBlockStubFn
+	oldOrphan := probeBlockReuseHasS3OrphanFn
+	t.Cleanup(func() {
+		claimReleasedBlockStubForRepairFn = oldClaim
+		deleteRepairClaimedBlockStubFn = oldDelete
+		probeBlockReuseHasS3OrphanFn = oldOrphan
+	})
+	claimReleasedBlockStubForRepairFn = func(*DB, string, string, string, time.Time) (bool, error) { return true, nil }
+	probeBlockReuseHasS3OrphanFn = func(*DB, string, string) (bool, error) { return true, nil }
+	deleteCalls := 0
+	deleteRepairClaimedBlockStubFn = func(*DB, string, string, string) (bool, error) {
+		deleteCalls++
+		return true, nil
+	}
+
+	repaired, err := (&DB{}).RepairReleasedBlockStub("org-1", "block-1")
+	if err != nil || repaired {
+		t.Fatalf("RepairReleasedBlockStub() = %v, %v, want false/nil", repaired, err)
+	}
+	if deleteCalls != 1 {
+		t.Fatalf("deleteCalls = %d, want repair claim cleanup", deleteCalls)
+	}
+}
+
+func TestRepairReleasedBlockStubResumesAmbiguousClaim(t *testing.T) {
+	oldClaim := claimReleasedBlockStubForRepairFn
+	oldDelete := deleteRepairClaimedBlockStubFn
+	oldOrphan := probeBlockReuseHasS3OrphanFn
+	oldRead := readBlockIdentityForRepairFn
+	t.Cleanup(func() {
+		claimReleasedBlockStubForRepairFn = oldClaim
+		deleteRepairClaimedBlockStubFn = oldDelete
+		probeBlockReuseHasS3OrphanFn = oldOrphan
+		readBlockIdentityForRepairFn = oldRead
+	})
+	claimedAt := time.Now().UTC()
+	repairID := blockStubRepairIDFn("org-1", "block-1")
+	claimReleasedBlockStubForRepairFn = func(*DB, string, string, string, time.Time) (bool, error) {
+		return false, errors.New("ambiguous timeout")
+	}
+	readBlockIdentityForRepairFn = func(*DB, string, string) (blockIdentityRepairRow, bool, error) {
+		return blockIdentityRepairRow{GCState: BlockGCStateRepairingStub, GCClaimID: repairID, GCClaimedAt: &claimedAt}, true, nil
+	}
+	probeBlockReuseHasS3OrphanFn = func(*DB, string, string) (bool, error) { return false, nil }
+	deleteRepairClaimedBlockStubFn = func(*DB, string, string, string) (bool, error) { return true, nil }
+
+	repaired, err := (&DB{}).RepairReleasedBlockStub("org-1", "block-1")
+	if err != nil || !repaired {
+		t.Fatalf("RepairReleasedBlockStub() = %v, %v, want true/nil", repaired, err)
+	}
+}
+
+func TestRepairReleasedBlockStubRetriesAmbiguousDelete(t *testing.T) {
+	oldClaim := claimReleasedBlockStubForRepairFn
+	oldDelete := deleteRepairClaimedBlockStubFn
+	oldOrphan := probeBlockReuseHasS3OrphanFn
+	oldRead := readBlockIdentityForRepairFn
+	t.Cleanup(func() {
+		claimReleasedBlockStubForRepairFn = oldClaim
+		deleteRepairClaimedBlockStubFn = oldDelete
+		probeBlockReuseHasS3OrphanFn = oldOrphan
+		readBlockIdentityForRepairFn = oldRead
+	})
+	claimedAt := time.Now().UTC()
+	repairID := blockStubRepairIDFn("org-1", "block-1")
+	claimReleasedBlockStubForRepairFn = func(*DB, string, string, string, time.Time) (bool, error) { return true, nil }
+	readBlockIdentityForRepairFn = func(*DB, string, string) (blockIdentityRepairRow, bool, error) {
+		return blockIdentityRepairRow{GCState: BlockGCStateRepairingStub, GCClaimID: repairID, GCClaimedAt: &claimedAt}, true, nil
+	}
+	probeBlockReuseHasS3OrphanFn = func(*DB, string, string) (bool, error) { return false, nil }
+	deleteCalls := 0
+	deleteRepairClaimedBlockStubFn = func(*DB, string, string, string) (bool, error) {
+		deleteCalls++
+		if deleteCalls == 1 {
+			return false, errors.New("ambiguous timeout")
+		}
+		return true, nil
+	}
+
+	repaired, err := (&DB{}).RepairReleasedBlockStub("org-1", "block-1")
+	if err != nil || !repaired || deleteCalls != 2 {
+		t.Fatalf("RepairReleasedBlockStub() = %v, %v with %d deletes, want true/nil with 2", repaired, err, deleteCalls)
+	}
+}
+
+func TestRepairReleasedBlockStubDoesNotSucceedWhenClaimedRowChanges(t *testing.T) {
+	oldClaim := claimReleasedBlockStubForRepairFn
+	oldDelete := deleteRepairClaimedBlockStubFn
+	oldOrphan := probeBlockReuseHasS3OrphanFn
+	oldRead := readBlockIdentityForRepairFn
+	t.Cleanup(func() {
+		claimReleasedBlockStubForRepairFn = oldClaim
+		deleteRepairClaimedBlockStubFn = oldDelete
+		probeBlockReuseHasS3OrphanFn = oldOrphan
+		readBlockIdentityForRepairFn = oldRead
+	})
+	claimReleasedBlockStubForRepairFn = func(*DB, string, string, string, time.Time) (bool, error) { return true, nil }
+	probeBlockReuseHasS3OrphanFn = func(*DB, string, string) (bool, error) { return false, nil }
+	deleteRepairClaimedBlockStubFn = func(*DB, string, string, string) (bool, error) { return false, nil }
+	readBlockIdentityForRepairFn = func(*DB, string, string) (blockIdentityRepairRow, bool, error) {
+		return completeIdentityRepairRow(PlainBlockRepresentationID, strings.Repeat("a", 40)), true, nil
+	}
+
+	repaired, err := (&DB{}).RepairReleasedBlockStub("org-1", "block-1")
+	if err == nil || repaired {
+		t.Fatalf("RepairReleasedBlockStub() = %v, %v, want false/lost-race error", repaired, err)
 	}
 }
 
@@ -317,8 +597,8 @@ func TestEnsureBlockIdentity_PlaintextBackfillsMissingRepresentationID(t *testin
 		backfillBlockSHA1Fn = oldBackfillSHA1
 	})
 
-	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (string, string, bool, error) {
-		return "", strings.Repeat("a", 40), true, nil
+	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (blockIdentityRepairRow, bool, error) {
+		return completeIdentityRepairRow("", strings.Repeat("a", 40)), true, nil
 	}
 	backfillBlockRepresentationIDFn = func(database *DB, orgID, blockID, representationID, expectedCurrent string) (bool, error) {
 		if representationID != PlainBlockRepresentationID {
@@ -350,8 +630,8 @@ func TestEnsureBlockIdentity_PlaintextRejectsStoredRepresentationConflict(t *tes
 		backfillBlockSHA1Fn = oldBackfillSHA1
 	})
 
-	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (string, string, bool, error) {
-		return EncryptedLibraryBlockRepresentationID("library-1"), strings.Repeat("a", 40), true, nil
+	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (blockIdentityRepairRow, bool, error) {
+		return completeIdentityRepairRow(EncryptedLibraryBlockRepresentationID("library-1"), strings.Repeat("a", 40)), true, nil
 	}
 	backfillBlockRepresentationIDFn = func(database *DB, orgID, blockID, representationID, expectedCurrent string) (bool, error) {
 		t.Fatal("representation backfill should not run on a stored conflict")
@@ -379,8 +659,8 @@ func TestEnsureBlockIdentity_DoesNotBackfillRepresentationWhenSHA1Conflicts(t *t
 		backfillBlockSHA1Fn = oldBackfillSHA1
 	})
 
-	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (string, string, bool, error) {
-		return "", strings.Repeat("d", 40), true, nil
+	readBlockIdentityForRepairFn = func(database *DB, orgID, blockID string) (blockIdentityRepairRow, bool, error) {
+		return completeIdentityRepairRow("", strings.Repeat("d", 40)), true, nil
 	}
 	backfillBlockRepresentationIDFn = func(database *DB, orgID, blockID, representationID, expectedCurrent string) (bool, error) {
 		t.Fatal("representation backfill should not run when the stored sha1 already conflicts")
@@ -635,7 +915,10 @@ func TestProbeBlockReuseReusable(t *testing.T) {
 	})
 
 	probeBlockReuseMetadataFn = func(database *DB, orgID, blockID string) (blockReuseMetadataRow, bool, error) {
-		return blockReuseMetadataRow{Sha1: "sha1-abc", SizeBytes: 123, StorageClass: "hot-s3", StorageKey: "", GCState: ""}, true, nil
+		row := completeProbeMetadataRow("hot-s3")
+		row.Sha1 = "sha1-abc"
+		row.SizeBytes = 123
+		return row, true, nil
 	}
 	probeBlockReuseHasReferencesFn = func(database *DB, orgID, blockID string) (bool, error) {
 		return true, nil
@@ -712,12 +995,142 @@ func TestProbeBlockReuseReturnsUnknownErrorForEmptyStorageClass(t *testing.T) {
 	t.Cleanup(func() { probeBlockReuseMetadataFn = oldMetadata })
 
 	probeBlockReuseMetadataFn = func(database *DB, orgID, blockID string) (blockReuseMetadataRow, bool, error) {
-		return blockReuseMetadataRow{SizeBytes: 123, StorageClass: "   ", StorageKey: "", GCState: ""}, true, nil
+		row := completeProbeMetadataRow("   ")
+		row.SizeBytes = 123
+		return row, true, nil
 	}
 
 	probe, err := (&DB{}).ProbeBlockReuse("org-1", "block-1")
 	if err == nil {
 		t.Fatal("ProbeBlockReuse() error = nil, want error")
+	}
+	if probe.Decision != BlockReuseUnknownError {
+		t.Fatalf("decision = %v, want BlockReuseUnknownError", probe.Decision)
+	}
+}
+
+func TestProbeBlockReuseReturnsRepairableStubForReleasedClaimRow(t *testing.T) {
+	oldMetadata := probeBlockReuseMetadataFn
+	oldOrphan := probeBlockReuseHasS3OrphanFn
+	t.Cleanup(func() {
+		probeBlockReuseMetadataFn = oldMetadata
+		probeBlockReuseHasS3OrphanFn = oldOrphan
+	})
+	probeBlockReuseMetadataFn = func(*DB, string, string) (blockReuseMetadataRow, bool, error) {
+		return blockReuseMetadataRow{Sha1: strings.Repeat("a", 40)}, true, nil
+	}
+	probeBlockReuseHasS3OrphanFn = func(*DB, string, string) (bool, error) { return false, nil }
+
+	probe, err := (&DB{}).ProbeBlockReuse("org-1", "block-1")
+	if err != nil {
+		t.Fatalf("ProbeBlockReuse() error = %v, want nil", err)
+	}
+	if probe.Decision != BlockReuseRepairableStub {
+		t.Fatalf("decision = %v, want BlockReuseRepairableStub", probe.Decision)
+	}
+}
+
+func TestProbeBlockReuseBlocksReleasedStubWithS3Orphan(t *testing.T) {
+	oldMetadata := probeBlockReuseMetadataFn
+	oldOrphan := probeBlockReuseHasS3OrphanFn
+	t.Cleanup(func() {
+		probeBlockReuseMetadataFn = oldMetadata
+		probeBlockReuseHasS3OrphanFn = oldOrphan
+	})
+	probeBlockReuseMetadataFn = func(*DB, string, string) (blockReuseMetadataRow, bool, error) {
+		return blockReuseMetadataRow{}, true, nil
+	}
+	probeBlockReuseHasS3OrphanFn = func(*DB, string, string) (bool, error) { return true, nil }
+
+	probe, err := (&DB{}).ProbeBlockReuse("org-1", "block-1")
+	if err != nil {
+		t.Fatalf("ProbeBlockReuse() error = %v, want nil", err)
+	}
+	if probe.Decision != BlockReuseBlockedByGC {
+		t.Fatalf("decision = %v, want BlockReuseBlockedByGC", probe.Decision)
+	}
+}
+
+func TestProbeBlockReuseBlocksActivelyClaimedStub(t *testing.T) {
+	oldMetadata := probeBlockReuseMetadataFn
+	oldOrphan := probeBlockReuseHasS3OrphanFn
+	t.Cleanup(func() {
+		probeBlockReuseMetadataFn = oldMetadata
+		probeBlockReuseHasS3OrphanFn = oldOrphan
+	})
+	claimedAt := time.Now().UTC()
+	probeBlockReuseMetadataFn = func(*DB, string, string) (blockReuseMetadataRow, bool, error) {
+		return blockReuseMetadataRow{GCState: BlockGCStateDeleting, GCClaimID: "claim-1", GCClaimedAt: &claimedAt}, true, nil
+	}
+	probeBlockReuseHasS3OrphanFn = func(*DB, string, string) (bool, error) {
+		t.Fatal("orphan read must not run for an active claim")
+		return false, nil
+	}
+
+	probe, err := (&DB{}).ProbeBlockReuse("org-1", "block-1")
+	if err != nil {
+		t.Fatalf("ProbeBlockReuse() error = %v, want nil", err)
+	}
+	if probe.Decision != BlockReuseBlockedByGC {
+		t.Fatalf("decision = %v, want BlockReuseBlockedByGC", probe.Decision)
+	}
+}
+
+func TestProbeBlockReuseResumesOwnedRepairingStub(t *testing.T) {
+	oldMetadata := probeBlockReuseMetadataFn
+	oldOrphan := probeBlockReuseHasS3OrphanFn
+	t.Cleanup(func() {
+		probeBlockReuseMetadataFn = oldMetadata
+		probeBlockReuseHasS3OrphanFn = oldOrphan
+	})
+	claimedAt := time.Now().UTC()
+	probeBlockReuseMetadataFn = func(*DB, string, string) (blockReuseMetadataRow, bool, error) {
+		return blockReuseMetadataRow{
+			GCState:     BlockGCStateRepairingStub,
+			GCClaimID:   blockStubRepairIDFn("org-1", "block-1"),
+			GCClaimedAt: &claimedAt,
+		}, true, nil
+	}
+	probeBlockReuseHasS3OrphanFn = func(*DB, string, string) (bool, error) { return false, nil }
+
+	probe, err := (&DB{}).ProbeBlockReuse("org-1", "block-1")
+	if err != nil || probe.Decision != BlockReuseRepairableStub {
+		t.Fatalf("ProbeBlockReuse() = %v, %v, want repairable/nil", probe.Decision, err)
+	}
+}
+
+func TestProbeBlockReuseBlocksForeignRepairingStub(t *testing.T) {
+	oldMetadata := probeBlockReuseMetadataFn
+	oldOrphan := probeBlockReuseHasS3OrphanFn
+	t.Cleanup(func() {
+		probeBlockReuseMetadataFn = oldMetadata
+		probeBlockReuseHasS3OrphanFn = oldOrphan
+	})
+	claimedAt := time.Now().UTC()
+	probeBlockReuseMetadataFn = func(*DB, string, string) (blockReuseMetadataRow, bool, error) {
+		return blockReuseMetadataRow{GCState: BlockGCStateRepairingStub, GCClaimID: "foreign", GCClaimedAt: &claimedAt}, true, nil
+	}
+	probeBlockReuseHasS3OrphanFn = func(*DB, string, string) (bool, error) {
+		t.Fatal("orphan read must not run for a foreign repair claim")
+		return false, nil
+	}
+
+	probe, err := (&DB{}).ProbeBlockReuse("org-1", "block-1")
+	if err != nil || probe.Decision != BlockReuseBlockedByGC {
+		t.Fatalf("ProbeBlockReuse() = %v, %v, want blocked/nil", probe.Decision, err)
+	}
+}
+
+func TestProbeBlockReuseRejectsIncompleteClaimOwnership(t *testing.T) {
+	oldMetadata := probeBlockReuseMetadataFn
+	t.Cleanup(func() { probeBlockReuseMetadataFn = oldMetadata })
+	probeBlockReuseMetadataFn = func(*DB, string, string) (blockReuseMetadataRow, bool, error) {
+		return blockReuseMetadataRow{GCState: BlockGCStateDeleting, GCClaimID: "claim-1"}, true, nil
+	}
+
+	probe, err := (&DB{}).ProbeBlockReuse("org-1", "block-1")
+	if err == nil {
+		t.Fatal("ProbeBlockReuse() error = nil, want malformed ownership error")
 	}
 	if probe.Decision != BlockReuseUnknownError {
 		t.Fatalf("decision = %v, want BlockReuseUnknownError", probe.Decision)
@@ -741,7 +1154,11 @@ func TestProbeBlockReuseNeedsPutWhenMetadataPresentButNoReferences(t *testing.T)
 	})
 
 	probeBlockReuseMetadataFn = func(database *DB, orgID, blockID string) (blockReuseMetadataRow, bool, error) {
-		return blockReuseMetadataRow{Sha1: "sha1-cold", SizeBytes: 4096, StorageClass: "cold-archive", StorageKey: "blocks/ab/cd", GCState: ""}, true, nil
+		row := completeProbeMetadataRow("cold-archive")
+		row.Sha1 = "sha1-cold"
+		row.SizeBytes = 4096
+		row.StorageKey = "blocks/ab/cd"
+		return row, true, nil
 	}
 	probeBlockReuseHasReferencesFn = func(database *DB, orgID, blockID string) (bool, error) {
 		return false, nil
@@ -783,7 +1200,13 @@ func TestProbeBlockReuseBlockedByGCWhenGCStateDeleting(t *testing.T) {
 	})
 
 	probeBlockReuseMetadataFn = func(database *DB, orgID, blockID string) (blockReuseMetadataRow, bool, error) {
-		return blockReuseMetadataRow{SizeBytes: 10, StorageClass: "hot", GCState: BlockGCStateDeleting}, true, nil
+		row := completeProbeMetadataRow("hot")
+		claimedAt := time.Now().UTC()
+		row.SizeBytes = 10
+		row.GCState = BlockGCStateDeleting
+		row.GCClaimID = "claim-1"
+		row.GCClaimedAt = &claimedAt
+		return row, true, nil
 	}
 	refsCalled := false
 	probeBlockReuseHasReferencesFn = func(database *DB, orgID, blockID string) (bool, error) {

--- a/internal/gc/store.go
+++ b/internal/gc/store.go
@@ -79,6 +79,10 @@ type GCStore interface {
 	// ReleaseBlockClaim clears gc_state only when the same claimID still owns the
 	// row. This prevents another attempt from releasing a claim it did not win.
 	ReleaseBlockClaim(orgID uuid.UUID, blockID, claimID string) error
+	// DeleteClaimedBlockStub removes only a metadata-free stub owned by claimID.
+	// applied=false means the row changed and callers must retry rather than
+	// treating the stale observation as success.
+	DeleteClaimedBlockStub(orgID uuid.UUID, blockID, claimID string) (bool, error)
 	// FinalizeBlockDelete removes the block row only when the same claimID still
 	// owns the row.
 	FinalizeBlockDelete(orgID uuid.UUID, blockID, claimID string) error

--- a/internal/gc/store_cassandra.go
+++ b/internal/gc/store_cassandra.go
@@ -2114,6 +2114,10 @@ func (s *CassandraStore) ReleaseBlockClaim(orgID uuid.UUID, blockID, claimID str
 	return nil
 }
 
+func (s *CassandraStore) DeleteClaimedBlockStub(orgID uuid.UUID, blockID, claimID string) (bool, error) {
+	return s.db.DeleteClaimedBlockStub(orgID.String(), blockID, claimID)
+}
+
 // FinalizeBlockDelete removes a block row that was previously claimed by GC.
 func (s *CassandraStore) FinalizeBlockDelete(orgID uuid.UUID, blockID, claimID string) error {
 	applied, err := s.db.Session().Query(`

--- a/internal/gc/store_mock.go
+++ b/internal/gc/store_mock.go
@@ -200,7 +200,8 @@ type MockStore struct {
 	dlqOpHook func(orgID uuid.UUID, op string)
 	// force the "row disappeared between CAS read and repair update" path in
 	// RecordS3Orphan so tests can verify we do not resurrect partial phantom rows.
-	recordS3OrphanRepairRace bool
+	recordS3OrphanRepairRace         bool
+	deleteClaimedBlockStubForceFalse bool
 
 	// audit_log entries
 	auditLog []AuditLogEntry
@@ -212,14 +213,16 @@ type MockStore struct {
 }
 
 type mockBlock struct {
-	OrgID            uuid.UUID
-	BlockID          string
-	StorageClass     string
-	CreatedAt        *time.Time
-	GCState          string
-	GCClaimID        string
-	RepresentationID string
-	Sha1             string
+	OrgID               uuid.UUID
+	BlockID             string
+	StorageClass        string
+	StorageClassPresent bool
+	CreatedAt           *time.Time
+	GCState             string
+	GCClaimID           string
+	GCClaimedAt         *time.Time
+	RepresentationID    string
+	Sha1                string
 }
 
 type mockPendingItemKey struct {
@@ -582,11 +585,12 @@ func (m *MockStore) AddBlock(orgID uuid.UUID, blockID, storageClass string, refC
 	key := fmt.Sprintf("%s:%s", orgID, blockID)
 	createdAt := time.Now().UTC()
 	m.blocks[key] = &mockBlock{
-		OrgID:            orgID,
-		BlockID:          blockID,
-		StorageClass:     storageClass,
-		RepresentationID: db.PlainBlockRepresentationID,
-		CreatedAt:        &createdAt,
+		OrgID:               orgID,
+		BlockID:             blockID,
+		StorageClass:        storageClass,
+		StorageClassPresent: true,
+		RepresentationID:    db.PlainBlockRepresentationID,
+		CreatedAt:           &createdAt,
 	}
 	// Model the legacy refCount as that many distinct reference rows so existing
 	// tests keep their "block is alive with N refs" intent under the row model.
@@ -2075,13 +2079,23 @@ func (m *MockStore) ClaimBlockDelete(orgID uuid.UUID, blockID, claimID string) (
 	key := fmt.Sprintf("%s:%s", orgID, blockID)
 	b, ok := m.blocks[key]
 	if !ok {
-		return false, nil
+		claimedAt := time.Now().UTC()
+		m.blocks[key] = &mockBlock{
+			OrgID:       orgID,
+			BlockID:     blockID,
+			GCState:     db.BlockGCStateDeleting,
+			GCClaimID:   claimID,
+			GCClaimedAt: &claimedAt,
+		}
+		return true, nil
 	}
 	if b.GCState == db.BlockGCStateDeleting {
 		return b.GCClaimID == claimID, nil
 	}
 	b.GCState = db.BlockGCStateDeleting
 	b.GCClaimID = claimID
+	claimedAt := time.Now().UTC()
+	b.GCClaimedAt = &claimedAt
 	return true, nil
 }
 
@@ -2095,9 +2109,26 @@ func (m *MockStore) ReleaseBlockClaim(orgID uuid.UUID, blockID, claimID string) 
 		}
 		b.GCState = ""
 		b.GCClaimID = ""
+		b.GCClaimedAt = nil
 		return nil
 	}
 	return fmt.Errorf("block delete claim release not applied for %s", blockID)
+}
+
+func (m *MockStore) DeleteClaimedBlockStub(orgID uuid.UUID, blockID, claimID string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.deleteClaimedBlockStubForceFalse {
+		return false, nil
+	}
+
+	key := fmt.Sprintf("%s:%s", orgID, blockID)
+	b, ok := m.blocks[key]
+	if !ok || b.CreatedAt != nil || b.StorageClassPresent || b.GCState != db.BlockGCStateDeleting || b.GCClaimID != claimID || b.GCClaimedAt == nil {
+		return false, nil
+	}
+	delete(m.blocks, key)
+	return true, nil
 }
 
 func (m *MockStore) FinalizeBlockDelete(orgID uuid.UUID, blockID, claimID string) error {

--- a/internal/gc/worker.go
+++ b/internal/gc/worker.go
@@ -467,6 +467,34 @@ func (w *Worker) processBlock(ctx context.Context, item QueueItem) error {
 		return fmt.Errorf("failed to re-check block references for %s: %w", item.ItemID, err)
 	}
 	if hasRefs {
+		blockInfo, infoErr := w.store.GetBlockInfo(item.OrgID, item.ItemID)
+		if infoErr != nil {
+			return fmt.Errorf("failed to load re-referenced block info for %s: %w", item.ItemID, infoErr)
+		}
+		if blockInfo.CreatedAt == nil {
+			if strings.TrimSpace(blockInfo.StorageClass) != "" {
+				return fmt.Errorf("stub block %s has storage class without creation timestamp", item.ItemID)
+			}
+			// The owned claim fences writers. Remove any partially backfilled mapping
+			// before deleting the only row that carries its identity; retries are
+			// idempotent if the subsequent conditional stub delete fails.
+			if err := w.cleanupBlockMapping(item.OrgID, item.ItemID, blockInfo.RepresentationID, blockInfo.Sha1); err != nil {
+				return err
+			}
+			deleted, deleteErr := w.store.DeleteClaimedBlockStub(item.OrgID, item.ItemID, claimID)
+			if deleteErr != nil {
+				return fmt.Errorf("failed to delete re-referenced claimed stub %s: %w", item.ItemID, deleteErr)
+			}
+			if !deleted {
+				return fmt.Errorf("claimed stub %s changed before conditional delete", item.ItemID)
+			}
+			if err := w.store.DeleteBlockGCCandidate(item.OrgID, item.ItemID, candidateAt); err != nil {
+				return fmt.Errorf("failed to clear block GC candidate after re-referenced stub cleanup: %w", err)
+			}
+			log.Printf("[GC Worker] Block %s re-referenced after a stub claim; removed the owned stub", item.ItemID)
+			metrics.GCItemsSkippedTotal.Inc()
+			return nil
+		}
 		if relErr := w.store.ReleaseBlockClaim(item.OrgID, item.ItemID, claimID); relErr != nil {
 			return fmt.Errorf("failed to release claim on re-referenced block %s: %w", item.ItemID, relErr)
 		}
@@ -488,14 +516,19 @@ func (w *Worker) processBlock(ctx context.Context, item QueueItem) error {
 	storageClass := strings.TrimSpace(blockInfo.StorageClass)
 	if storageClass == "" {
 		if blockInfo.CreatedAt == nil {
-			if err := w.store.FinalizeBlockDelete(item.OrgID, item.ItemID, claimID); err != nil {
-				return fmt.Errorf("failed to remove stub block row for %s: %w", item.ItemID, err)
-			}
-			// Stub row carries no metadata; blockInfo.Sha1 is captured before the
-			// FinalizeBlockDelete above and is normally empty for a stub.
 			if err := w.cleanupBlockMapping(item.OrgID, item.ItemID, blockInfo.RepresentationID, blockInfo.Sha1); err != nil {
 				return err
 			}
+			deleted, deleteErr := w.store.DeleteClaimedBlockStub(item.OrgID, item.ItemID, claimID)
+			if deleteErr != nil {
+				return fmt.Errorf("failed to remove stub block row for %s: %w", item.ItemID, deleteErr)
+			}
+			if !deleted {
+				return fmt.Errorf("claimed stub %s changed before conditional delete", item.ItemID)
+			}
+			// Stub row carries no canonical metadata; blockInfo.Sha1 is captured
+			// before deletion and is normally empty, but may have been backfilled by
+			// an interrupted materialization attempt.
 			if err := w.store.DeleteBlockGCCandidate(item.OrgID, item.ItemID, candidateAt); err != nil {
 				return fmt.Errorf("failed to clear block GC candidate after stub cleanup: %w", err)
 			}

--- a/internal/gc/worker_test.go
+++ b/internal/gc/worker_test.go
@@ -1084,6 +1084,64 @@ func TestWorker_ProcessBlock_ReReferencedClaimReleaseIsOwnedByCandidate(t *testi
 	}
 }
 
+func TestWorker_ProcessBlock_ReReferencedClaimedStubIsDeleted(t *testing.T) {
+	store := NewMockStore()
+	w := NewWorker(store, nil, NewQueue(store), 100, 0, false, &Stats{})
+	orgID := uuid.New()
+	libID := uuid.New()
+	candidateAt := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Millisecond)
+	checks := 0
+	store.blockHasReferencesHook = func(hookOrgID uuid.UUID, hookBlockID string, current bool) (bool, error) {
+		checks++
+		if checks == 1 {
+			return false, nil
+		}
+		store.AddFSObjectReferenceForTest(hookOrgID, hookBlockID, libID, "fs-live")
+		return true, nil
+	}
+	store.AddStubBlockForTest(orgID, "blk-stub-rereferenced")
+	store.AddBlockGCCandidate(orgID, "blk-stub-rereferenced", "hot", candidateAt)
+	store.EnqueueItem(orgID, candidateAt, ItemBlock, "blk-stub-rereferenced", libID, "hot", 0)
+
+	n, err := w.ProcessOnce(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessOnce() error = %v, want nil", err)
+	}
+	if n != 1 || store.GetBlock(orgID, "blk-stub-rereferenced") != nil {
+		t.Fatalf("processed/block = %d/%v, want 1/nil", n, store.GetBlock(orgID, "blk-stub-rereferenced"))
+	}
+	if len(store.AllBlockGCCandidates()) != 0 {
+		t.Fatal("candidate should be cleared after claimed stub deletion")
+	}
+}
+
+func TestWorker_ProcessBlock_ClaimedStubDeleteLostRaceFailsClosed(t *testing.T) {
+	store := NewMockStore()
+	w := NewWorker(store, nil, NewQueue(store), 100, 0, false, &Stats{})
+	orgID := uuid.New()
+	libID := uuid.New()
+	candidateAt := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Millisecond)
+	checks := 0
+	store.blockHasReferencesHook = func(uuid.UUID, string, bool) (bool, error) {
+		checks++
+		return checks > 1, nil
+	}
+	store.AddStubBlockForTest(orgID, "blk-stub-race")
+	store.AddBlockGCCandidate(orgID, "blk-stub-race", "hot", candidateAt)
+	store.EnqueueItem(orgID, candidateAt, ItemBlock, "blk-stub-race", libID, "hot", 0)
+	store.deleteClaimedBlockStubForceFalse = true
+
+	if _, err := w.ProcessOnce(context.Background()); err != nil {
+		t.Fatalf("ProcessOnce() error = %v, want queue-level retry handling", err)
+	}
+	if store.GetBlock(orgID, "blk-stub-race") == nil {
+		t.Fatal("stub must remain when conditional delete loses the race")
+	}
+	if len(store.AllBlockGCCandidates()) != 1 {
+		t.Fatal("candidate must remain for retry when conditional delete loses the race")
+	}
+}
+
 func TestWorker_ProcessFSObject_CascadesDirEntries(t *testing.T) {
 	store := NewMockStore()
 	stats := &Stats{}

--- a/internal/integration/gc_integration_test.go
+++ b/internal/integration/gc_integration_test.go
@@ -1551,15 +1551,119 @@ func TestGC_ClaimBlockDelete_StubRowMaterializationIsCleaned(t *testing.T) {
 		t.Fatalf("materialized stub should have nil created_at, got %v", info.CreatedAt)
 	}
 
-	// FinalizeBlockDelete (the worker's stub-cleanup primitive) must remove the
-	// stub we claimed, with the same claimID.
-	if err := store.FinalizeBlockDelete(orgUUID, blockID, claimID); err != nil {
-		t.Fatalf("FinalizeBlockDelete(stub): %v", err)
+	// The narrow claimed-stub primitive must remove the stub with the same claimID.
+	deleted, err := store.DeleteClaimedBlockStub(orgUUID, blockID, claimID)
+	if err != nil {
+		t.Fatalf("DeleteClaimedBlockStub(stub): %v", err)
+	}
+	if !deleted {
+		t.Fatal("DeleteClaimedBlockStub(stub) did not apply")
 	}
 	if exists, err := store.BlockExists(orgUUID, blockID); err != nil {
 		t.Fatalf("BlockExists(after finalize): %v", err)
 	} else if exists {
 		t.Fatal("stub row still present after FinalizeBlockDelete")
+	}
+}
+
+func TestGC_ReleasedBlockStub_ProbeRepairAndMaterialize(t *testing.T) {
+	requireCassandra(t)
+
+	database := shareProjectionDBForTest(t)
+	orgID := uuid.New().String()
+	blockID := strings.Repeat("a", 64)
+	sha1ID := strings.Repeat("b", 40)
+	t.Cleanup(func() {
+		if err := database.Session().Query(`DELETE FROM block_references WHERE org_id = ? AND block_id = ?`, orgID, blockID).Exec(); err != nil {
+			t.Fatalf("cleanup block references: %v", err)
+		}
+		if err := database.Session().Query(`DELETE FROM blocks WHERE org_id = ? AND block_id = ?`, orgID, blockID).Exec(); err != nil {
+			t.Fatalf("cleanup block row: %v", err)
+		}
+	})
+
+	if err := database.Session().Query(`
+		INSERT INTO blocks (org_id, block_id) VALUES (?, ?)
+	`, orgID, blockID).Exec(); err != nil {
+		t.Fatalf("seed released stub: %v", err)
+	}
+	probe, err := database.ProbeBlockReuse(orgID, blockID)
+	if err != nil {
+		t.Fatalf("ProbeBlockReuse(released stub): %v", err)
+	}
+	if probe.Decision != db.BlockReuseRepairableStub {
+		t.Fatalf("released stub decision = %v, want RepairableStub", probe.Decision)
+	}
+
+	repaired, err := database.RepairReleasedBlockStub(orgID, blockID)
+	if err != nil {
+		t.Fatalf("RepairReleasedBlockStub: %v", err)
+	}
+	if !repaired {
+		t.Fatal("RepairReleasedBlockStub did not apply")
+	}
+
+	// Re-seed the stub and drive the unprobed materialization backstop.
+	if err := database.Session().Query(`INSERT INTO blocks (org_id, block_id) VALUES (?, ?)`, orgID, blockID).Exec(); err != nil {
+		t.Fatalf("reseed released stub: %v", err)
+	}
+	if err := database.UpsertBlockMetadataWithSHA1(orgID, blockID, sha1ID, 123, "hot", "blocks/"+orgID+"/aa/aa/"+blockID); err != nil {
+		t.Fatalf("UpsertBlockMetadataWithSHA1(stub backstop): %v", err)
+	}
+	if err := database.AddBlockReference(orgID, blockID, "test:live", uuid.New().String(), 0); err != nil {
+		t.Fatalf("AddBlockReference: %v", err)
+	}
+	probe, err = database.ProbeBlockReuse(orgID, blockID)
+	if err != nil {
+		t.Fatalf("ProbeBlockReuse(materialized): %v", err)
+	}
+	if probe.Decision != db.BlockReuseReusable || probe.StorageClass != "hot" {
+		t.Fatalf("materialized probe = %+v, want reusable hot block", probe)
+	}
+}
+
+func TestGC_ActiveBlockStub_RequiresOwningClaim(t *testing.T) {
+	requireCassandra(t)
+
+	database := shareProjectionDBForTest(t)
+	store := gcpkg.NewCassandraStore(database)
+	orgUUID := uuid.New()
+	orgID := orgUUID.String()
+	blockID := strings.Repeat("c", 64)
+	claimID := "claim-active-stub"
+	t.Cleanup(func() {
+		if err := database.Session().Query(`DELETE FROM blocks WHERE org_id = ? AND block_id = ?`, orgID, blockID).Exec(); err != nil {
+			t.Fatalf("cleanup active stub: %v", err)
+		}
+	})
+
+	if err := database.Session().Query(`
+		INSERT INTO blocks (org_id, block_id, gc_state, gc_claim_id, gc_claimed_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, orgID, blockID, db.BlockGCStateDeleting, claimID, time.Now().UTC()).Exec(); err != nil {
+		t.Fatalf("seed active stub: %v", err)
+	}
+	probe, err := database.ProbeBlockReuse(orgID, blockID)
+	if err != nil {
+		t.Fatalf("ProbeBlockReuse(active stub): %v", err)
+	}
+	if probe.Decision != db.BlockReuseBlockedByGC {
+		t.Fatalf("active stub decision = %v, want BlockedByGC", probe.Decision)
+	}
+	if repaired, err := database.RepairReleasedBlockStub(orgID, blockID); err != nil {
+		t.Fatalf("RepairReleasedBlockStub(active): %v", err)
+	} else if repaired {
+		t.Fatal("released-stub repair applied to active claim")
+	}
+	if deleted, err := store.DeleteClaimedBlockStub(orgUUID, blockID, "wrong-claim"); err != nil {
+		t.Fatalf("DeleteClaimedBlockStub(wrong owner): %v", err)
+	} else if deleted {
+		t.Fatal("wrong owner deleted active stub")
+	}
+	if deleted, err := store.DeleteClaimedBlockStub(orgUUID, blockID, claimID); err != nil {
+		t.Fatalf("DeleteClaimedBlockStub(owner): %v", err)
+	} else if !deleted {
+		t.Fatal("owning claim did not delete active stub")
 	}
 }
 

--- a/internal/integration/web_block_upload_test.go
+++ b/internal/integration/web_block_upload_test.go
@@ -1149,10 +1149,16 @@ func TestWebBlockUploadGCFenceRejected(t *testing.T) {
 
 	// Simulate the GC worker claiming the block for deletion.
 	db := shareProjectionDBForTest(t).Session()
-	if err := db.Query(`UPDATE blocks SET gc_state = 'deleting' WHERE org_id = ? AND block_id = ?`, orgID, hash).Exec(); err != nil {
+	if err := db.Query(`
+		UPDATE blocks SET gc_state = 'deleting', gc_claim_id = ?, gc_claimed_at = ?
+		WHERE org_id = ? AND block_id = ?
+	`, "integration-fence-claim", time.Now().UTC(), orgID, hash).Exec(); err != nil {
 		t.Fatalf("set gc_state: %v", err)
 	}
-	defer db.Query(`UPDATE blocks SET gc_state = '' WHERE org_id = ? AND block_id = ?`, orgID, hash).Exec()
+	defer db.Query(`
+		UPDATE blocks SET gc_state = null, gc_claim_id = null, gc_claimed_at = null
+		WHERE org_id = ? AND block_id = ?
+	`, orgID, hash).Exec()
 
 	commit := webCommit(t, adminClient, repoID, map[string]interface{}{
 		"session": session, "parent_dir": "/", "filename": "fenced.txt",


### PR DESCRIPTION
## Resumen

Convierte el "claim stub" del GC en un **estado de ciclo de vida explícito** y cierra las carreras alrededor de bloques re-referenciados tras un claim.

### Cambios clave
- **`DeleteClaimedBlockStub`** (nuevo, store + Cassandra + mock): borra **solo** una fila stub sin metadata que aún pertenece a `claimID`, vía LWT fail-closed (`created_at = null AND storage_class = null AND gc_state AND gc_claim_id`). Si la fila cambió, devuelve `applied=false` → el caller **reintenta** en vez de tratar la observación obsoleta como éxito.
- **`worker.processBlock`**: cuando un bloque se re-referencia después de un stub-claim, limpia el mapping parcial y elimina el stub que porta su identidad (idempotente ante reintentos). Un stub con storage class pero sin timestamp de creación ahora es un error explícito.
- **`fix(gc)`**: una carrera perdida de stub-repair es **reintentable**, no un error duro.
- **`refactor(blocks)`**: centraliza el mapeo de errores de materialize de web-session + prueba el status HTTP; elimina el seam legacy muerto Exists+PUT en seafhttp.
- Documentación y configs de GC actualizadas.

### Verificación
- `go build ./...` ✅
- `go vet` (api, db, gc) ✅
- Unit tests `internal/api/...`, `internal/db/...`, `internal/gc/...` ✅
- Tests de integración compilan ✅ (requieren stack docker vivo para ejecutar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
