### PR TITLE
fix(gc): retry block materialization failures

### DIFF
--- a/docs/GC-UPLOAD-FENCE-PR-PLAN.md
+++ b/docs/GC-UPLOAD-FENCE-PR-PLAN.md
@@ -3,8 +3,11 @@
 **Date:** 2026-07-21
 **Research branch:** `docs/gc-upload-fence-rematerialization` — **not for merge**
 **Status:** PR-1 merged as [#137](https://github.com/Sesame-Disk/sesamefs/pull/137);
-PR-2 is implemented and verified on `fix/gc-claim-stub-lifecycle`, pending review
-and merge. F2/X7 remain open on `main` until that merge.
+PR-2 merged as [#138](https://github.com/Sesame-Disk/sesamefs/pull/138) (closed F2/X7).
+PR-3 is implemented and verified on `fix/gc-store-materialize-retry-contract`, pending
+review and merge; it closes F6 and F14 and the **observed-fence half** of F1 — the F1
+fast-clear window (a full GC cycle completing between the single fence read and publish)
+stays with PR-5.
 
 ## Why this document exists
 
@@ -247,9 +250,76 @@ behaviour change, not as dormant plumbing.
 
 **Acceptance:** the sentinel is produced by the production helper, not only injected
 in tests; a permanent metadata failure is not retried; retry reasons are
-`gc_fence` / `probe` / `materialization` and never mislabel a write as a read; and
-the six already-wired funnels are exercised under a fence to confirm the new repeat
-behaviour is what we want.
+`gc_fence` / `probe` / `materialization` and never label a materialize-phase write as
+`probe`; and each of the three retry wrappers is exercised under a fence to confirm
+the repeat behaviour shared by the six wired funnels. Full six-call-site coverage and
+the deterministic fast-clear regression remain PR-5 acceptance.
+
+**Implementation notes (as landed):**
+
+- `RegisterUploadedBlock` is now linear: it reads the delete fence **once** and
+  returns `ErrBlockDeleteInProgress` immediately on an active fence, leaving the
+  provisional reference in place. The old inner wait loop is gone; the outer wrapper
+  owns retrying and re-PUTs the object on the next store pass. This closes the
+  **observed-fence half** of F1 — the store→materialize contract now re-PUTs whenever
+  the fence is seen. It does **not** close the F1 fast-clear window where a full GC
+  cycle completes before that single fence read (the fence is never observed); that is
+  PR-5's deterministic real-worker regression. Destructive GC stays disabled meanwhile.
+- Cassandra I/O in the helper (and the mapping write in
+  `RegisterUploadedBlockAndMapping`) is tagged `v2.ErrBlockMaterializationTransient`
+  with the cause preserved via `%w`; `db.ErrBlockMetadataPermanent` (empty class,
+  malformed sha1, conflicting representation/sha1, corrupt GC ownership) is returned
+  untagged and not retried. Default bias is transient — only deterministically
+  irrecoverable failures are permanent. This closes F6. **Exception:** the
+  provisional-expiry write fails closed — on its failure the helper releases the
+  reference and enqueues it rather than leaving a reference with no GC-discovery
+  projection (the F10 interim guard); it is not retried because a retry would re-add
+  the reference into the same split write.
+- The retry metric `block_upload_materialization_retries_total{surface,reason}` is
+  emitted by all three retry wrappers — the generic `RetryUploadedBlockMaterialization`,
+  the SeafHTTP `retrySeafHTTPBlockMaterialization`, and the template-CreateFile
+  `retryCreateFileTemplateBlockMaterialization`. The reason is derived from the failing
+  **phase** (store→`probe`, materialize→`materialization`), overridden to `gc_fence`
+  only when the block is fenced — so a materialize-phase metadata write is never
+  labeled `probe`. This closes F14. Note `probe` denotes the store phase (probe/HEAD/
+  PUT), not a "read side", and is reached only if a store callback opts into the
+  transient sentinel; the shipped store callbacks return only a fence or a
+  non-retryable raw error, so store-phase retries are otherwise `gc_fence`. All three
+  wrappers also retry on the transient sentinel and re-PUT on a fence. Structurally
+  collapsing the three wrappers into one stays with PR-5.
+- Added the cancellable `RetryUploadedBlockMaterializationContext`. Only the three
+  funnels that use the **generic** wrapper are wired to it — UploadFile
+  (`c.Request.Context()`), sync PutBlock (`c.Request.Context()`) and OnlyOffice (its
+  `ctx` arg) — so an aborted request there stops the retry backoff instead of burning
+  the budget. The two bespoke wrappers (SeafHTTP and template-CreateFile) keep their
+  own non-cancellable backoff; giving them a cancellable context is part of PR-5's
+  wrapper normalisation, not PR-3. The worst case they carry is a bounded ~2s of
+  backoff sleep on an already-aborted request, not a correctness gap.
+- **Test coverage note:** the retry behaviour is verified at the level of the three
+  retry wrappers (generic, SeafHTTP, template), which is the shared mechanism the six
+  funnels drive, plus the linear-helper (`RegisterUploadedBlock`) and mapping unit
+  tests. It does **not** yet drive all six production call sites under a live fence.
+  The full six-call-site + deterministic fast-clear regression (real GC worker paused
+  at its post-claim liveness read) is **PR-5's** acceptance; PR-3 lands the mechanism
+  and its wrapper/helper-level proofs.
+
+Verification completed 2026-07-21 (local, Windows dev box has no gcc so no `-race`
+locally; `-race` + integration run in Docker per the verification debt below):
+
+```bash
+go build ./...
+go vet ./internal/api/... ./internal/db/... ./internal/metrics/...
+go test ./internal/api/... ./internal/db/... ./internal/metrics/...
+go vet -tags=integration ./...
+docker compose --profile test run --rm --build gotest go test -race -count=1 ./internal/db ./internal/gc ./internal/api/...
+docker compose --profile test run --rm --build go-integration-test
+```
+
+Known pre-existing flake (not in PR-3's diff): a wider `-race ./internal/api/...` run
+can intermittently trip `TestAcquireSeafHTTPDistributedUploadFinalizeLeaseRenewsWhileHeld`
+(a distributed-lease renewal test, unrelated to the retry contract); an isolated rerun
+passes. It predates PR-3 and is tracked separately; do not read PR-3's `-race` result as
+covering it.
 
 ---
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -952,7 +952,7 @@ This is fixed for the *server-side hot upload paths*, not across the whole repo:
 #### Why skipping the legacy PUT is safe
 
 GC-race safety derives from the *reference-first, then fence-check* protocol in
-`FSHelper.RegisterUploadedBlock` (`fs_helpers.go:1006–1034`) versus GC's
+`FSHelper.RegisterUploadedBlock` (`fs_helpers.go`) versus GC's
 *claim-then-verify-references* in `worker.go:processBlock` (L410–443) — a
 Dekker-style mutual flagging — not from the S3 PUT. The `gc_s3_orphans` fence is
 written before the S3 `DeleteObject`, so probes can observe the normal in-flight
@@ -962,10 +962,22 @@ cannot revoke it. Only never-reused generational physical keys close that ABA. T
 canonical verify/repair on the reuse path is an additional check, not permission to
 enable destructive GC.
 
-The materialization retry loop (`retrySeafHTTPBlockMaterialization` and
-`v2.RetryUploadedBlockMaterialization`) now also retries when the `store` phase
-returns `ErrBlockDeleteInProgress`, since a probe can reject a block before any S3
-work begins.
+The materialization retry loop (`retrySeafHTTPBlockMaterialization`,
+`v2.RetryUploadedBlockMaterialization` and the template-CreateFile wrapper) retries on
+a GC delete fence (`ErrBlockDeleteInProgress`) in **either** phase, and on a transient
+failure that is **tagged** `v2.ErrBlockMaterializationTransient`. Only the materialize
+phase tags transients today — `RegisterUploadedBlock`'s Cassandra I/O and the mapping
+write — so a store-phase retry is otherwise fence-only (the shipped store callbacks
+return a fence or a non-retryable raw probe/PUT error). As of PR-3,
+`RegisterUploadedBlock` no longer waits out the fence internally: it reads the fence
+once and propagates `ErrBlockDeleteInProgress`, so the wrapper repeats store→materialize
+and **re-PUTs the object** when the fence is observed (closing the observed-fence half
+of F1; the fast-clear window where the fence is never seen stays with PR-5). A permanent
+metadata failure (`db.ErrBlockMetadataPermanent`) is returned untagged and not retried;
+the provisional-expiry write fails closed with a rollback (F10 guard). The retry metric
+`block_upload_materialization_retries_total{surface,reason}` labels the reason by the
+failing phase (`probe` = store phase, `materialization` = metadata materialize phase,
+`gc_fence`), so a metadata-write failure is never labeled `probe`.
 
 #### Caveats
 

--- a/docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md
+++ b/docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md
@@ -4,8 +4,11 @@
 **Origin:** eight successive audits of the GC upload-fence work, 2026-07-20/21.
 **Companion:** [GC-UPLOAD-FENCE-PR-PLAN.md](./GC-UPLOAD-FENCE-PR-PLAN.md) — which PR closes what.
 **Series progress:** PR-1 merged as [#137](https://github.com/Sesame-Disk/sesamefs/pull/137);
-PR-2 is implemented and verified on `fix/gc-claim-stub-lifecycle`, pending review
-and merge. No finding is closed by PR-2 on `main` yet.
+PR-2 merged as [#138](https://github.com/Sesame-Disk/sesamefs/pull/138), closing F2 and
+X7. PR-3 (store/materialize retry contract) is implemented on
+`fix/gc-store-materialize-retry-contract`, **pending merge**: it closes F6 and F14 and
+the observed-fence half of F1 (the F1 fast-clear window stays with PR-5). Rows stay in
+**## Open** until PR-3 merges.
 
 Every row is verified against code at the cited location, except where the row
 explicitly identifies engine-dependent behavior that still needs a non-skipping
@@ -33,32 +36,46 @@ out here so the decision is visible rather than implicit.
 
 ## Open on `main`
 
+Rows whose **Closed by** names PR-3 have their code landed on
+`fix/gc-store-materialize-retry-contract` but stay **open** here until that branch
+merges (a row only moves to **## Closed** on merge — see the note at the top).
+
 | # | Severity | Finding | Evidence | Closed by |
 |---|---|---|---|---|
-| F1 | Blocker | **Fast-clearing GC fence loses the uploaded object.** An upload can PUT, add its provisional reference after GC's post-claim liveness read, wait for the fence, then publish metadata without repeating the PUT GC deleted — returning success for an absent object. The store→materialize contract exists but `RegisterUploadedBlock`'s inner wait absorbs the fence and returns `nil`, so the outer wrapper never repeats the store. | `fs_helpers.go` `RegisterUploadedBlock`; `upload_reuse.go` `RetryUploadedBlockMaterialization` | PR-3, PR-5 |
-| F2 | Blocker where the deployed Cassandra/Scylla engine materializes the row | **A materialized GC-claim stub permanently breaks a block id.** A conditional claim against a row that vanishes between the existence check and claim can, depending on engine behavior, materialize a stub with no `storage_class`/`created_at`. If the post-claim recheck finds a reference, the claim is released and the stub survives; `ProbeBlockReuse` then hard-errors on it forever, and because the probe runs in the store phase the writer-side repair in materialize is unreachable. | `worker.go` `processBlock` hasRefs branch; `block_references.go` `ProbeBlockReuse` empty-class branch; `gc_integration_test.go` explicitly records the engine-dependent missing-row LWT behavior | PR-2 |
+| F1 | Blocker | **Fast-clearing GC fence loses the uploaded object.** An upload can PUT, add its provisional reference after GC's post-claim liveness read, then publish metadata without repeating the PUT GC deleted. PR-3 fixes the **observed-fence** half: `RegisterUploadedBlock` no longer absorbs the fence — it reads it once and propagates `ErrBlockDeleteInProgress`, leaving the provisional reference in place, so the wrapper repeats store→materialize and re-PUTs the object. The **fast-clear window** — a whole GC claim→verify→delete→clear cycle completing between the single fence read and publish, so the fence is never observed — is NOT closed by PR-3; that needs PR-5's deterministic real-worker regression and the web-funnel half. Destructive GC stays disabled meanwhile. | `fs_helpers.go` `RegisterUploadedBlock`; `upload_reuse.go` `RetryUploadedBlockMaterialization` | PR-3 (observed-fence half) + PR-5 (fast-clear window) |
 | F3 | High | **Web block-session upload funnel is unwrapped.** `v2/blocks.go` uses raw `BlockExists` + `PutBlockData` + materialize with no probe and no store retry, so it cannot honour the fence contract at all. | `v2/blocks.go` `UploadBlock` | PR-5 |
 | F4 | High | **`NeedsPut` with existing metadata stores to the wrong backend.** The PUT targets the serving node's preferred store while first-writer metadata may point elsewhere, so physical placement and metadata diverge. | `sync.go`, `seafhttp.go` NeedsPut branches | PR-4 |
 | F5 | High | **Download can serve stale legacy bytes.** `HandleDownload` falls back to the path-based object on *any* streaming failure, including a Cassandra timeout. On a library since written through blocks that object can hold an older version of the same path, so a transient failure answers 200 with stale content. | `seafhttp.go` `HandleDownload` fallback | PR-6 |
-| F6 | Medium | **Transient retry sentinel is not produced by the production helper.** `RegisterUploadedBlock` returns plain errors, so a Cassandra timeout during materialize fails the request immediately with no retry and no metric. | `fs_helpers.go`; `upload_rollback.go` | PR-3 |
+| F6 | Medium | **Transient retry sentinel is not produced by the production helper.** PR-3 tags transient Cassandra I/O in `RegisterUploadedBlock` and the mapping write in `RegisterUploadedBlockAndMapping` with `ErrBlockMaterializationTransient` (retried, cause preserved via `%w`), and returns `db.ErrBlockMetadataPermanent` untagged (not retried). The provisional-expiry write is the one exception: it fails closed with a rollback rather than retry (see F10). | `fs_helpers.go`; `upload_rollback.go` | PR-3 |
 | F7 | Medium | **Readers resolve by routing, not by metadata.** Once bytes follow canonical metadata (F4), a reader that picks the backend by request routing looks in the wrong bucket. | read call sites in `fileview.go`, `sharelink_view.go`, `sync.go`, `seafhttp.go` | PR-4 |
 | F8 | Medium | **Legacy no-session upload leaks S3 objects (R2).** `/api/v2/blocks/upload` without a session writes an object with no `blocks` row and no reference. Reachable by any authenticated user regardless of the block-upload feature flag. | `v2/blocks.go` legacy path | PR-7 |
 | F9 | Medium | **GC Phase 0 can delete a renewed provisional reference.** The scanner removed the reference based on a stale expiry projection, which could drop liveness for a live upload that renewed the same referrer. | `gc/scanner.go` `scanExpiredProvisionalBlockRefs` | PR-8 |
-| F10 | Medium | **Provisional reference and its expiry are written separately.** A failure between them leaves a reference with no discovery projection, so the zero-ref transition is never found. | `fs_helpers.go`; `provisional_block_ref_expiry.go` | PR-8 |
+| F10 | Medium | **Provisional reference and its expiry are written separately.** A failure between them leaves a reference with no discovery projection, so the zero-ref transition is never found. The atomic single-batch write is PR-8; PR-3 keeps the interim guard (on an expiry-write failure `RegisterUploadedBlock` releases the reference and enqueues it, rather than leaving the orphan) so it does not widen this window. | `fs_helpers.go`; `provisional_block_ref_expiry.go` | PR-8 |
 | F11 | Medium | **Abandoned prefetch leaks an open S3 reader.** `PrefetchBlock` buffered its result, so a consumer that stopped early left the `io.ReadCloser` unclosed. | `streaming/streaming.go` | PR-9 |
 | F12 | Medium | **Unbounded request bodies.** `PutBlock` and `check-blocks` read the whole body with `io.ReadAll` and no size or id-count limit. | `sync.go` | PR-10 |
 | F13 | High | **Corrupt directory listings resolve, and 404/503 semantics are inverted for a deleted path.** High, not the Low it was first filed as: two of the cases below serve bytes from the wrong FS object. Not Blocker only because it needs an already-corrupt dirent — see the severity note above. The 404/503 half on its own would be Low. `findEntryInDir` returns a plain error, so a renamed or deleted file surfaces as 503 while an absent commit row gives 404. Related, and worse: a JSON-valid but corrupt listing resolves anyway. Structural cases (`null`, `[null]`, non-string name, missing id) parse and the bad entries are skipped, reporting a false absence; semantic cases (empty name, empty or non-40-hex id, duplicate names) resolve to a wrong or missing FS object; and `encoding/json` silently keeps the **last** value for a repeated key, so `{"id":"A","id":"B"}` serves B and `{"name":"a","name":"b"}` hides `a` entirely. Both of the last two can serve arbitrary bytes or report a present file as absent. | `seafhttp.go` `findEntryInDir` | PR-6 |
-| F14 | Low | **Retry metric mislabels write failures.** The SeafHTTP wrapper defaults every non-fence retry to `reason="probe"`, attributing Cassandra write errors to the read path. | `seafhttp.go` retry wrapper | PR-3 |
+| F14 | Low | **Retry metric mislabels write failures.** A retry metric must not attribute a metadata-write failure to the read path. PR-3 emits `block_upload_materialization_retries_total{surface,reason}` from all three wrappers with the reason derived from the failing **phase** (materialize→`materialization`, never `probe`; fence→`gc_fence`). The `probe` label denotes the store phase (not "read side") and is reached only if a store callback opts into the transient sentinel. | `seafhttp.go` retry wrapper; `metrics.go` | PR-3 |
+
+## Closed
+
+Rows move here only once the PR that fixes them **merges**.
+
+| # | Severity | Finding | Closed by |
+|---|---|---|---|
+| F2 | Blocker (engine-dependent) | A materialized GC-claim stub permanently breaks a block id. | PR-2 ([#138](https://github.com/Sesame-Disk/sesamefs/pull/138)) |
+| X7 | Medium (perf) | Design constraint: stub repair must not add a hot-path `blocks` read. Closed by exposing `RepairableStub` from the existing probe plus a metadata-LWT backstop — no extra read on the absent-row path. | PR-2 ([#138](https://github.com/Sesame-Disk/sesamefs/pull/138)) |
 
 ## Open, deferred, or constraining the series
 
 X1-X3, X5 and X6 are not closed by the immediate code PRs; X4 is deferred to PR-11;
-X7 is a design constraint that PR-2 must close without adding hot-path cost.
-Destructive GC stays disabled until X1 and X2 are resolved.
+X7 was closed by PR-2 (see **## Closed**). Destructive GC stays disabled until X1 and
+X2 are resolved.
 
-PR-2 also removes writer-side active-claim release from `internal/api/v2/fs_helpers.go`.
+PR-2 also removed writer-side active-claim release from `internal/api/v2/fs_helpers.go`.
 Only the GC owner may release or delete an active claim; writers must wait/retry or
-fail closed. This is part of F2's lifecycle fix, not deferred to PR-3.
+fail closed. This is part of F2's lifecycle fix. PR-3 goes further on the writer side:
+`RegisterUploadedBlock` no longer waits internally at all — it propagates the fence to
+the outer store→materialize wrapper.
 
 | # | Severity | Finding | Tracked as |
 |---|---|---|---|
@@ -68,7 +85,6 @@ fail closed. This is part of F2's lifecycle fix, not deferred to PR-3.
 | X4 | High (perf) | **One global Paxos round per block on every metadata-registering upload path.** The first-writer `INSERT ... IF NOT EXISTS` is a per-block LWT; under production `SERIAL` and multi-DC it is a global consensus round, ~128 cross-region rounds per GB at the 8 MB block size. **Correction:** an earlier revision said the legacy resumable path "does not pay this at all". That is false — `finalizeUploadStreaming` splits the file into 8 MB blocks and calls `RegisterUploadedBlock` → `UpsertBlockMetadata` per block, so resumable pays the same ~128 LWTs. The defective no-session path in F8 is the exception: it leaves only an S3 object and never registers metadata. This is a **shared** cost of the governed upload paths, not a block-upload disadvantage, and removing it benefits all of them. `main` also reads the `blocks` row twice per upload (`ProbeBlockReuse`, `BlockDeleteFenceActive`), **but those two are not redundant and must not be merged**: the probe reads before the PUT, the fence reads after the provisional reference is durable, and that ordering is the mutual exclusion the protocol depends on. Reusing the pre-PUT observation to authorize publication reintroduces F1. Only the LWT is removable here. **Pre-existing since `e3883aa5d` (2026-05-28)** — not introduced by this work; `13e01263a` only made it representation-aware. | P-4 in `UPLOAD-PERFORMANCE-SECURITY-2026-06.md`; PR-11 (deferred) |
 | X5 | Medium | **Canonical read fan-out unvalidated.** One Cassandra point read per unique block before the first byte. The existing benchmark substitutes an in-memory function for Cassandra, so it measures goroutines and allocations, not driver, pool, latency or cluster load. | `WEB-BLOCK-UPLOAD.md` pre-flag checklist |
 | X6 | Medium | **Read-after-write across DCs.** Canonical lookups retry a missing row 3×25 ms, which covers local lag but not cross-DC. Safe (fails closed) but an availability dependency: transient 404/503 after a remote upload, `check-blocks` reporting a block missing, needless re-uploads. | same as X2 |
-| X7 | Medium (perf) | **The research prototype adds a third unconditional read of the `blocks` row.** On `main` the stub-repair read (`GetBlockDeleteClaimInfo`) only fires when the delete fence is active. The research prototype calls `removeStaleUploadedBlockDeleteStub` on the unfenced path too, so every block upload pays an extra point read. **The obvious shortcut does not work:** an earlier revision proposed keying repair off "`NeedsPut` with an empty `StorageClass`", but a genuinely missing row has that same result. PR-2 exposes `RepairableStub` from the existing probe read, acquires an upload-owned `repairing_stub` token, rechecks the orphan fence, and adds an unapplied-metadata-LWT repair backstop for the unprobed web-session path and probe/delete races. An absent first-writer row still incurs neither an extra read nor repair LWT. | research branch `fs_helpers.go` `RegisterUploadedBlock`; `db.BlockReuseProbe`; PR-2 |
 
 ## X1 design space — closing the physical-delete ABA
 

--- a/docs/UPLOAD-PERFORMANCE-SECURITY-2026-06.md
+++ b/docs/UPLOAD-PERFORMANCE-SECURITY-2026-06.md
@@ -101,10 +101,18 @@ can outlive its Cassandra authorization state. Keep GC disabled fleet-wide until
 generational physical keys close X1. See the audit thread for the full interleaving
 analysis.
 
-**Retry loop change:** `retrySeafHTTPBlockMaterialization` (and the shared
-`v2.RetryUploadedBlockMaterialization`) now treat `ErrBlockDeleteInProgress` from
-the `store` phase as retryable (previously only the `materialize` phase was), since
-a Cassandra-first probe can reject the block before any S3 work starts.
+**Retry loop change:** `retrySeafHTTPBlockMaterialization`, the shared
+`v2.RetryUploadedBlockMaterialization`, and the template-CreateFile wrapper treat a GC
+delete fence (`ErrBlockDeleteInProgress`) in **either** phase as retryable, plus any
+failure **tagged** `v2.ErrBlockMaterializationTransient` (produced today by the
+materialize phase — `RegisterUploadedBlock` Cassandra I/O and the mapping write). As of
+PR-3, `RegisterUploadedBlock` no longer waits out the fence internally — it propagates
+it, so the wrapper re-PUTs the object when the fence is observed (closes the
+observed-fence half of F1; the fast-clear window stays with PR-5). A permanent metadata
+failure (`db.ErrBlockMetadataPermanent`) is not retried, and the retry metric
+`block_upload_materialization_retries_total{surface,reason}` labels the reason by the
+failing phase (`probe` = store phase, `materialization` = metadata materialize phase),
+so a metadata write is never counted as `probe` (closes F14).
 
 **Tests:**
 - `internal/db/block_references_test.go` — full `ProbeBlockReuse` decision matrix

--- a/internal/api/seafhttp.go
+++ b/internal/api/seafhttp.go
@@ -2375,8 +2375,17 @@ func retrySeafHTTPBlockMaterialization(label, blockID string, store func() error
 		attempts = 1
 	}
 
-	retryBlocked := func(attempt int) {
-		if resolveFence != nil {
+	// retryBlocked records the retry under a reason derived from the failing PHASE
+	// (never the sentinel), so a materialize-phase write failure is never
+	// attributed to the probe read path (finding F14). The reason labels match the
+	// generic v2 wrapper's; PR-5 folds this duplicate wrapper into that one.
+	retryBlocked := func(attempt int, phaseReason string, retryErr error) {
+		reason := phaseReason
+		if errors.Is(retryErr, v2.ErrBlockDeleteInProgress) {
+			reason = "gc_fence"
+		}
+		metrics.BlockUploadMaterializationRetriesTotal.WithLabelValues(label, reason).Inc()
+		if reason == "gc_fence" && resolveFence != nil {
 			resolved, resolveErr := resolveFence()
 			if resolveErr != nil {
 				log.Printf("[%s] failed to inspect S3 orphan fence for block %s: %v", label, blockID, resolveErr)
@@ -2385,7 +2394,7 @@ func retrySeafHTTPBlockMaterialization(label, blockID string, store func() error
 			}
 		}
 		sleepFor := seafHTTPBlockMaterializationRetryBackoffFn(attempt)
-		log.Printf("[%s] block %s is fenced by GC delete during materialization; retrying (%d/%d) after %s", label, blockID, attempt, attempts, sleepFor)
+		log.Printf("[%s] block %s materialization retry reason=%s (%d/%d) after %s", label, blockID, reason, attempt, attempts, sleepFor)
 		if sleepFor > 0 {
 			seafHTTPBlockMaterializationSleepFn(sleepFor)
 		}
@@ -2393,17 +2402,17 @@ func retrySeafHTTPBlockMaterialization(label, blockID string, store func() error
 
 	for attempt := 1; attempt <= attempts; attempt++ {
 		if err := store(); err != nil {
-			if !errors.Is(err, v2.ErrBlockDeleteInProgress) || attempt == attempts {
+			if !v2.IsRetryableBlockMaterializationError(err) || attempt == attempts {
 				return err
 			}
-			retryBlocked(attempt)
+			retryBlocked(attempt, "probe", err)
 			continue
 		}
 		if err := materialize(); err != nil {
-			if !errors.Is(err, v2.ErrBlockDeleteInProgress) || attempt == attempts {
+			if !v2.IsRetryableBlockMaterializationError(err) || attempt == attempts {
 				return err
 			}
-			retryBlocked(attempt)
+			retryBlocked(attempt, "materialization", err)
 			continue
 		}
 		return nil

--- a/internal/api/seafhttp_test.go
+++ b/internal/api/seafhttp_test.go
@@ -678,6 +678,85 @@ func TestRetrySeafHTTPBlockMaterialization_RetriesStoreFence(t *testing.T) {
 	}
 }
 
+// TestRetrySeafHTTPBlockMaterialization_LabelsReasonByPhase pins finding F14 for
+// the SeafHTTP wrapper: a materialize-phase transient is labeled "materialization"
+// (never "probe"), a store-phase transient is "probe", and a fence is "gc_fence".
+func TestRetrySeafHTTPBlockMaterialization_LabelsReasonByPhase(t *testing.T) {
+	oldBackoff := seafHTTPBlockMaterializationRetryBackoffFn
+	oldSleep := seafHTTPBlockMaterializationSleepFn
+	t.Cleanup(func() {
+		seafHTTPBlockMaterializationRetryBackoffFn = oldBackoff
+		seafHTTPBlockMaterializationSleepFn = oldSleep
+	})
+	seafHTTPBlockMaterializationRetryBackoffFn = func(int) time.Duration { return 0 }
+	seafHTTPBlockMaterializationSleepFn = func(time.Duration) {}
+
+	reasonCount := func(surface, reason string) float64 {
+		return testutil.ToFloat64(metrics.BlockUploadMaterializationRetriesTotal.WithLabelValues(surface, reason))
+	}
+
+	t.Run("materialize-phase transient is materialization", func(t *testing.T) {
+		const surface = "TestSeafHTTPReasonMaterialize"
+		beforeMat := reasonCount(surface, "materialization")
+		beforeProbe := reasonCount(surface, "probe")
+		calls := 0
+		err := retrySeafHTTPBlockMaterialization(surface, "block-1", func() error { return nil }, func() error {
+			calls++
+			if calls == 1 {
+				return fmt.Errorf("metadata write: %w", v2.ErrBlockMaterializationTransient)
+			}
+			return nil
+		}, nil)
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		if got := reasonCount(surface, "materialization") - beforeMat; got != 1 {
+			t.Fatalf("materialization retries = %v, want 1", got)
+		}
+		if got := reasonCount(surface, "probe") - beforeProbe; got != 0 {
+			t.Fatalf("probe retries = %v, want 0 (write must not be labeled as read)", got)
+		}
+	})
+
+	t.Run("store-phase transient is probe", func(t *testing.T) {
+		const surface = "TestSeafHTTPReasonProbe"
+		before := reasonCount(surface, "probe")
+		calls := 0
+		err := retrySeafHTTPBlockMaterialization(surface, "block-1", func() error {
+			calls++
+			if calls == 1 {
+				return fmt.Errorf("probe read: %w", v2.ErrBlockMaterializationTransient)
+			}
+			return nil
+		}, func() error { return nil }, nil)
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		if got := reasonCount(surface, "probe") - before; got != 1 {
+			t.Fatalf("probe retries = %v, want 1", got)
+		}
+	})
+
+	t.Run("fence is gc_fence", func(t *testing.T) {
+		const surface = "TestSeafHTTPReasonFence"
+		before := reasonCount(surface, "gc_fence")
+		calls := 0
+		err := retrySeafHTTPBlockMaterialization(surface, "block-1", func() error { return nil }, func() error {
+			calls++
+			if calls == 1 {
+				return v2.ErrBlockDeleteInProgress
+			}
+			return nil
+		}, nil)
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		if got := reasonCount(surface, "gc_fence") - before; got != 1 {
+			t.Fatalf("gc_fence retries = %v, want 1", got)
+		}
+	})
+}
+
 func TestRetrySeafHTTPBlockMaterialization_StopsOnNonRetryableError(t *testing.T) {
 	oldBackoff := seafHTTPBlockMaterializationRetryBackoffFn
 	oldSleep := seafHTTPBlockMaterializationSleepFn

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -1297,15 +1297,16 @@ func (h *SyncHandler) PutBlock(c *gin.Context) {
 		}
 		// IMPORTANT: this store callback can be re-invoked by
 		// RetryUploadedBlockMaterialization (the retry path fires when store or
-		// materialize returns ErrBlockDeleteInProgress). It is therefore only
-		// safe to write a gin response (c.JSON) here because every branch that
-		// writes one returns a NON-retryable sentinel (errSyncStorageQuotaExceeded,
+		// materialize returns a retryable sentinel: ErrBlockDeleteInProgress or
+		// ErrBlockMaterializationTransient). It is therefore only safe to write a
+		// gin response (c.JSON) here because every branch that writes one returns a
+		// NON-retryable sentinel (errSyncStorageQuotaExceeded,
 		// errSyncBlockExistenceCheck, errSyncStoreBackend) — those short-circuit
 		// the retry loop, so the callback runs exactly once and never double-writes.
-		// The only retryable return (ErrBlockDeleteInProgress) writes no response.
-		// If you add a new response-writing branch, it MUST return a non-retryable
-		// error or the response will be written twice on retry.
-		if err := v2.RetryUploadedBlockMaterialization("PutBlock", internalID, func() error {
+		// The retryable returns write no response. If you add a new response-writing
+		// branch, it MUST return a non-retryable error or the response will be
+		// written twice on retry.
+		if err := v2.RetryUploadedBlockMaterializationContext(c.Request.Context(), "PutBlock", internalID, func() error {
 			probe, probeErr := syncProbeUploadedBlockReuseFn(h.db, orgID, internalID)
 			if probeErr != nil {
 				return fmt.Errorf("probe block reuse for %s: %w", internalID, probeErr)

--- a/internal/api/v2/files.go
+++ b/internal/api/v2/files.go
@@ -198,12 +198,20 @@ func retryCreateFileTemplateBlockMaterialization(store func() error, register fu
 		attempts = 1
 	}
 
-	retryBlocked := func(attempt int) {
+	// reason is derived from the failing PHASE (never the sentinel), matching the
+	// generic wrapper so a register-phase write failure is not mislabeled as a
+	// probe read (finding F14). PR-5 folds this duplicate wrapper into the generic one.
+	retryBlocked := func(attempt int, phaseReason string, retryErr error) {
 		if resetStored != nil {
 			resetStored()
 		}
+		reason := phaseReason
+		if errors.Is(retryErr, ErrBlockDeleteInProgress) {
+			reason = blockMaterializationReasonFence
+		}
+		metrics.BlockUploadMaterializationRetriesTotal.WithLabelValues("CreateFile", reason).Inc()
 		sleepFor := createFileTemplateBlockRetryBackoffFn(attempt)
-		log.Printf("[CreateFile] template block registration fenced by GC; retrying (%d/%d) after %s", attempt, attempts, sleepFor)
+		log.Printf("[CreateFile] template block materialization retry reason=%s (%d/%d) after %s", reason, attempt, attempts, sleepFor)
 		if sleepFor > 0 {
 			createFileTemplateBlockSleepFn(sleepFor)
 		}
@@ -211,17 +219,17 @@ func retryCreateFileTemplateBlockMaterialization(store func() error, register fu
 
 	for attempt := 1; attempt <= attempts; attempt++ {
 		if err := store(); err != nil {
-			if !errors.Is(err, ErrBlockDeleteInProgress) || attempt == attempts {
+			if !IsRetryableBlockMaterializationError(err) || attempt == attempts {
 				return err
 			}
-			retryBlocked(attempt)
+			retryBlocked(attempt, blockMaterializationReasonProbe, err)
 			continue
 		}
 		if err := register(); err != nil {
-			if !errors.Is(err, ErrBlockDeleteInProgress) || attempt == attempts {
+			if !IsRetryableBlockMaterializationError(err) || attempt == attempts {
 				return err
 			}
-			retryBlocked(attempt)
+			retryBlocked(attempt, blockMaterializationReasonMaterial, err)
 			continue
 		}
 		return nil
@@ -3429,7 +3437,7 @@ func (h *FileHandler) UploadFile(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "storage not available"})
 		return
 	}
-	if err := RetryUploadedBlockMaterialization("UploadFile", sha256ID, func() error {
+	if err := RetryUploadedBlockMaterializationContext(c.Request.Context(), "UploadFile", sha256ID, func() error {
 		probe, probeErr := probeUploadedBlockReuseFn(h.db, orgID, sha256ID)
 		if probeErr != nil {
 			return fmt.Errorf("probe block reuse for %s: %w", sha256ID, probeErr)

--- a/internal/api/v2/fs_helpers.go
+++ b/internal/api/v2/fs_helpers.go
@@ -97,19 +97,20 @@ var registerUploadedBlockUpsertProvisionalExpiryFn = func(h *FSHelper, orgID, bl
 	return h.db.UpsertProvisionalBlockReferenceExpiry(orgID, blockID, referrer, storageClass, expiresAt)
 }
 
-var registerUploadedBlockReleaseRefsFn = func(h *FSHelper, orgID, libraryID, operationID string, blockIDs []string) []string {
-	return h.ReleaseUploadReferences(orgID, libraryID, operationID, blockIDs)
-}
-
 var releaseUploadReferenceDeleteExpiryFn = func(h *FSHelper, orgID, blockID, referrer string) error {
 	return h.db.DeleteProvisionalBlockReferenceExpiry(orgID, blockID, referrer, time.Time{})
 }
 
-var registerUploadedBlockRetryAttemptsFn = RetryAttempts
-
-var registerUploadedBlockRetryBackoffFn = RetryBackoff
-
-var registerUploadedBlockSleepFn = time.Sleep
+// registerUploadedBlockReleaseRefsFn / registerUploadedBlockEnqueueZeroRefFn roll
+// back a provisional reference whose expiry projection could not be written. The
+// reference and its expiry projection must land together — a reference without a
+// projection is invisible to GC Phase 0 and would leak (F10). When the projection
+// write fails we therefore release the reference and enqueue any now-zero-ref
+// block for GC, rather than leaving the orphan behind. (The atomic
+// reference+projection write is F10's full fix, in PR-8.)
+var registerUploadedBlockReleaseRefsFn = func(h *FSHelper, orgID, libraryID, operationID string, blockIDs []string) []string {
+	return h.ReleaseUploadReferences(orgID, libraryID, operationID, blockIDs)
+}
 
 var registerUploadedBlockEnqueueZeroRefFn = func(orgID string, blockIDs []string, storageClass string) {
 	if len(blockIDs) == 0 {
@@ -119,6 +120,11 @@ var registerUploadedBlockEnqueueZeroRefFn = func(orgID string, blockIDs []string
 		blockEnqueuer.EnqueueBlocks(orgID, blockIDs, storageClass)
 	}
 }
+
+// registerUploadedBlockSleepFn is the overridable backoff sleep used by the
+// non-cancellable store->materialize retry path (see upload_reuse.go). Tests
+// swap it to avoid real sleeps.
+var registerUploadedBlockSleepFn = time.Sleep
 
 var registerFSObjectBlockReferencesFSObjectExistsFn = func(h *FSHelper, libraryID, fsID string) (bool, error) {
 	return h.fsObjectExists(libraryID, fsID)
@@ -976,62 +982,68 @@ func (h *FSHelper) ResolveStoredBlockIDs(orgID, libraryID string, blockIDs []str
 // blockID must already be the internal (SHA-256) ID. operationID must identify
 // the specific upload/session/rollback flow that owns the provisional ref so a
 // rollback only removes its own pin. The reference is written BEFORE the
-// metadata read so that a concurrent GC claim-then-verify observes it. If the
-// GC worker has already claimed the block for deletion, the same provisional
-// ref is kept in place while the helper retries the fence. This lets the GC
-// worker observe the ref and abandon the delete without dropping liveness for
-// the current operation. Only if the fence never clears inside the bounded
-// retry budget do we roll back our own provisional ref and re-enqueue any
-// newly-zero-ref block for GC before returning a retryable error.
+// metadata read so that a concurrent GC claim-then-verify observes it.
+//
+// This helper does NOT wait out a GC delete fence. It reads the fence exactly
+// once and, when it is active, returns the retryable ErrBlockDeleteInProgress
+// immediately, leaving the provisional reference in place: the GC worker
+// observes that reference and abandons the delete, and the outer
+// store->materialize wrapper repeats the WHOLE cycle — re-PUTting the object
+// after the fence clears. Absorbing the fence here (the old inner wait) is the
+// F1 data-loss bug: GC could delete the physical object in the window while
+// this helper still reported success, leaving metadata that points at nothing.
+// No rollback is done on the fenced return; the provisional reference's TTL
+// bounds any genuinely abandoned upload.
+//
+// Cassandra I/O in this helper is transient and tagged ErrBlockMaterializationTransient
+// so the wrapper retries it inside its bounded budget instead of failing on the
+// first timeout — EXCEPT the provisional-expiry write: a reference already exists
+// at that point, so on its failure we roll the reference back (release + enqueue)
+// and fail closed rather than leave a reference with no GC-discovery projection
+// (F10). A permanent metadata failure (db.ErrBlockMetadataPermanent) is returned
+// untagged so it is not retried.
 func (h *FSHelper) RegisterUploadedBlock(orgID, libraryID, blockID, operationID string, sizeBytes int, storageClass, storageKey, sha1ID string) error {
 	referrer := db.BlockReferrerForUpload(operationID)
 	expiresAt := time.Now().UTC().Add(time.Duration(db.ProvisionalBlockReferenceTTLSeconds) * time.Second)
 
 	if err := registerUploadedBlockAddReferenceFn(h, orgID, blockID, referrer, libraryID, db.ProvisionalBlockReferenceTTLSeconds); err != nil {
-		return fmt.Errorf("add provisional block reference for %s: %w", blockID, err)
+		// Nothing durable was written yet; a plain transient retry re-adds it.
+		return fmt.Errorf("%w: add provisional block reference for %s: %w", ErrBlockMaterializationTransient, blockID, err)
 	}
 	if err := registerUploadedBlockUpsertProvisionalExpiryFn(h, orgID, blockID, referrer, storageClass, expiresAt); err != nil {
+		// The reference landed but its expiry projection did not: release the
+		// reference so GC does not lose track of the (now unpinned) block, then
+		// fail closed. Not retried, because a wrapper retry would re-add the
+		// reference and could hit the same split write again.
 		zeroRefBlocks := registerUploadedBlockReleaseRefsFn(h, orgID, libraryID, operationID, []string{blockID})
 		registerUploadedBlockEnqueueZeroRefFn(orgID, zeroRefBlocks, storageClass)
 		return fmt.Errorf("record provisional block expiry for %s: %w", blockID, err)
 	}
 
-	attempts := registerUploadedBlockRetryAttemptsFn()
-	if attempts < 1 {
-		attempts = 1
+	deleteFenceActive, err := registerUploadedBlockFenceActiveFn(h, orgID, blockID)
+	if err != nil {
+		return fmt.Errorf("%w: read block delete fence for %s: %w", ErrBlockMaterializationTransient, blockID, err)
+	}
+	if deleteFenceActive {
+		return fmt.Errorf("%w: block %s is currently fenced by GC delete", ErrBlockDeleteInProgress, blockID)
 	}
 
-	for attempt := 1; attempt <= attempts; attempt++ {
-		deleteFenceActive, err := registerUploadedBlockFenceActiveFn(h, orgID, blockID)
-		if err != nil {
-			return fmt.Errorf("read block delete fence for %s: %w", blockID, err)
-		}
-		if !deleteFenceActive {
-			if err := registerUploadedBlockUpsertMetadataFn(h, orgID, libraryID, blockID, sha1ID, sizeBytes, storageClass, storageKey); err != nil {
-				// A contended stub repair is a transient race (concurrent completion or
-				// a reappeared GC orphan fence), not a permanent failure. Surface it as
-				// the retryable GC-fence signal so the materialization wrapper re-probes.
-				if errors.Is(err, db.ErrBlockStubRepairContended) {
-					return fmt.Errorf("%w: block %s stub repair lost a race", ErrBlockDeleteInProgress, blockID)
-				}
-				return fmt.Errorf("upsert block metadata for %s: %w", blockID, err)
-			}
-			return nil
-		}
-		if attempt == attempts {
-			zeroRefBlocks := registerUploadedBlockReleaseRefsFn(h, orgID, libraryID, operationID, []string{blockID})
-			registerUploadedBlockEnqueueZeroRefFn(orgID, zeroRefBlocks, storageClass)
-			return fmt.Errorf("%w: block %s is currently fenced by GC delete", ErrBlockDeleteInProgress, blockID)
-		}
-
-		sleepFor := registerUploadedBlockRetryBackoffFn(attempt)
-		log.Printf("[RegisterUploadedBlock] block %s is fenced by GC delete; retrying (%d/%d) after %s", blockID, attempt, attempts, sleepFor)
-		if sleepFor > 0 {
-			registerUploadedBlockSleepFn(sleepFor)
+	if err := registerUploadedBlockUpsertMetadataFn(h, orgID, libraryID, blockID, sha1ID, sizeBytes, storageClass, storageKey); err != nil {
+		switch {
+		case errors.Is(err, db.ErrBlockStubRepairContended):
+			// A contended stub repair is a transient race (concurrent completion or a
+			// reappeared GC orphan fence): surface the retryable GC-fence signal so the
+			// materialization wrapper re-probes.
+			return fmt.Errorf("%w: block %s stub repair lost a race", ErrBlockDeleteInProgress, blockID)
+		case errors.Is(err, db.ErrBlockMetadataPermanent):
+			// Deterministically irrecoverable (invariant/identity violation): return
+			// as-is so the wrapper does NOT retry it.
+			return fmt.Errorf("upsert block metadata for %s: %w", blockID, err)
+		default:
+			return fmt.Errorf("%w: upsert block metadata for %s: %w", ErrBlockMaterializationTransient, blockID, err)
 		}
 	}
-
-	return fmt.Errorf("%w: exhausted upload block registration retry budget for block %s", ErrBlockDeleteInProgress, blockID)
+	return nil
 }
 
 // RegisterFSObjectBlockReferences creates the permanent reference rows for every

--- a/internal/api/v2/fs_helpers_test.go
+++ b/internal/api/v2/fs_helpers_test.go
@@ -158,85 +158,57 @@ func TestRegisterFSObjectBlockReferences_AddsReferencesForPersistedFSObject(t *t
 	}
 }
 
-func TestRegisterUploadedBlock_RetriesFenceWithoutDroppingProvisionalRef(t *testing.T) {
+// TestRegisterUploadedBlock_PropagatesFenceWithoutWaitingOrDroppingRef is the F1
+// core: on an active GC delete fence the helper returns the retryable signal
+// immediately — it reads the fence once (no loop, no sleep) and leaves the
+// provisional reference in place so GC observes it and the outer wrapper repeats
+// store->materialize (re-PUT). It must NOT upsert metadata over a fenced block.
+func TestRegisterUploadedBlock_PropagatesFenceWithoutWaitingOrDroppingRef(t *testing.T) {
 	helper := &FSHelper{}
 	oldAdd := registerUploadedBlockAddReferenceFn
 	oldFence := registerUploadedBlockFenceActiveFn
 	oldUpsert := registerUploadedBlockUpsertMetadataFn
 	oldUpsertExpiry := registerUploadedBlockUpsertProvisionalExpiryFn
-	oldRelease := registerUploadedBlockReleaseRefsFn
-	oldAttempts := registerUploadedBlockRetryAttemptsFn
-	oldBackoff := registerUploadedBlockRetryBackoffFn
 	oldSleep := registerUploadedBlockSleepFn
 	t.Cleanup(func() {
 		registerUploadedBlockAddReferenceFn = oldAdd
 		registerUploadedBlockFenceActiveFn = oldFence
 		registerUploadedBlockUpsertMetadataFn = oldUpsert
 		registerUploadedBlockUpsertProvisionalExpiryFn = oldUpsertExpiry
-		registerUploadedBlockReleaseRefsFn = oldRelease
-		registerUploadedBlockRetryAttemptsFn = oldAttempts
-		registerUploadedBlockRetryBackoffFn = oldBackoff
 		registerUploadedBlockSleepFn = oldSleep
 	})
 
 	var calls []string
 	registerUploadedBlockAddReferenceFn = func(h *FSHelper, orgID, blockID, referrer, libraryID string, ttlSeconds int) error {
 		calls = append(calls, "add")
-		if orgID != "org-1" || blockID != "block-1" || libraryID != "lib-1" {
-			t.Fatalf("add args = %s/%s/%s, want org-1/block-1/lib-1", orgID, blockID, libraryID)
-		}
-		if referrer != db.BlockReferrerForUpload("op-1") {
-			t.Fatalf("referrer = %q, want upload referrer", referrer)
-		}
-		if ttlSeconds != db.ProvisionalBlockReferenceTTLSeconds {
-			t.Fatalf("ttlSeconds = %d, want %d", ttlSeconds, db.ProvisionalBlockReferenceTTLSeconds)
-		}
+		return nil
+	}
+	registerUploadedBlockUpsertProvisionalExpiryFn = func(h *FSHelper, orgID, blockID, referrer, storageClass string, expiresAt time.Time) error {
+		calls = append(calls, "expiry")
 		return nil
 	}
 	fenceChecks := 0
 	registerUploadedBlockFenceActiveFn = func(h *FSHelper, orgID, blockID string) (bool, error) {
 		fenceChecks++
-		calls = append(calls, fmt.Sprintf("fence-%d", fenceChecks))
-		return fenceChecks == 1, nil
+		calls = append(calls, "fence")
+		return true, nil
 	}
 	registerUploadedBlockUpsertMetadataFn = func(h *FSHelper, orgID, libraryID, blockID, sha1ID string, sizeBytes int, storageClass, storageKey string) error {
-		calls = append(calls, "upsert")
-		if libraryID != "lib-1" {
-			t.Fatalf("libraryID = %q, want lib-1", libraryID)
-		}
-		if sizeBytes != 123 || storageClass != "hot" || storageKey != "key-1" || sha1ID != "sha1-1" {
-			t.Fatalf("upsert args = %d/%s/%s/%s, want 123/hot/key-1/sha1-1", sizeBytes, storageClass, storageKey, sha1ID)
-		}
+		t.Fatal("metadata upsert must not run over an active GC delete fence")
 		return nil
-	}
-	registerUploadedBlockUpsertProvisionalExpiryFn = func(h *FSHelper, orgID, blockID, referrer, storageClass string, expiresAt time.Time) error {
-		calls = append(calls, "expiry")
-		if orgID != "org-1" || blockID != "block-1" || referrer != db.BlockReferrerForUpload("op-1") || storageClass != "hot" {
-			t.Fatalf("expiry args = %s/%s/%s/%s", orgID, blockID, referrer, storageClass)
-		}
-		if expiresAt.IsZero() {
-			t.Fatal("expiresAt should be set")
-		}
-		return nil
-	}
-	registerUploadedBlockReleaseRefsFn = func(h *FSHelper, orgID, libraryID, operationID string, blockIDs []string) []string {
-		t.Fatal("release should not run when the fence clears during retry")
-		return nil
-	}
-	registerUploadedBlockRetryAttemptsFn = func() int { return 2 }
-	registerUploadedBlockRetryBackoffFn = func(attempt int) time.Duration {
-		calls = append(calls, fmt.Sprintf("backoff-%d", attempt))
-		return time.Millisecond
 	}
 	registerUploadedBlockSleepFn = func(delay time.Duration) {
-		calls = append(calls, fmt.Sprintf("sleep-%s", delay))
+		t.Fatalf("helper must not sleep on the fence; the outer wrapper owns backoff (slept %s)", delay)
 	}
 
 	err := helper.RegisterUploadedBlock("org-1", "lib-1", "block-1", "op-1", 123, "hot", "key-1", "sha1-1")
-	if err != nil {
-		t.Fatalf("RegisterUploadedBlock() error = %v, want nil", err)
+	if !errors.Is(err, ErrBlockDeleteInProgress) {
+		t.Fatalf("RegisterUploadedBlock() error = %v, want ErrBlockDeleteInProgress", err)
 	}
-	want := []string{"add", "expiry", "fence-1", "backoff-1", "sleep-1ms", "fence-2", "upsert"}
+	if fenceChecks != 1 {
+		t.Fatalf("fenceChecks = %d, want 1 (single read, no wait loop)", fenceChecks)
+	}
+	want := []string{"add", "expiry", "fence"}
 	if len(calls) != len(want) {
 		t.Fatalf("calls = %#v, want %#v", calls, want)
 	}
@@ -244,6 +216,93 @@ func TestRegisterUploadedBlock_RetriesFenceWithoutDroppingProvisionalRef(t *test
 		if calls[i] != want[i] {
 			t.Fatalf("calls[%d] = %q, want %q (full=%#v)", i, calls[i], want[i], calls)
 		}
+	}
+}
+
+// TestRegisterUploadedBlock_TagsTransientCassandraIO proves the retryable
+// Cassandra I/O failures in the helper carry ErrBlockMaterializationTransient so
+// the wrapper retries them, and none is mislabeled permanent. The
+// provisional-expiry write is deliberately excluded — it fails closed with a
+// rollback (see TestRegisterUploadedBlock_RollsBackWhenExpiryTrackingFails).
+func TestRegisterUploadedBlock_TagsTransientCassandraIO(t *testing.T) {
+	oldAdd := registerUploadedBlockAddReferenceFn
+	oldFence := registerUploadedBlockFenceActiveFn
+	oldUpsert := registerUploadedBlockUpsertMetadataFn
+	oldUpsertExpiry := registerUploadedBlockUpsertProvisionalExpiryFn
+	t.Cleanup(func() {
+		registerUploadedBlockAddReferenceFn = oldAdd
+		registerUploadedBlockFenceActiveFn = oldFence
+		registerUploadedBlockUpsertMetadataFn = oldUpsert
+		registerUploadedBlockUpsertProvisionalExpiryFn = oldUpsertExpiry
+	})
+
+	boom := errors.New("cassandra timeout")
+	// Neutral defaults; each subtest injects a failure at one stage.
+	reset := func() {
+		registerUploadedBlockAddReferenceFn = func(*FSHelper, string, string, string, string, int) error { return nil }
+		registerUploadedBlockUpsertProvisionalExpiryFn = func(*FSHelper, string, string, string, string, time.Time) error { return nil }
+		registerUploadedBlockFenceActiveFn = func(*FSHelper, string, string) (bool, error) { return false, nil }
+		registerUploadedBlockUpsertMetadataFn = func(*FSHelper, string, string, string, string, int, string, string) error { return nil }
+	}
+
+	cases := []struct {
+		name  string
+		setup func()
+	}{
+		{"add reference", func() { registerUploadedBlockAddReferenceFn = func(*FSHelper, string, string, string, string, int) error { return boom } }},
+		{"fence read", func() {
+			registerUploadedBlockFenceActiveFn = func(*FSHelper, string, string) (bool, error) { return false, boom }
+		}},
+		{"metadata upsert I/O", func() {
+			registerUploadedBlockUpsertMetadataFn = func(*FSHelper, string, string, string, string, int, string, string) error { return boom }
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reset()
+			tc.setup()
+			err := (&FSHelper{}).RegisterUploadedBlock("org-1", "lib-1", "block-1", "op-1", 1, "hot", "key", "")
+			if !errors.Is(err, ErrBlockMaterializationTransient) {
+				t.Fatalf("error = %v, want ErrBlockMaterializationTransient", err)
+			}
+			if !errors.Is(err, boom) {
+				t.Fatalf("error = %v, want wrapped %v", err, boom)
+			}
+		})
+	}
+}
+
+// TestRegisterUploadedBlock_ReturnsPermanentMetadataFailureUntagged proves a
+// deterministically irrecoverable metadata failure is returned as-is so the
+// wrapper does NOT retry it.
+func TestRegisterUploadedBlock_ReturnsPermanentMetadataFailureUntagged(t *testing.T) {
+	oldAdd := registerUploadedBlockAddReferenceFn
+	oldFence := registerUploadedBlockFenceActiveFn
+	oldUpsert := registerUploadedBlockUpsertMetadataFn
+	oldUpsertExpiry := registerUploadedBlockUpsertProvisionalExpiryFn
+	t.Cleanup(func() {
+		registerUploadedBlockAddReferenceFn = oldAdd
+		registerUploadedBlockFenceActiveFn = oldFence
+		registerUploadedBlockUpsertMetadataFn = oldUpsert
+		registerUploadedBlockUpsertProvisionalExpiryFn = oldUpsertExpiry
+	})
+
+	registerUploadedBlockAddReferenceFn = func(*FSHelper, string, string, string, string, int) error { return nil }
+	registerUploadedBlockUpsertProvisionalExpiryFn = func(*FSHelper, string, string, string, string, time.Time) error { return nil }
+	registerUploadedBlockFenceActiveFn = func(*FSHelper, string, string) (bool, error) { return false, nil }
+	registerUploadedBlockUpsertMetadataFn = func(*FSHelper, string, string, string, string, int, string, string) error {
+		return fmt.Errorf("upsert: %w", db.ErrBlockMetadataPermanent)
+	}
+
+	err := (&FSHelper{}).RegisterUploadedBlock("org-1", "lib-1", "block-1", "op-1", 1, "hot", "key", "")
+	if !errors.Is(err, db.ErrBlockMetadataPermanent) {
+		t.Fatalf("error = %v, want db.ErrBlockMetadataPermanent", err)
+	}
+	if errors.Is(err, ErrBlockMaterializationTransient) {
+		t.Fatalf("permanent failure must not be tagged transient: %v", err)
+	}
+	if IsRetryableBlockMaterializationError(err) {
+		t.Fatalf("permanent failure must not be retryable: %v", err)
 	}
 }
 
@@ -257,25 +316,16 @@ func TestRegisterUploadedBlock_TranslatesContendedStubRepairToRetryableFence(t *
 	oldFence := registerUploadedBlockFenceActiveFn
 	oldUpsert := registerUploadedBlockUpsertMetadataFn
 	oldUpsertExpiry := registerUploadedBlockUpsertProvisionalExpiryFn
-	oldRelease := registerUploadedBlockReleaseRefsFn
-	oldAttempts := registerUploadedBlockRetryAttemptsFn
 	t.Cleanup(func() {
 		registerUploadedBlockAddReferenceFn = oldAdd
 		registerUploadedBlockFenceActiveFn = oldFence
 		registerUploadedBlockUpsertMetadataFn = oldUpsert
 		registerUploadedBlockUpsertProvisionalExpiryFn = oldUpsertExpiry
-		registerUploadedBlockReleaseRefsFn = oldRelease
-		registerUploadedBlockRetryAttemptsFn = oldAttempts
 	})
 
 	registerUploadedBlockAddReferenceFn = func(*FSHelper, string, string, string, string, int) error { return nil }
 	registerUploadedBlockUpsertProvisionalExpiryFn = func(*FSHelper, string, string, string, string, time.Time) error { return nil }
 	registerUploadedBlockFenceActiveFn = func(*FSHelper, string, string) (bool, error) { return false, nil }
-	registerUploadedBlockRetryAttemptsFn = func() int { return 1 }
-	registerUploadedBlockReleaseRefsFn = func(*FSHelper, string, string, string, []string) []string {
-		t.Fatal("provisional ref must survive a transient contended-stub error for the retry")
-		return nil
-	}
 	registerUploadedBlockUpsertMetadataFn = func(*FSHelper, string, string, string, string, int, string, string) error {
 		return fmt.Errorf("%w: block block-1 changed before stub repair", db.ErrBlockStubRepairContended)
 	}
@@ -334,6 +384,12 @@ func TestRegisterUploadedBlock_RecordsProvisionalExpiryAtTTL(t *testing.T) {
 	}
 }
 
+// TestRegisterUploadedBlock_RollsBackWhenExpiryTrackingFails proves the F10
+// guard: a reference and its expiry projection must land together, so if the
+// projection write fails after the reference was added, the helper releases the
+// reference (and enqueues any now-zero-ref block) instead of leaving an orphan
+// reference that GC Phase 0 cannot discover. It fails closed and does not tag the
+// error transient (a retry would re-add the reference and risk the same split).
 func TestRegisterUploadedBlock_RollsBackWhenExpiryTrackingFails(t *testing.T) {
 	helper := &FSHelper{}
 	oldAdd := registerUploadedBlockAddReferenceFn
@@ -371,6 +427,9 @@ func TestRegisterUploadedBlock_RollsBackWhenExpiryTrackingFails(t *testing.T) {
 	}
 	registerUploadedBlockReleaseRefsFn = func(h *FSHelper, orgID, libraryID, operationID string, blockIDs []string) []string {
 		calls = append(calls, "release")
+		if len(blockIDs) != 1 || blockIDs[0] != "block-1" {
+			t.Fatalf("release blockIDs = %#v, want []string{\"block-1\"}", blockIDs)
+		}
 		return []string{"block-1"}
 	}
 	registerUploadedBlockEnqueueZeroRefFn = func(orgID string, blockIDs []string, storageClass string) {
@@ -381,84 +440,10 @@ func TestRegisterUploadedBlock_RollsBackWhenExpiryTrackingFails(t *testing.T) {
 	if !errors.Is(err, expiryErr) {
 		t.Fatalf("RegisterUploadedBlock() error = %v, want wrapped %v", err, expiryErr)
 	}
+	if errors.Is(err, ErrBlockMaterializationTransient) {
+		t.Fatalf("expiry-write failure must fail closed, not be retried: %v", err)
+	}
 	want := []string{"add", "expiry", "release", "enqueue"}
-	if len(calls) != len(want) {
-		t.Fatalf("calls = %#v, want %#v", calls, want)
-	}
-	for i := range want {
-		if calls[i] != want[i] {
-			t.Fatalf("calls[%d] = %q, want %q (full=%#v)", i, calls[i], want[i], calls)
-		}
-	}
-}
-
-func TestRegisterUploadedBlock_ReenqueuesZeroRefWhenFenceNeverClears(t *testing.T) {
-	helper := &FSHelper{}
-	oldAdd := registerUploadedBlockAddReferenceFn
-	oldFence := registerUploadedBlockFenceActiveFn
-	oldUpsert := registerUploadedBlockUpsertMetadataFn
-	oldRelease := registerUploadedBlockReleaseRefsFn
-	oldAttempts := registerUploadedBlockRetryAttemptsFn
-	oldBackoff := registerUploadedBlockRetryBackoffFn
-	oldSleep := registerUploadedBlockSleepFn
-	oldEnqueue := registerUploadedBlockEnqueueZeroRefFn
-	t.Cleanup(func() {
-		registerUploadedBlockAddReferenceFn = oldAdd
-		registerUploadedBlockFenceActiveFn = oldFence
-		registerUploadedBlockUpsertMetadataFn = oldUpsert
-		registerUploadedBlockReleaseRefsFn = oldRelease
-		registerUploadedBlockRetryAttemptsFn = oldAttempts
-		registerUploadedBlockRetryBackoffFn = oldBackoff
-		registerUploadedBlockSleepFn = oldSleep
-		registerUploadedBlockEnqueueZeroRefFn = oldEnqueue
-	})
-
-	var calls []string
-	registerUploadedBlockAddReferenceFn = func(h *FSHelper, orgID, blockID, referrer, libraryID string, ttlSeconds int) error {
-		calls = append(calls, "add")
-		return nil
-	}
-	registerUploadedBlockFenceActiveFn = func(h *FSHelper, orgID, blockID string) (bool, error) {
-		calls = append(calls, "fence")
-		return true, nil
-	}
-	registerUploadedBlockUpsertMetadataFn = func(h *FSHelper, orgID, libraryID, blockID, sha1ID string, sizeBytes int, storageClass, storageKey string) error {
-		t.Fatal("upsert should not run while the delete fence remains active")
-		return nil
-	}
-	registerUploadedBlockReleaseRefsFn = func(h *FSHelper, orgID, libraryID, operationID string, blockIDs []string) []string {
-		calls = append(calls, "release")
-		if orgID != "org-1" || libraryID != "lib-1" || operationID != "op-1" {
-			t.Fatalf("release args = %s/%s/%s, want org-1/lib-1/op-1", orgID, libraryID, operationID)
-		}
-		if len(blockIDs) != 1 || blockIDs[0] != "block-1" {
-			t.Fatalf("release blockIDs = %#v, want []string{\"block-1\"}", blockIDs)
-		}
-		return []string{"block-1"}
-	}
-	registerUploadedBlockRetryAttemptsFn = func() int { return 2 }
-	registerUploadedBlockRetryBackoffFn = func(attempt int) time.Duration {
-		calls = append(calls, fmt.Sprintf("backoff-%d", attempt))
-		return 0
-	}
-	registerUploadedBlockSleepFn = func(delay time.Duration) {
-		t.Fatalf("sleep should not run when backoff is zero, got %s", delay)
-	}
-	registerUploadedBlockEnqueueZeroRefFn = func(orgID string, blockIDs []string, storageClass string) {
-		calls = append(calls, "enqueue")
-		if orgID != "org-1" || storageClass != "hot" {
-			t.Fatalf("enqueue args = %s/%s, want org-1/hot", orgID, storageClass)
-		}
-		if len(blockIDs) != 1 || blockIDs[0] != "block-1" {
-			t.Fatalf("enqueue blockIDs = %#v, want []string{\"block-1\"}", blockIDs)
-		}
-	}
-
-	err := helper.RegisterUploadedBlock("org-1", "lib-1", "block-1", "op-1", 123, "hot", "", "")
-	if !errors.Is(err, ErrBlockDeleteInProgress) {
-		t.Fatalf("RegisterUploadedBlock() error = %v, want ErrBlockDeleteInProgress", err)
-	}
-	want := []string{"add", "fence", "backoff-1", "fence", "release", "enqueue"}
 	if len(calls) != len(want) {
 		t.Fatalf("calls = %#v, want %#v", calls, want)
 	}

--- a/internal/api/v2/onlyoffice.go
+++ b/internal/api/v2/onlyoffice.go
@@ -1208,7 +1208,7 @@ func (h *OnlyOfficeHandler) saveEditedDocument(ctx context.Context, repoID, file
 	}
 
 	var storageKey string
-	if err := RetryUploadedBlockMaterialization("OnlyOffice", internalBlockID, func() error {
+	if err := RetryUploadedBlockMaterializationContext(ctx, "OnlyOffice", internalBlockID, func() error {
 		probe, probeErr := probeUploadedBlockReuseFn(h.db, orgID, internalBlockID)
 		if probeErr != nil {
 			return fmt.Errorf("probe block reuse for %s: %w", internalBlockID, probeErr)

--- a/internal/api/v2/upload_reuse.go
+++ b/internal/api/v2/upload_reuse.go
@@ -6,9 +6,39 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/Sesame-Disk/sesamefs/internal/db"
+	"github.com/Sesame-Disk/sesamefs/internal/metrics"
 	"github.com/Sesame-Disk/sesamefs/internal/storage"
+)
+
+// ErrBlockMaterializationTransient marks a retryable transient failure surfaced
+// from the store or materialize phase — a Cassandra/S3 I/O error, a lost CAS
+// race, or a still-converging stub/fence row. The store->materialize wrapper
+// retries it inside its bounded budget instead of failing the upload on the
+// first timeout. Permanent metadata failures (db.ErrBlockMetadataPermanent) are
+// deliberately NOT wrapped with it, so they are not retried.
+var ErrBlockMaterializationTransient = errors.New("block materialization transient failure")
+
+// IsRetryableBlockMaterializationError reports whether the store->materialize
+// wrapper should retry err: a GC delete fence (ErrBlockDeleteInProgress) or a
+// tagged transient I/O failure (ErrBlockMaterializationTransient). Anything else —
+// including a permanent metadata failure and any untagged raw error — is returned
+// to the caller as-is. Note the store callbacks tag only their fence result; their
+// raw probe/HEAD/PUT errors are NOT transient-tagged, so a store-phase transient
+// retry (reason "probe") only occurs if a callback explicitly opts into it.
+func IsRetryableBlockMaterializationError(err error) bool {
+	return errors.Is(err, ErrBlockDeleteInProgress) || errors.Is(err, ErrBlockMaterializationTransient)
+}
+
+// Retry reasons for BlockUploadMaterializationRetriesTotal. The reason is chosen
+// by the PHASE that failed (which callback returned it), never the sentinel, so a
+// materialize-phase metadata write is never labeled "probe" (finding F14).
+const (
+	blockMaterializationReasonFence    = "gc_fence"
+	blockMaterializationReasonProbe    = "probe"          // store phase (probe/HEAD/PUT)
+	blockMaterializationReasonMaterial = "materialization" // metadata materialize phase
 )
 
 var probeUploadedBlockReuseFn = ProbeUploadedBlockReuse
@@ -115,10 +145,24 @@ func EnsureReusableBlockPresent(ctx context.Context, blockID string, probe db.Bl
 }
 
 // RetryUploadedBlockMaterialization retries the full store->materialize cycle
-// when GC temporarily fences the block. The retryable sentinel can now surface
-// from either phase because Cassandra-first probes may reject a PUT before S3
-// work starts.
+// when GC temporarily fences the block or a transient I/O failure interrupts
+// either phase. The retryable sentinel can surface from either phase because
+// Cassandra-first probes may reject a PUT before S3 work starts, and the
+// materialize helper now propagates the fence instead of absorbing it (F1), so
+// a fence during materialize repeats the store phase and re-PUTs the object.
 func RetryUploadedBlockMaterialization(label, blockID string, store func() error, materialize func() error, onRetry func(), resolveFence func() (bool, error)) error {
+	return retryUploadedBlockMaterialization(nil, label, blockID, store, materialize, onRetry, resolveFence)
+}
+
+// RetryUploadedBlockMaterializationContext is the request-cancellable variant
+// used by production handlers. The context aborts only the retry backoff wait;
+// the store and materialize callbacks remain responsible for propagating it to
+// their own I/O.
+func RetryUploadedBlockMaterializationContext(ctx context.Context, label, blockID string, store func() error, materialize func() error, onRetry func(), resolveFence func() (bool, error)) error {
+	return retryUploadedBlockMaterialization(ctx, label, blockID, store, materialize, onRetry, resolveFence)
+}
+
+func retryUploadedBlockMaterialization(ctx context.Context, label, blockID string, store func() error, materialize func() error, onRetry func(), resolveFence func() (bool, error)) error {
 	attempts := RetryAttempts()
 	if attempts < 1 {
 		attempts = 1
@@ -129,11 +173,20 @@ func RetryUploadedBlockMaterialization(label, blockID string, store func() error
 		blockSuffix = fmt.Sprintf(" for block %s", blockID)
 	}
 
-	retryBlocked := func(attempt int) error {
+	// retryBlocked records the retry under a reason derived from the failing
+	// PHASE (phaseReason), overridden to gc_fence only when the block is fenced.
+	// It returns a non-nil error only when the backoff wait must abort the whole
+	// operation (context cancelled).
+	retryBlocked := func(attempt int, phaseReason string, retryErr error) error {
 		if onRetry != nil {
 			onRetry()
 		}
-		if resolveFence != nil {
+		reason := phaseReason
+		if errors.Is(retryErr, ErrBlockDeleteInProgress) {
+			reason = blockMaterializationReasonFence
+		}
+		metrics.BlockUploadMaterializationRetriesTotal.WithLabelValues(label, reason).Inc()
+		if reason == blockMaterializationReasonFence && resolveFence != nil {
 			resolved, resolveErr := resolveFence()
 			if resolveErr != nil {
 				log.Printf("[%s] failed to inspect S3 orphan fence%s: %v", label, blockSuffix, resolveErr)
@@ -142,29 +195,26 @@ func RetryUploadedBlockMaterialization(label, blockID string, store func() error
 			}
 		}
 		sleepFor := RetryBackoff(attempt)
-		log.Printf("[%s] block materialization fenced by GC%s; retrying (%d/%d) after %s", label, blockSuffix, attempt, attempts, sleepFor)
-		if sleepFor > 0 {
-			registerUploadedBlockSleepFn(sleepFor)
-		}
-		return nil
+		log.Printf("[%s] block materialization retry%s reason=%s (%d/%d) after %s", label, blockSuffix, reason, attempt, attempts, sleepFor)
+		return waitBeforeBlockMaterializationRetry(ctx, sleepFor)
 	}
 
 	for attempt := 1; attempt <= attempts; attempt++ {
 		if err := store(); err != nil {
-			if !errors.Is(err, ErrBlockDeleteInProgress) || attempt == attempts {
+			if !IsRetryableBlockMaterializationError(err) || attempt == attempts {
 				return err
 			}
-			if retryErr := retryBlocked(attempt); retryErr != nil {
-				return retryErr
+			if abortErr := retryBlocked(attempt, blockMaterializationReasonProbe, err); abortErr != nil {
+				return abortErr
 			}
 			continue
 		}
 		if err := materialize(); err != nil {
-			if !errors.Is(err, ErrBlockDeleteInProgress) || attempt == attempts {
+			if !IsRetryableBlockMaterializationError(err) || attempt == attempts {
 				return err
 			}
-			if retryErr := retryBlocked(attempt); retryErr != nil {
-				return retryErr
+			if abortErr := retryBlocked(attempt, blockMaterializationReasonMaterial, err); abortErr != nil {
+				return abortErr
 			}
 			continue
 		}
@@ -172,4 +222,31 @@ func RetryUploadedBlockMaterialization(label, blockID string, store func() error
 	}
 
 	return fmt.Errorf("%w%s", ErrBlockDeleteInProgress, blockSuffix)
+}
+
+// waitBeforeBlockMaterializationRetry sleeps sleepFor before the next attempt.
+// With a non-nil context the wait is cancellable (an aborted request stops
+// retrying instead of burning the full budget); without one it uses the
+// overridable sleep hook so tests stay fast.
+func waitBeforeBlockMaterializationRetry(ctx context.Context, sleepFor time.Duration) error {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+	if sleepFor <= 0 {
+		return nil
+	}
+	if ctx == nil {
+		registerUploadedBlockSleepFn(sleepFor)
+		return nil
+	}
+	timer := time.NewTimer(sleepFor)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }

--- a/internal/api/v2/upload_reuse_test.go
+++ b/internal/api/v2/upload_reuse_test.go
@@ -3,12 +3,41 @@ package v2
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/Sesame-Disk/sesamefs/internal/db"
+	"github.com/Sesame-Disk/sesamefs/internal/metrics"
 	"github.com/Sesame-Disk/sesamefs/internal/storage"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
+
+// fastBlockMaterializationRetries shrinks the shared retry backoff to keep tests
+// fast and returns the recorded sleeps captured through the overridable hook.
+func fastBlockMaterializationRetries(t *testing.T) *[]time.Duration {
+	t.Helper()
+	oldDelay := libraryHeadMutationRetryDelay
+	oldMaxDelay := libraryHeadMutationRetryMaxDelay
+	oldJitter := libraryHeadMutationRetryJitter
+	oldSleep := registerUploadedBlockSleepFn
+	t.Cleanup(func() {
+		libraryHeadMutationRetryDelay = oldDelay
+		libraryHeadMutationRetryMaxDelay = oldMaxDelay
+		libraryHeadMutationRetryJitter = oldJitter
+		registerUploadedBlockSleepFn = oldSleep
+	})
+	libraryHeadMutationRetryDelay = time.Millisecond
+	libraryHeadMutationRetryMaxDelay = time.Millisecond
+	libraryHeadMutationRetryJitter = 0
+	slept := &[]time.Duration{}
+	registerUploadedBlockSleepFn = func(delay time.Duration) { *slept = append(*slept, delay) }
+	return slept
+}
+
+func retryReasonCount(surface, reason string) float64 {
+	return testutil.ToFloat64(metrics.BlockUploadMaterializationRetriesTotal.WithLabelValues(surface, reason))
+}
 
 func TestRetryUploadedBlockMaterializationRetriesStoreFence(t *testing.T) {
 	oldDelay := libraryHeadMutationRetryDelay
@@ -205,6 +234,188 @@ func TestRetryUploadedBlockMaterializationReturnsNonRetryableStoreError(t *testi
 	}, nil, nil)
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("RetryUploadedBlockMaterialization() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestRetryUploadedBlockMaterializationRetriesTransientMaterialize(t *testing.T) {
+	fastBlockMaterializationRetries(t)
+
+	storeCalls := 0
+	materializeCalls := 0
+	err := RetryUploadedBlockMaterialization("UploadFile", "block-1", func() error {
+		storeCalls++
+		return nil
+	}, func() error {
+		materializeCalls++
+		if materializeCalls == 1 {
+			return fmt.Errorf("cassandra timeout: %w", ErrBlockMaterializationTransient)
+		}
+		return nil
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("error = %v, want nil", err)
+	}
+	// A transient materialize failure re-runs the WHOLE cycle, so store re-PUTs
+	// before the second materialize.
+	if storeCalls != 2 || materializeCalls != 2 {
+		t.Fatalf("store/materialize calls = %d/%d, want 2/2", storeCalls, materializeCalls)
+	}
+}
+
+// TestRetryUploadedBlockMaterializationRePutsAfterMaterializeFence is the F1
+// regression for the generic wrapper: when the materialize phase
+// (RegisterUploadedBlock) reports a GC delete fence — the exact case where GC may
+// have physically deleted the object — the wrapper repeats the WHOLE cycle so the
+// store phase re-PUTs the object before the second materialize succeeds. Three of
+// the six funnels use this generic wrapper (UploadFile, PutBlock, OnlyOffice); the
+// SeafHTTP and template-CreateFile wrappers are separate copies with the same
+// re-PUT-on-fence shape, exercised by their own tests
+// (TestRetrySeafHTTP... and TestRetryCreateFileTemplate...). This F1 coverage is at
+// the wrapper level; the deterministic fast-clear window (a full GC cycle between
+// the single fence read and publish) is closed with PR-5's real-worker regression.
+func TestRetryUploadedBlockMaterializationRePutsAfterMaterializeFence(t *testing.T) {
+	fastBlockMaterializationRetries(t)
+
+	puts := 0
+	materializeCalls := 0
+	// store models a NeedsPut branch: each invocation is a physical re-PUT.
+	store := func() error {
+		puts++
+		return nil
+	}
+	materialize := func() error {
+		materializeCalls++
+		if materializeCalls == 1 {
+			// GC fenced the block during materialize; the object may be gone.
+			return ErrBlockDeleteInProgress
+		}
+		return nil
+	}
+	if err := RetryUploadedBlockMaterialization("UploadFile", "block-1", store, materialize, nil, nil); err != nil {
+		t.Fatalf("error = %v, want nil", err)
+	}
+	if puts != 2 {
+		t.Fatalf("store(re-PUT) calls = %d, want 2 (object re-PUT after the fence cleared)", puts)
+	}
+	if materializeCalls != 2 {
+		t.Fatalf("materialize calls = %d, want 2", materializeCalls)
+	}
+}
+
+func TestRetryUploadedBlockMaterializationDoesNotRetryPermanentFailure(t *testing.T) {
+	fastBlockMaterializationRetries(t)
+
+	storeCalls := 0
+	materializeCalls := 0
+	err := RetryUploadedBlockMaterialization("UploadFile", "block-1", func() error {
+		storeCalls++
+		return nil
+	}, func() error {
+		materializeCalls++
+		return fmt.Errorf("upsert block metadata: %w", db.ErrBlockMetadataPermanent)
+	}, nil, nil)
+	if !errors.Is(err, db.ErrBlockMetadataPermanent) {
+		t.Fatalf("error = %v, want db.ErrBlockMetadataPermanent", err)
+	}
+	if storeCalls != 1 || materializeCalls != 1 {
+		t.Fatalf("store/materialize calls = %d/%d, want 1/1 (no retry)", storeCalls, materializeCalls)
+	}
+}
+
+// TestRetryUploadedBlockMaterializationLabelsReasonByPhase is the direct F14
+// regression: a write failure in the materialize phase is labeled
+// "materialization", never "probe"; a store-phase transient is "probe"; and a
+// fence in either phase is "gc_fence".
+func TestRetryUploadedBlockMaterializationLabelsReasonByPhase(t *testing.T) {
+	fastBlockMaterializationRetries(t)
+
+	t.Run("store-phase transient is probe", func(t *testing.T) {
+		const surface = "TestReasonProbe"
+		before := retryReasonCount(surface, blockMaterializationReasonProbe)
+		calls := 0
+		err := RetryUploadedBlockMaterialization(surface, "block-1", func() error {
+			calls++
+			if calls == 1 {
+				return fmt.Errorf("probe read: %w", ErrBlockMaterializationTransient)
+			}
+			return nil
+		}, func() error { return nil }, nil, nil)
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		if got := retryReasonCount(surface, blockMaterializationReasonProbe) - before; got != 1 {
+			t.Fatalf("probe retries = %v, want 1", got)
+		}
+		if got := retryReasonCount(surface, blockMaterializationReasonMaterial); got != 0 {
+			t.Fatalf("materialization retries = %v, want 0 (write not mislabeled as read)", got)
+		}
+	})
+
+	t.Run("materialize-phase transient is materialization", func(t *testing.T) {
+		const surface = "TestReasonMaterialize"
+		beforeMat := retryReasonCount(surface, blockMaterializationReasonMaterial)
+		beforeProbe := retryReasonCount(surface, blockMaterializationReasonProbe)
+		calls := 0
+		err := RetryUploadedBlockMaterialization(surface, "block-1", func() error { return nil }, func() error {
+			calls++
+			if calls == 1 {
+				return fmt.Errorf("metadata write: %w", ErrBlockMaterializationTransient)
+			}
+			return nil
+		}, nil, nil)
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		if got := retryReasonCount(surface, blockMaterializationReasonMaterial) - beforeMat; got != 1 {
+			t.Fatalf("materialization retries = %v, want 1", got)
+		}
+		if got := retryReasonCount(surface, blockMaterializationReasonProbe) - beforeProbe; got != 0 {
+			t.Fatalf("probe retries = %v, want 0 (write must not be labeled as read)", got)
+		}
+	})
+
+	t.Run("fence in materialize phase is gc_fence", func(t *testing.T) {
+		const surface = "TestReasonFence"
+		before := retryReasonCount(surface, blockMaterializationReasonFence)
+		calls := 0
+		err := RetryUploadedBlockMaterialization(surface, "block-1", func() error { return nil }, func() error {
+			calls++
+			if calls == 1 {
+				return ErrBlockDeleteInProgress
+			}
+			return nil
+		}, nil, nil)
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		if got := retryReasonCount(surface, blockMaterializationReasonFence) - before; got != 1 {
+			t.Fatalf("gc_fence retries = %v, want 1", got)
+		}
+		if got := retryReasonCount(surface, blockMaterializationReasonMaterial); got != 0 {
+			t.Fatalf("materialization retries = %v, want 0 (fence is not a plain transient)", got)
+		}
+	})
+}
+
+func TestRetryUploadedBlockMaterializationContextAbortsBackoff(t *testing.T) {
+	fastBlockMaterializationRetries(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled: the first backoff wait must abort immediately.
+
+	storeCalls := 0
+	err := RetryUploadedBlockMaterializationContext(ctx, "UploadFile", "block-1", func() error {
+		storeCalls++
+		return ErrBlockMaterializationTransient
+	}, func() error {
+		t.Fatal("materialize must not run when store keeps failing")
+		return nil
+	}, nil, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if storeCalls != 1 {
+		t.Fatalf("storeCalls = %d, want 1 (budget not exhausted after cancel)", storeCalls)
 	}
 }
 

--- a/internal/api/v2/upload_rollback.go
+++ b/internal/api/v2/upload_rollback.go
@@ -70,6 +70,12 @@ func RollbackUploadedBlockRefs(database *db.DB, orgID, repoID, operationID strin
 // writing the optional external SHA-1 mapping. If the mapping write fails, the
 // provisional reference is rolled back so retries can restart from a clean
 // state instead of leaving a registered block without a usable mapping.
+//
+// A transient mapping-write failure (Cassandra I/O) is tagged
+// ErrBlockMaterializationTransient — with the cause preserved via %w — so the
+// store->materialize wrapper retries the whole cycle (re-register + re-map are
+// idempotent) instead of failing the upload on the first timeout (F6). A
+// permanent id-mapping conflict is not tagged and not retried.
 func RegisterUploadedBlockAndMapping(database *db.DB, orgID, repoID, internalBlockID, operationID string, sizeBytes int, storageClass, storageKey, externalBlockID string) error {
 	if err := registerUploadedBlockForMaterializationFn(database, orgID, repoID, internalBlockID, operationID, sizeBytes, storageClass, storageKey, externalBlockID); err != nil {
 		return err
@@ -79,7 +85,10 @@ func RegisterUploadedBlockAndMapping(database *db.DB, orgID, repoID, internalBlo
 	}
 	if err := writeBlockMappingForMaterializationFn(database, orgID, repoID, externalBlockID, internalBlockID); err != nil {
 		rollbackUploadedBlockRefsFn(database, orgID, repoID, operationID, []string{internalBlockID})
-		return fmt.Errorf("%w: %v", ErrBlockMappingWriteFailed, err)
+		if errors.Is(err, db.ErrBlockIDMappingConflict) {
+			return fmt.Errorf("%w: %w", ErrBlockMappingWriteFailed, err)
+		}
+		return fmt.Errorf("%w: %w: %w", ErrBlockMaterializationTransient, ErrBlockMappingWriteFailed, err)
 	}
 	return nil
 }
@@ -107,7 +116,7 @@ func RegisterWebUploadedBlockAndMapping(database *db.DB, orgID, repoID, internal
 		if errors.Is(err, db.ErrBlockIDMappingConflict) {
 			return err
 		}
-		return fmt.Errorf("%w: %v", ErrBlockMappingWriteFailed, err)
+		return fmt.Errorf("%w: %w: %w", ErrBlockMaterializationTransient, ErrBlockMappingWriteFailed, err)
 	}
 	return nil
 }

--- a/internal/api/v2/upload_rollback_test.go
+++ b/internal/api/v2/upload_rollback_test.go
@@ -92,6 +92,67 @@ func TestRegisterUploadedBlockAndMapping_RollsBackOnMappingFailure(t *testing.T)
 	}
 }
 
+// TestRegisterUploadedBlockAndMapping_TransientMappingFailureIsRetryable is the
+// F6 mapping regression: a transient mapping-write failure is tagged
+// ErrBlockMaterializationTransient (so the wrapper retries) and preserves the
+// underlying cause via %w, while still carrying ErrBlockMappingWriteFailed.
+func TestRegisterUploadedBlockAndMapping_TransientMappingFailureIsRetryable(t *testing.T) {
+	oldRegister := registerUploadedBlockForMaterializationFn
+	oldWriteMapping := writeBlockMappingForMaterializationFn
+	oldRollback := rollbackUploadedBlockRefsFn
+	defer func() {
+		registerUploadedBlockForMaterializationFn = oldRegister
+		writeBlockMappingForMaterializationFn = oldWriteMapping
+		rollbackUploadedBlockRefsFn = oldRollback
+	}()
+
+	registerUploadedBlockForMaterializationFn = func(*db.DB, string, string, string, string, int, string, string, string) error {
+		return nil
+	}
+	wantCause := errors.New("cassandra timeout")
+	writeBlockMappingForMaterializationFn = func(*db.DB, string, string, string, string) error { return wantCause }
+	rollbackUploadedBlockRefsFn = func(*db.DB, string, string, string, []string) {}
+
+	err := RegisterUploadedBlockAndMapping(nil, "org-1", "repo-1", "int-1", "op-1", 123, "hot", "", "ext-1")
+	if !IsRetryableBlockMaterializationError(err) {
+		t.Fatalf("error = %v, want retryable (ErrBlockMaterializationTransient)", err)
+	}
+	if !errors.Is(err, ErrBlockMappingWriteFailed) {
+		t.Fatalf("error = %v, want ErrBlockMappingWriteFailed preserved", err)
+	}
+	if !errors.Is(err, wantCause) {
+		t.Fatalf("error = %v, want underlying cause preserved via %%w", err)
+	}
+}
+
+// A permanent id-mapping conflict must NOT become retryable.
+func TestRegisterWebUploadedBlockAndMapping_ConflictIsNotRetryable(t *testing.T) {
+	oldRegister := registerUploadedBlockForMaterializationFn
+	oldWriteMapping := writeVerifiedWebBlockMappingFn
+	oldRollback := rollbackUploadedBlockRefsFn
+	defer func() {
+		registerUploadedBlockForMaterializationFn = oldRegister
+		writeVerifiedWebBlockMappingFn = oldWriteMapping
+		rollbackUploadedBlockRefsFn = oldRollback
+	}()
+
+	registerUploadedBlockForMaterializationFn = func(*db.DB, string, string, string, string, int, string, string, string) error {
+		return nil
+	}
+	writeVerifiedWebBlockMappingFn = func(*db.DB, string, string, string, string) error {
+		return db.ErrBlockIDMappingConflict
+	}
+	rollbackUploadedBlockRefsFn = func(*db.DB, string, string, string, []string) {}
+
+	err := RegisterWebUploadedBlockAndMapping(nil, "org-1", "repo-1", "int-1", "op-1", 123, "hot", "", "ext-1")
+	if !errors.Is(err, db.ErrBlockIDMappingConflict) {
+		t.Fatalf("error = %v, want db.ErrBlockIDMappingConflict", err)
+	}
+	if IsRetryableBlockMaterializationError(err) {
+		t.Fatalf("a permanent mapping conflict must not be retryable: %v", err)
+	}
+}
+
 func TestRegisterUploadedBlockAndMapping_SkipsMappingWithoutExternalID(t *testing.T) {
 	oldRegister := registerUploadedBlockForMaterializationFn
 	oldWriteMapping := writeBlockMappingForMaterializationFn

--- a/internal/db/block_references.go
+++ b/internal/db/block_references.go
@@ -57,6 +57,17 @@ var ErrBlockIDMappingConflict = errors.New("block id mapping conflict")
 // hard error. Upload funnels translate it into their retryable GC-fence signal.
 var ErrBlockStubRepairContended = errors.New("block stub repair contended")
 
+// ErrBlockMetadataPermanent marks a metadata-write failure that is
+// deterministically irrecoverable — an invalid argument (missing storage class,
+// malformed sha1/representation id), a conflicting first-writer identity, or a
+// corrupt row. Retrying only burns the caller's bounded budget, so the upload
+// materialization wrapper must NOT retry it. Everything left unmarked (raw
+// Cassandra driver I/O, lost CAS races, transient stub/fence states) is treated
+// as transient and retried. Keeping the permanent set small is the safe bias: a
+// transient mislabeled permanent fails a recoverable upload, while a permanent
+// mislabeled transient only wastes a bounded budget before failing.
+var ErrBlockMetadataPermanent = errors.New("block metadata write is permanently failed")
+
 type BlockReuseDecision int
 
 const (
@@ -539,15 +550,15 @@ func (db *DB) UpsertBlockMetadataWithSHA1(orgID, blockID, sha1 string, sizeBytes
 
 func (db *DB) UpsertBlockMetadataWithRepresentationAndSHA1(orgID, representationID, blockID, sha1 string, sizeBytes int, storageClass, storageKey string) error {
 	if err := ValidateBlockRepresentationID(representationID); err != nil {
-		return err
+		return fmt.Errorf("%w: %w", ErrBlockMetadataPermanent, err)
 	}
 	storageClass = strings.TrimSpace(storageClass)
 	if storageClass == "" {
-		return fmt.Errorf("missing canonical storage class for block %s", blockID)
+		return fmt.Errorf("%w: missing canonical storage class for block %s", ErrBlockMetadataPermanent, blockID)
 	}
 	sha1 = NormalizeBlockID(sha1)
 	if sha1 != "" && !isHexN(sha1, 40) {
-		return fmt.Errorf("invalid block sha1 for %s", blockID)
+		return fmt.Errorf("%w: invalid block sha1 for %s", ErrBlockMetadataPermanent, blockID)
 	}
 	now := time.Now().UTC()
 	insert := func() (bool, error) {
@@ -608,19 +619,25 @@ func (db *DB) ensureBlockIdentity(orgID, blockID, representationID, sha1 string)
 func (db *DB) ensureBlockIdentityRow(orgID, blockID, representationID, sha1 string, row blockIdentityRepairRow) error {
 	activeClaim, repairClaim, ownershipErr := classifyBlockClaimOwnership(row.GCState, row.GCClaimID, row.GCClaimedAt)
 	if ownershipErr != nil {
-		return fmt.Errorf("block %s has malformed GC ownership: %w", blockID, ownershipErr)
+		// A malformed lifecycle/ownership combination is row corruption, not a
+		// transient mid-write state (LWTs mutate the row atomically). Fail closed
+		// rather than retry into the same corrupt row or mask it.
+		return fmt.Errorf("%w: block %s has malformed GC ownership: %w", ErrBlockMetadataPermanent, blockID, ownershipErr)
 	}
 	if activeClaim || repairClaim || row.CreatedAt == nil || !row.StorageClassPresent || strings.TrimSpace(row.StorageClass) == "" {
+		// Deliberately transient (unmarked): an active/repair claim or a still-stub
+		// row can converge on a re-probe (GC abandons, or a concurrent uploader
+		// completes it), so the caller retries instead of failing the upload.
 		return fmt.Errorf("block %s has incomplete canonical metadata", blockID)
 	}
 
 	currentRepresentationID := strings.TrimSpace(row.RepresentationID)
 	currentSHA1 := strings.TrimSpace(row.Sha1)
 	if currentRepresentationID != "" && currentRepresentationID != representationID {
-		return fmt.Errorf("block %s already has conflicting representation id %s", blockID, currentRepresentationID)
+		return fmt.Errorf("%w: block %s already has conflicting representation id %s", ErrBlockMetadataPermanent, blockID, currentRepresentationID)
 	}
 	if sha1 != "" && currentSHA1 != "" && currentSHA1 != sha1 {
-		return fmt.Errorf("block %s already has conflicting sha1 %s", blockID, currentSHA1)
+		return fmt.Errorf("%w: block %s already has conflicting sha1 %s", ErrBlockMetadataPermanent, blockID, currentSHA1)
 	}
 	if currentRepresentationID == "" {
 		applied, err := backfillBlockRepresentationIDFn(db, orgID, blockID, representationID, currentRepresentationID)

--- a/internal/db/block_references_test.go
+++ b/internal/db/block_references_test.go
@@ -680,6 +680,106 @@ func TestEnsureBlockIdentity_DoesNotBackfillRepresentationWhenSHA1Conflicts(t *t
 	}
 }
 
+func TestUpsertBlockMetadataClassifiesPermanentFailures(t *testing.T) {
+	// Entry-level invariant violations never reach the driver: they are
+	// deterministically irrecoverable and must carry ErrBlockMetadataPermanent so
+	// the upload materialization wrapper refuses to retry them.
+	t.Run("empty storage class is permanent", func(t *testing.T) {
+		err := (&DB{}).UpsertBlockMetadata("org-1", "block-1", 1, "   ", "key")
+		if !errors.Is(err, ErrBlockMetadataPermanent) {
+			t.Fatalf("error = %v, want ErrBlockMetadataPermanent", err)
+		}
+	})
+	t.Run("invalid sha1 is permanent", func(t *testing.T) {
+		err := (&DB{}).UpsertBlockMetadataWithSHA1("org-1", "block-1", "not-a-sha1", 1, "hot", "key")
+		if !errors.Is(err, ErrBlockMetadataPermanent) {
+			t.Fatalf("error = %v, want ErrBlockMetadataPermanent", err)
+		}
+	})
+
+	oldRead := readBlockIdentityForRepairFn
+	t.Cleanup(func() { readBlockIdentityForRepairFn = oldRead })
+
+	t.Run("conflicting representation id is permanent", func(t *testing.T) {
+		readBlockIdentityForRepairFn = func(*DB, string, string) (blockIdentityRepairRow, bool, error) {
+			return completeIdentityRepairRow(EncryptedLibraryBlockRepresentationID("library-1"), strings.Repeat("a", 40)), true, nil
+		}
+		err := (&DB{}).ensureBlockIdentity("org-1", "block-1", PlainBlockRepresentationID, strings.Repeat("a", 40))
+		if !errors.Is(err, ErrBlockMetadataPermanent) {
+			t.Fatalf("error = %v, want ErrBlockMetadataPermanent", err)
+		}
+	})
+	t.Run("conflicting sha1 is permanent", func(t *testing.T) {
+		readBlockIdentityForRepairFn = func(*DB, string, string) (blockIdentityRepairRow, bool, error) {
+			return completeIdentityRepairRow("", strings.Repeat("d", 40)), true, nil
+		}
+		err := (&DB{}).ensureBlockIdentity("org-1", "block-1", PlainBlockRepresentationID, strings.Repeat("e", 40))
+		if !errors.Is(err, ErrBlockMetadataPermanent) {
+			t.Fatalf("error = %v, want ErrBlockMetadataPermanent", err)
+		}
+	})
+	t.Run("malformed GC ownership is permanent", func(t *testing.T) {
+		createdAt := time.Now().UTC()
+		readBlockIdentityForRepairFn = func(*DB, string, string) (blockIdentityRepairRow, bool, error) {
+			// Claim identity present without a lifecycle state == row corruption.
+			return blockIdentityRepairRow{
+				RepresentationID:    PlainBlockRepresentationID,
+				StorageClass:        "hot",
+				StorageClassPresent: true,
+				CreatedAt:           &createdAt,
+				GCClaimID:           "claim-1",
+			}, true, nil
+		}
+		err := (&DB{}).ensureBlockIdentity("org-1", "block-1", PlainBlockRepresentationID, "")
+		if !errors.Is(err, ErrBlockMetadataPermanent) {
+			t.Fatalf("error = %v, want ErrBlockMetadataPermanent", err)
+		}
+	})
+}
+
+func TestUpsertBlockMetadataLeavesTransientFailuresUnmarked(t *testing.T) {
+	oldInsert := upsertBlockMetadataInsertFn
+	oldRead := readBlockIdentityForRepairFn
+	t.Cleanup(func() {
+		upsertBlockMetadataInsertFn = oldInsert
+		readBlockIdentityForRepairFn = oldRead
+	})
+
+	t.Run("raw driver insert error is transient", func(t *testing.T) {
+		wantErr := errors.New("cassandra timeout")
+		upsertBlockMetadataInsertFn = func(*DB, string, string, string, int, string, string, time.Time) (bool, error) {
+			return false, wantErr
+		}
+		err := (&DB{}).UpsertBlockMetadata("org-1", "block-1", 1, "hot", "key")
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("error = %v, want wrapped %v", err, wantErr)
+		}
+		if errors.Is(err, ErrBlockMetadataPermanent) {
+			t.Fatalf("driver I/O error must not be classified permanent: %v", err)
+		}
+	})
+
+	t.Run("incomplete metadata from an active claim is transient", func(t *testing.T) {
+		claimedAt := time.Now().UTC()
+		readBlockIdentityForRepairFn = func(*DB, string, string) (blockIdentityRepairRow, bool, error) {
+			// An active GC delete claim (deleting) can converge on a re-probe, so
+			// the caller must retry rather than fail closed.
+			return blockIdentityRepairRow{
+				GCState:     BlockGCStateDeleting,
+				GCClaimID:   "claim-1",
+				GCClaimedAt: &claimedAt,
+			}, true, nil
+		}
+		err := (&DB{}).ensureBlockIdentity("org-1", "block-1", PlainBlockRepresentationID, "")
+		if err == nil {
+			t.Fatal("ensureBlockIdentity() error = nil, want incomplete metadata error")
+		}
+		if errors.Is(err, ErrBlockMetadataPermanent) {
+			t.Fatalf("incomplete-metadata (active claim) must not be permanent: %v", err)
+		}
+	})
+}
+
 func TestPromotePublishAttemptReferences_RetriesRegisterFailure(t *testing.T) {
 	oldAttempts := publishAttemptPromotionRetryAttempts
 	oldDelay := publishAttemptPromotionRetryDelay

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -459,6 +459,28 @@ var (
 		},
 		[]string{"reason"},
 	)
+
+	// BlockUploadMaterializationRetriesTotal counts bounded store->materialize
+	// retries taken by the upload funnels, by surface and reason. The reason is
+	// derived from the retry PHASE (which callback failed), never the sentinel:
+	//   "gc_fence"       — the block is fenced by a GC delete claim, in either phase.
+	//   "probe"          — a retryable failure in the STORE phase (probe/HEAD/repair/PUT).
+	//                      The shipped store callbacks return only a fence (counted as
+	//                      gc_fence) or non-retryable raw errors, so in practice this
+	//                      label is reached only if a store callback opts into the
+	//                      transient sentinel; it is NOT a claim that every store error
+	//                      is retried.
+	//   "materialization"— a retryable failure in the metadata materialize phase
+	//                      (RegisterUploadedBlock / mapping write).
+	// The invariant that matters for F14: a materialize-phase failure is ALWAYS
+	// "materialization", never "probe" — a metadata write is never counted as a probe.
+	BlockUploadMaterializationRetriesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "block_upload_materialization_retries_total",
+			Help: "Total bounded block upload store->materialize retries by surface and reason.",
+		},
+		[]string{"surface", "reason"},
+	)
 )
 
 // Register registers all custom metrics with the default Prometheus registry.
@@ -509,5 +531,6 @@ func Register() {
 		BlockUploadStagedBlocksTotal,
 		BlockUploadConcurrencyRejectionsTotal,
 		BlockUploadSessionAdmissionRejectionsTotal,
+		BlockUploadMaterializationRetriesTotal,
 	)
 }


### PR DESCRIPTION
## Summary
- propagate observed GC fences to the outer store/materialize retry cycle so uploads re-PUT instead of publishing missing objects
- classify transient versus permanent metadata and mapping failures without weakening the provisional-expiry rollback guard
- add bounded retry metrics, cancellation, wrapper tests, and update the upload-fence audit record

## Scope
- closes F6 and F14
- closes only the observed-fence half of F1; the fast-clear window remains assigned to PR5
- does not close X1 or X2; destructive GC remains disabled

## Verification
- go build ./...
- go vet ./internal/api/... ./internal/db/... ./internal/metrics/...
- go vet -tags=integration ./...
- go test -count=1 ./internal/api/... ./internal/db/... ./internal/metrics/...
- docker compose --profile test run --rm --build gotest go test -race -count=1 ./internal/db ./internal/gc ./internal/api/...
- docker compose --profile test run --rm --build go-integration-test