### PR TITLE
fix(gc): route block placement and reads by canonical metadata

### DIFF
--- a/docs/GC-UPLOAD-FENCE-PR-PLAN.md
+++ b/docs/GC-UPLOAD-FENCE-PR-PLAN.md
@@ -4,10 +4,11 @@
 **Research branch:** `docs/gc-upload-fence-rematerialization` — **not for merge**
 **Status:** PR-1 merged as [#137](https://github.com/Sesame-Disk/sesamefs/pull/137);
 PR-2 merged as [#138](https://github.com/Sesame-Disk/sesamefs/pull/138) (closed F2/X7).
-PR-3 is implemented and verified on `fix/gc-store-materialize-retry-contract`, pending
-review and merge; it closes F6 and F14 and the **observed-fence half** of F1 — the F1
-fast-clear window (a full GC cycle completing between the single fence read and publish)
-stays with PR-5.
+PR-3 merged as [#139](https://github.com/Sesame-Disk/sesamefs/pull/139), closing F6,
+F14 and the **observed-fence half** of F1. PR-4 is implemented on
+`fix/gc-canonical-placement-reads` and pending review; F4 and F7 remain open on
+`main` until it merges. The F1 fast-clear window (a full GC cycle completing between
+the single fence read and publish) stays with PR-5, and X1/X2 remain open.
 
 ## Why this document exists
 
@@ -330,8 +331,9 @@ metadata `NeedsPut` stores through `probe.StorageClass` and the canonical key in
 of the serving node's preferred backend — **together with**
 `internal/streaming/canonical_block_reader.go`,
 `internal/db/block_storage_location.go`, the read call sites (`fileview.go`,
-`sharelink_view.go`, `sync.go`, `seafhttp.go`) and the canonical `/blocks/check` in
-`v2/blocks.go`.
+`sharelink_view.go`, `sync.go`, `seafhttp.go`) and canonical placement checks in the
+session upload/check/commit funnel. The metadata-free no-session check/upload pair
+remains on preferred-store routing until PR-7 governs and canonicalizes both together.
 
 **Why these are one PR and not two.** An earlier draft split them and papered over
 the gap with "ship in the same release", which contradicts rule 1. They are not
@@ -357,23 +359,59 @@ new caller of that helper lands.
 **Acceptance:** the two-bucket MinIO integration test proving the object lands in the
 canonical bucket and not the preferred one; exact-class routing, derived-key
 validation, cross-org key rejection and the bounded deduplicated lookup all covered;
-resolution fails before any response header is committed.
+canonical resolution fails before a block-stream body is committed. The legacy
+path-based object fallback remains an explicit F5/PR-6 issue; conditional `304` cache
+validation remains an intentional no-body short circuit.
+
+**Current implementation (pending review):** existing-metadata `NeedsPut` writes use
+the immutable `storage_class` and derived org-scoped key through
+`internal/api/v2/upload_reuse.go`; `internal/db/block_storage_location.go` supplies
+bounded canonical metadata lookups; and
+`internal/streaming/canonical_block_reader.go` resolves reads before response headers.
+The session upload, check, and commit paths resolve the same metadata placement, so a
+repair cannot be committed in a preferred bucket that canonical readers will ignore.
+The API/SeafHTTP read surfaces in `internal/api/seafhttp.go`, `internal/api/sync.go`,
+`internal/api/v2/blocks.go`, `internal/api/v2/fileview.go`,
+`internal/api/v2/sharelink_view.go`, and related V2 readers consume that canonical
+location rather than request routing. `internal/integration/gc_upload_fence_test.go`
+creates a bucket-B-pinned library, seeds zero-reference metadata in bucket A, drives
+the production Sync PUT endpoint, proves bytes exist only in A while metadata and the
+SHA-1 mapping remain canonical, then reads the bytes back through the production Sync
+GET endpoint from that B-preferring library. It then removes A's object and drives the
+real web session check/upload/commit/download flow, including uppercase hash inputs,
+to prove the session repairs and verifies A without writing B.
+
+PR-4 verification completed on 2026-07-21:
+
+```bash
+# completed: PASS
+go test ./internal/db ./internal/storage ./internal/streaming ./internal/api/...
+
+# completed: PASS (real Cassandra + two MinIO buckets)
+docker compose --profile test run --rm --build go-integration-test go test -tags=integration -v -count=1 -timeout 3m -run '^TestNeedsPutUsesCanonicalMinIOBucket$' ./internal/integration
+
+# completed: PASS
+docker compose --profile test run --rm --build gotest go test -race -count=1 ./internal/db ./internal/storage ./internal/streaming ./internal/api/...
+
+# completed: PASS (230.573s)
+docker compose --profile test run --rm --build go-integration-test
+```
 
 ---
 
 ### PR-5 — Cover the remaining funnel and normalise the wrappers
 
-**Scope:** the web block-session path in `v2/blocks.go`, which is the one funnel with
-no probe and no retry wrapper at all. Traffic accounting and the staged-block
-reservation hoisted so a retry cannot double-charge or double-reserve. Normalise the
-SeafHTTP wrapper's retry-reason labels against the generic one. Frontend: treat the
-new `409 block_delete_in_progress` as a soft retry honouring `Retry-After`.
+**Scope:** wrap the web block-session path in `v2/blocks.go`, which PR-4 now probes and
+routes canonically but which still has no bounded store-to-materialize retry. Traffic
+accounting and staged-block reservation remain single-shot across retries. Normalise
+the SeafHTTP wrapper's retry-reason labels against the generic one. Frontend: treat
+the new `409 block_delete_in_progress` as a soft retry honouring `Retry-After`.
 
 **Not** "the moment everything gets connected" — PR-3 already did that for six
 funnels. This closes the seventh and makes the wrappers consistent.
 
-**Depends on PR-4**, not merely follows it: this funnel calls the canonical store
-helper, so the canonical readers have to be in place first.
+**Depends on PR-4**, not merely follows it: this funnel already calls the canonical
+store helper, so its retry contract must preserve that placement.
 
 **Why the frontend rides along:** this PR is what makes the 409 reachable from the
 web client. Splitting them would ship a user-visible upload failure for one release.
@@ -525,10 +563,8 @@ These stay open and keep destructive GC disabled:
 
 ## Verification debt carried by the whole series
 
-- `go test -race` has never run: the dev box has no gcc. Must run in Docker before
-  any PR that touches concurrency or conditional lifecycle races merges: **PR-2,
-  PR-3, PR-4, PR-5 and PR-9**. PR-4 in particular introduces the concurrent
-  canonical reader and must not merge without it.
+- PR-2, PR-3, and PR-4 ran `go test -race` in Docker. PR-5 and PR-9 must still run
+  their own race validation because they change separate lifecycle or channel behavior.
 - No end-to-end download tests against real Cassandra exist for the 404/503 contract.
 - No multi-DC test exercises any of the cross-DC reasoning; it is derived from the
   production consistency contract, not from a reproduction. The dedicated

--- a/docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md
+++ b/docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md
@@ -5,10 +5,10 @@
 **Companion:** [GC-UPLOAD-FENCE-PR-PLAN.md](./GC-UPLOAD-FENCE-PR-PLAN.md) — which PR closes what.
 **Series progress:** PR-1 merged as [#137](https://github.com/Sesame-Disk/sesamefs/pull/137);
 PR-2 merged as [#138](https://github.com/Sesame-Disk/sesamefs/pull/138), closing F2 and
-X7. PR-3 (store/materialize retry contract) is implemented on
-`fix/gc-store-materialize-retry-contract`, **pending merge**: it closes F6 and F14 and
-the observed-fence half of F1 (the F1 fast-clear window stays with PR-5). Rows stay in
-**## Open** until PR-3 merges.
+X7. PR-3 merged as [#139](https://github.com/Sesame-Disk/sesamefs/pull/139), closing
+F6, F14 and the observed-fence half of F1. PR-4 is implemented on
+`fix/gc-canonical-placement-reads` and pending review; F4/F7 stay open on `main` until
+it merges. The F1 fast-clear window stays with PR-5, and X1/X2 remain open.
 
 Every row is verified against code at the cited location, except where the row
 explicitly identifies engine-dependent behavior that still needs a non-skipping
@@ -36,17 +36,15 @@ out here so the decision is visible rather than implicit.
 
 ## Open on `main`
 
-Rows whose **Closed by** names PR-3 have their code landed on
-`fix/gc-store-materialize-retry-contract` but stay **open** here until that branch
-merges (a row only moves to **## Closed** on merge — see the note at the top).
+F4 and F7 have implementations on `fix/gc-canonical-placement-reads` but stay open
+until PR-4 merges. F1 remains open for its PR-5 fast-clear half.
 
 | # | Severity | Finding | Evidence | Closed by |
 |---|---|---|---|---|
 | F1 | Blocker | **Fast-clearing GC fence loses the uploaded object.** An upload can PUT, add its provisional reference after GC's post-claim liveness read, then publish metadata without repeating the PUT GC deleted. PR-3 fixes the **observed-fence** half: `RegisterUploadedBlock` no longer absorbs the fence — it reads it once and propagates `ErrBlockDeleteInProgress`, leaving the provisional reference in place, so the wrapper repeats store→materialize and re-PUTs the object. The **fast-clear window** — a whole GC claim→verify→delete→clear cycle completing between the single fence read and publish, so the fence is never observed — is NOT closed by PR-3; that needs PR-5's deterministic real-worker regression and the web-funnel half. Destructive GC stays disabled meanwhile. | `fs_helpers.go` `RegisterUploadedBlock`; `upload_reuse.go` `RetryUploadedBlockMaterialization` | PR-3 (observed-fence half) + PR-5 (fast-clear window) |
-| F3 | High | **Web block-session upload funnel is unwrapped.** `v2/blocks.go` uses raw `BlockExists` + `PutBlockData` + materialize with no probe and no store retry, so it cannot honour the fence contract at all. | `v2/blocks.go` `UploadBlock` | PR-5 |
+| F3 | High | **Web block-session upload funnel is unwrapped.** PR-4 probes and routes this funnel canonically, but `v2/blocks.go` still performs only one store→materialize attempt, so it cannot recover when the post-reference fence read observes GC ownership. | `v2/blocks.go` `UploadBlock` | PR-5 |
 | F4 | High | **`NeedsPut` with existing metadata stores to the wrong backend.** The PUT targets the serving node's preferred store while first-writer metadata may point elsewhere, so physical placement and metadata diverge. | `sync.go`, `seafhttp.go` NeedsPut branches | PR-4 |
 | F5 | High | **Download can serve stale legacy bytes.** `HandleDownload` falls back to the path-based object on *any* streaming failure, including a Cassandra timeout. On a library since written through blocks that object can hold an older version of the same path, so a transient failure answers 200 with stale content. | `seafhttp.go` `HandleDownload` fallback | PR-6 |
-| F6 | Medium | **Transient retry sentinel is not produced by the production helper.** PR-3 tags transient Cassandra I/O in `RegisterUploadedBlock` and the mapping write in `RegisterUploadedBlockAndMapping` with `ErrBlockMaterializationTransient` (retried, cause preserved via `%w`), and returns `db.ErrBlockMetadataPermanent` untagged (not retried). The provisional-expiry write is the one exception: it fails closed with a rollback rather than retry (see F10). | `fs_helpers.go`; `upload_rollback.go` | PR-3 |
 | F7 | Medium | **Readers resolve by routing, not by metadata.** Once bytes follow canonical metadata (F4), a reader that picks the backend by request routing looks in the wrong bucket. | read call sites in `fileview.go`, `sharelink_view.go`, `sync.go`, `seafhttp.go` | PR-4 |
 | F8 | Medium | **Legacy no-session upload leaks S3 objects (R2).** `/api/v2/blocks/upload` without a session writes an object with no `blocks` row and no reference. Reachable by any authenticated user regardless of the block-upload feature flag. | `v2/blocks.go` legacy path | PR-7 |
 | F9 | Medium | **GC Phase 0 can delete a renewed provisional reference.** The scanner removed the reference based on a stale expiry projection, which could drop liveness for a live upload that renewed the same referrer. | `gc/scanner.go` `scanExpiredProvisionalBlockRefs` | PR-8 |
@@ -54,7 +52,6 @@ merges (a row only moves to **## Closed** on merge — see the note at the top).
 | F11 | Medium | **Abandoned prefetch leaks an open S3 reader.** `PrefetchBlock` buffered its result, so a consumer that stopped early left the `io.ReadCloser` unclosed. | `streaming/streaming.go` | PR-9 |
 | F12 | Medium | **Unbounded request bodies.** `PutBlock` and `check-blocks` read the whole body with `io.ReadAll` and no size or id-count limit. | `sync.go` | PR-10 |
 | F13 | High | **Corrupt directory listings resolve, and 404/503 semantics are inverted for a deleted path.** High, not the Low it was first filed as: two of the cases below serve bytes from the wrong FS object. Not Blocker only because it needs an already-corrupt dirent — see the severity note above. The 404/503 half on its own would be Low. `findEntryInDir` returns a plain error, so a renamed or deleted file surfaces as 503 while an absent commit row gives 404. Related, and worse: a JSON-valid but corrupt listing resolves anyway. Structural cases (`null`, `[null]`, non-string name, missing id) parse and the bad entries are skipped, reporting a false absence; semantic cases (empty name, empty or non-40-hex id, duplicate names) resolve to a wrong or missing FS object; and `encoding/json` silently keeps the **last** value for a repeated key, so `{"id":"A","id":"B"}` serves B and `{"name":"a","name":"b"}` hides `a` entirely. Both of the last two can serve arbitrary bytes or report a present file as absent. | `seafhttp.go` `findEntryInDir` | PR-6 |
-| F14 | Low | **Retry metric mislabels write failures.** A retry metric must not attribute a metadata-write failure to the read path. PR-3 emits `block_upload_materialization_retries_total{surface,reason}` from all three wrappers with the reason derived from the failing **phase** (materialize→`materialization`, never `probe`; fence→`gc_fence`). The `probe` label denotes the store phase (not "read side") and is reached only if a store callback opts into the transient sentinel. | `seafhttp.go` retry wrapper; `metrics.go` | PR-3 |
 
 ## Closed
 
@@ -64,6 +61,8 @@ Rows move here only once the PR that fixes them **merges**.
 |---|---|---|---|
 | F2 | Blocker (engine-dependent) | A materialized GC-claim stub permanently breaks a block id. | PR-2 ([#138](https://github.com/Sesame-Disk/sesamefs/pull/138)) |
 | X7 | Medium (perf) | Design constraint: stub repair must not add a hot-path `blocks` read. Closed by exposing `RepairableStub` from the existing probe plus a metadata-LWT backstop — no extra read on the absent-row path. | PR-2 ([#138](https://github.com/Sesame-Disk/sesamefs/pull/138)) |
+| F6 | Medium | Production metadata registration did not produce the transient retry sentinel. PR-3 tags transient Cassandra I/O while leaving permanent metadata failures untagged. | PR-3 ([#139](https://github.com/Sesame-Disk/sesamefs/pull/139)) |
+| F14 | Low | Retry metrics mislabeled materialization failures as probe failures. PR-3 derives the label from the failing phase. | PR-3 ([#139](https://github.com/Sesame-Disk/sesamefs/pull/139)) |
 
 ## Open, deferred, or constraining the series
 
@@ -164,9 +163,10 @@ cluster. Destructive GC stays disabled until one lands.
 
 Applies to every PR in the series, not to any single finding.
 
-- **PR-2 race validation passed in Docker on 2026-07-21.** PR-3, PR-4, PR-5 and
+- **PR-2, PR-3, and PR-4 race validation passed in Docker on 2026-07-21.** PR-5 and
   PR-9 must still run their own `go test -race` validation because they change
-  separate goroutine/channel or lifecycle behavior.
+  separate lifecycle or channel behavior. PR-4's focused real-Cassandra/two-bucket-
+  MinIO acceptance and full integration suite also passed in Compose on 2026-07-21.
 - **No end-to-end download tests against real Cassandra** exist for the 404/503
   contract (F5, F13). The unit tests cover the classifier, not the handler.
 - **No multi-DC test** exercises X2 or X6. Both are reasoned from the production

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.6
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.95.0
+	github.com/aws/smithy-go v1.24.0
 	github.com/gin-contrib/cors v1.7.6
 	github.com/gin-contrib/gzip v1.2.5
 	github.com/gin-gonic/gin v1.11.0
@@ -15,9 +16,11 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/prometheus/client_golang v1.22.0
+	github.com/prometheus/client_model v0.6.1
 	github.com/stretchr/testify v1.11.1
 	github.com/xuri/excelize/v2 v2.10.1
 	golang.org/x/crypto v0.48.0
+	golang.org/x/sync v0.19.0
 	golang.org/x/time v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -37,7 +40,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.5 // indirect
-	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.14.1 // indirect
@@ -63,7 +65,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
@@ -78,7 +79,6 @@ require (
 	golang.org/x/arch v0.22.0 // indirect
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.50.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect

--- a/internal/api/handler_mapping_failure_test.go
+++ b/internal/api/handler_mapping_failure_test.go
@@ -29,7 +29,7 @@ func TestSeafHTTPHandleUploadMappingFailureReturns500(t *testing.T) {
 	})
 
 	probeUploadedBlockReuseForUploadFn = func(*db.DB, string, string) (db.BlockReuseProbe, error) {
-		return db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut}, nil
+		return db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut, StorageClass: "hot"}, nil
 	}
 	putUploadedBlockAutoDirectForUploadFn = func(ctx context.Context, blockStore *storage.BlockStore, hash string, data []byte) (string, error) {
 		return hash, nil
@@ -49,7 +49,10 @@ func TestSeafHTTPHandleUploadMappingFailureReturns500(t *testing.T) {
 		t.Fatalf("CreateUploadToken() error = %v", err)
 	}
 
-	handler := NewSeafHTTPHandler(&storage.S3Store{}, nil, nil, tokenStore, nil, nil)
+	s3Store := &storage.S3Store{}
+	storageManager := storage.NewManager()
+	storageManager.RegisterBackend("hot", s3Store, "")
+	handler := NewSeafHTTPHandler(s3Store, storageManager, nil, tokenStore, nil, nil)
 	r := gin.New()
 	r.POST("/seafhttp/upload-api/:token", handler.HandleUpload)
 

--- a/internal/api/seafhttp.go
+++ b/internal/api/seafhttp.go
@@ -1289,6 +1289,15 @@ type zipPreparedFile struct {
 	sizeBytes   int64
 }
 
+var seafHTTPNewCanonicalBlockReaderFn = streaming.NewCanonicalBlockReader
+var seafHTTPBatchResolveBlockIDsFn = streaming.BatchResolveBlockIDs
+var seafHTTPLookupFileBlocksFn = func(h *SeafHTTPHandler, hostname string, token *AccessToken) ([]string, int64, []byte, []byte, *storage.BlockStore, string, error) {
+	return h.lookupFileBlocks(hostname, token)
+}
+var seafHTTPResolveBlockRepresentationIDFn = func(h *SeafHTTPHandler, orgID, repoID string) (string, error) {
+	return h.resolveBlockRepresentationID(orgID, repoID)
+}
+
 func (b *zipTraversalBudget) noteDirectory(depth int) error {
 	if depth > b.maxDepth {
 		return &zipLimitError{message: fmt.Sprintf("zip download exceeds maximum directory depth of %d", b.maxDepth)}
@@ -1519,6 +1528,7 @@ var putUploadedBlockAutoDirectForUploadFn = func(ctx context.Context, blockStore
 var probeUploadedBlockReuseForUploadFn = v2.ProbeUploadedBlockReuse
 var prepareUploadedBlockProbeForUploadFn = v2.PrepareUploadedBlockProbe
 var ensureReusableBlockPresentForUploadFn = v2.EnsureReusableBlockPresent
+var resolveNeedsPutBlockStoreForUploadFn = v2.ResolveNeedsPutBlockStore
 var registerUploadedBlockAndMappingForUploadFn = v2.RegisterUploadedBlockAndMapping
 var resolveSeafHTTPStoredBlockIDsFn = func(fsHelper *v2.FSHelper, orgID, repoID string, blockIDs []string) ([]string, error) {
 	return fsHelper.ResolveStoredBlockIDs(orgID, repoID, blockIDs)
@@ -2155,7 +2165,9 @@ func (h *SeafHTTPHandler) HandleUpload(c *gin.Context) {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "block storage not available"})
 		return
 	}
+	materializedStorageClass := actualStorageClass
 	storeUploadedBlock := func() error {
+		materializedStorageClass = actualStorageClass
 		probe, probeErr := probeUploadedBlockReuseForUploadFn(h.db, token.OrgID, sha256ID)
 		if probeErr != nil {
 			return fmt.Errorf("probe block reuse for %s: %w", sha256ID, probeErr)
@@ -2166,13 +2178,20 @@ func (h *SeafHTTPHandler) HandleUpload(c *gin.Context) {
 		}
 		switch probe.Decision {
 		case db.BlockReuseReusable:
-			if _, ensureErr := ensureReusableBlockPresentForUploadFn(ctx, sha256ID, probe, storedContent, h.storageManager, blockStore, actualStorageClass, token.OrgID); ensureErr != nil {
+			materializedStorageClass = strings.TrimSpace(probe.StorageClass)
+			_, ensureErr := ensureReusableBlockPresentForUploadFn(ctx, sha256ID, probe, storedContent, h.storageManager, blockStore, actualStorageClass, token.OrgID)
+			if ensureErr != nil {
 				return ensureErr
 			}
 			log.Printf("[HandleUpload] Reused canonical block %s (SHA-256: %s) after physical verification", fileID[:16], sha256ID[:16])
 			return nil
 		case db.BlockReuseNeedsPut:
-			_, putErr := putUploadedBlockAutoDirectForUploadFn(ctx, blockStore, sha256ID, storedContent)
+			putStore, resolvedClass, _, resolveErr := resolveNeedsPutBlockStoreForUploadFn(h.storageManager, blockStore, actualStorageClass, probe, token.OrgID, sha256ID)
+			if resolveErr != nil {
+				return resolveErr
+			}
+			materializedStorageClass = resolvedClass
+			_, putErr := putUploadedBlockAutoDirectForUploadFn(ctx, putStore, sha256ID, storedContent)
 			if putErr == nil {
 				log.Printf("[HandleUpload] Stored block %s (SHA-256: %s) via direct PUT", fileID[:16], sha256ID[:16])
 			}
@@ -2192,7 +2211,7 @@ func (h *SeafHTTPHandler) HandleUpload(c *gin.Context) {
 		}
 		return nil
 	}, func() error {
-		return registerUploadedBlockAndMappingForUploadFn(h.db, token.OrgID, token.RepoID, sha256ID, uploadOperationID, len(storedContent), actualStorageClass, "", fileID)
+		return registerUploadedBlockAndMappingForUploadFn(h.db, token.OrgID, token.RepoID, sha256ID, uploadOperationID, len(storedContent), materializedStorageClass, "", fileID)
 	}, func() (bool, error) {
 		return clearSeafHTTPS3OrphanFenceFn(c.Request.Context(), h.db, h.storageManager, "HandleUpload", token.OrgID, sha256ID)
 	}); err != nil {
@@ -2660,7 +2679,9 @@ readLoop:
 
 			uploadOperationID := upload.UploadOperationID()
 			if blkErr := upload.AccountBlockOnce(blockIndexLocal, sha256ID, func() error {
+				materializedStorageClass := actualStorageClass
 				return retrySeafHTTPBlockMaterialization("finalizeUploadStreaming", sha256ID, func() error {
+					materializedStorageClass = actualStorageClass
 					probe, probeErr := probeUploadedBlockReuseForUploadFn(h.db, token.OrgID, sha256ID)
 					if probeErr != nil {
 						return fmt.Errorf("probe block reuse for %s: %w", sha256ID, probeErr)
@@ -2671,10 +2692,16 @@ readLoop:
 					}
 					switch probe.Decision {
 					case db.BlockReuseReusable:
+						materializedStorageClass = strings.TrimSpace(probe.StorageClass)
 						_, ensureErr := ensureReusableBlockPresentForUploadFn(egCtx, sha256ID, probe, storedBlock, h.storageManager, blockStore, actualStorageClass, token.OrgID)
 						return ensureErr
 					case db.BlockReuseNeedsPut:
-						_, putErr := putUploadedBlockAutoDirectForUploadFn(egCtx, blockStore, sha256ID, storedBlock)
+						putStore, resolvedClass, _, resolveErr := resolveNeedsPutBlockStoreForUploadFn(h.storageManager, blockStore, actualStorageClass, probe, token.OrgID, sha256ID)
+						if resolveErr != nil {
+							return resolveErr
+						}
+						materializedStorageClass = resolvedClass
+						_, putErr := putUploadedBlockAutoDirectForUploadFn(egCtx, putStore, sha256ID, storedBlock)
 						if putErr != nil {
 							return fmt.Errorf("failed to store block: %w", putErr)
 						}
@@ -2692,7 +2719,7 @@ readLoop:
 						return permitErr
 					}
 					defer releaseMetadataPermit()
-					return registerUploadedBlockAndMappingForUploadFn(h.db, token.OrgID, token.RepoID, sha256ID, uploadOperationID, len(storedBlock), actualStorageClass, "", blockSHA1IDLocal)
+					return registerUploadedBlockAndMappingForUploadFn(h.db, token.OrgID, token.RepoID, sha256ID, uploadOperationID, len(storedBlock), materializedStorageClass, "", blockSHA1IDLocal)
 				}, func() (bool, error) {
 					return clearSeafHTTPS3OrphanFenceFn(egCtx, h.db, h.storageManager, "finalizeUploadStreaming", token.OrgID, sha256ID)
 				})
@@ -3562,20 +3589,20 @@ func (h *SeafHTTPHandler) resolveBlockID(orgID, repoID, blockID string) (string,
 
 // lookupFileBlocks resolves a token's path to its block IDs, file size, encryption key, and block store.
 // This is the common metadata lookup used by both download and streaming paths.
-func (h *SeafHTTPHandler) lookupFileBlocks(hostname string, token *AccessToken) (blockIDs []string, fileSize int64, fileKey []byte, fileIV []byte, blockStore *storage.BlockStore, err error) {
+func (h *SeafHTTPHandler) lookupFileBlocks(hostname string, token *AccessToken) (blockIDs []string, fileSize int64, fileKey []byte, fileIV []byte, blockStore *storage.BlockStore, storageClass string, err error) {
 	// Check encryption
 	var encrypted bool
 	err = h.db.Session().Query(`
 		SELECT encrypted FROM libraries WHERE org_id = ? AND library_id = ?
 	`, token.OrgID, token.RepoID).Scan(&encrypted)
 	if err != nil {
-		return nil, 0, nil, nil, nil, fmt.Errorf("failed to check library encryption: %w", err)
+		return nil, 0, nil, nil, nil, "", fmt.Errorf("failed to check library encryption: %w", err)
 	}
 
 	if encrypted {
 		fileKey, fileIV = v2.GetDecryptSessions().GetFileKeyAndIV(token.UserID, token.RepoID)
 		if fileKey == nil {
-			return nil, 0, nil, nil, nil, fmt.Errorf("library is encrypted but not unlocked")
+			return nil, 0, nil, nil, nil, "", fmt.Errorf("library is encrypted but not unlocked")
 		}
 	}
 
@@ -3585,7 +3612,7 @@ func (h *SeafHTTPHandler) lookupFileBlocks(hostname string, token *AccessToken) 
 		SELECT head_commit_id FROM libraries WHERE org_id = ? AND library_id = ?
 	`, token.OrgID, token.RepoID).Scan(&headCommit)
 	if err != nil {
-		return nil, 0, nil, nil, nil, fmt.Errorf("library not found: %w", err)
+		return nil, 0, nil, nil, nil, "", fmt.Errorf("library not found: %w", err)
 	}
 
 	var rootFSID string
@@ -3593,7 +3620,7 @@ func (h *SeafHTTPHandler) lookupFileBlocks(hostname string, token *AccessToken) 
 		SELECT root_fs_id FROM commits WHERE library_id = ? AND commit_id = ?
 	`, token.RepoID, headCommit).Scan(&rootFSID)
 	if err != nil {
-		return nil, 0, nil, nil, nil, fmt.Errorf("commit not found: %w", err)
+		return nil, 0, nil, nil, nil, "", fmt.Errorf("commit not found: %w", err)
 	}
 
 	// Navigate directory tree to the target file
@@ -3603,14 +3630,14 @@ func (h *SeafHTTPHandler) lookupFileBlocks(hostname string, token *AccessToken) 
 	}
 	pathParts := strings.Split(strings.Trim(filePath, "/"), "/")
 	if len(pathParts) == 0 || (len(pathParts) == 1 && pathParts[0] == "") {
-		return nil, 0, nil, nil, nil, fmt.Errorf("invalid file path")
+		return nil, 0, nil, nil, nil, "", fmt.Errorf("invalid file path")
 	}
 
 	currentFSID := rootFSID
 	for i := 0; i < len(pathParts)-1; i++ {
 		nextFSID, err := h.findEntryInDir(token.RepoID, currentFSID, pathParts[i])
 		if err != nil {
-			return nil, 0, nil, nil, nil, fmt.Errorf("directory not found: %s: %w", pathParts[i], err)
+			return nil, 0, nil, nil, nil, "", fmt.Errorf("directory not found: %s: %w", pathParts[i], err)
 		}
 		currentFSID = nextFSID
 	}
@@ -3618,7 +3645,7 @@ func (h *SeafHTTPHandler) lookupFileBlocks(hostname string, token *AccessToken) 
 	targetName := pathParts[len(pathParts)-1]
 	fileFSID, err := h.findEntryInDir(token.RepoID, currentFSID, targetName)
 	if err != nil {
-		return nil, 0, nil, nil, nil, fmt.Errorf("file not found: %s: %w", targetName, err)
+		return nil, 0, nil, nil, nil, "", fmt.Errorf("file not found: %s: %w", targetName, err)
 	}
 
 	// Get block IDs and file size from fs_object
@@ -3626,22 +3653,22 @@ func (h *SeafHTTPHandler) lookupFileBlocks(hostname string, token *AccessToken) 
 		SELECT block_ids, size_bytes FROM fs_objects WHERE library_id = ? AND fs_id = ?
 	`, token.RepoID, fileFSID).Scan(&blockIDs, &fileSize)
 	if err != nil {
-		return nil, 0, nil, nil, nil, fmt.Errorf("file metadata not found: %w", err)
+		return nil, 0, nil, nil, nil, "", fmt.Errorf("file metadata not found: %w", err)
 	}
 
-	blockStore, _, err = h.resolveLibraryBlockStore(hostname, token.OrgID, token.RepoID)
+	blockStore, storageClass, err = h.resolveLibraryBlockStore(hostname, token.OrgID, token.RepoID)
 	if err != nil {
-		return nil, 0, nil, nil, nil, fmt.Errorf("block store not available: %w", err)
+		return nil, 0, nil, nil, nil, "", fmt.Errorf("block store not available: %w", err)
 	}
 
-	return blockIDs, fileSize, fileKey, fileIV, blockStore, nil
+	return blockIDs, fileSize, fileKey, fileIV, blockStore, storageClass, nil
 }
 
 // streamFileFromBlocks streams a file's blocks directly to the HTTP response.
 // Uses prefetching (overlap S3 fetch with HTTP write) and 4MB io.CopyBuffer
 // for maximum throughput. Only O(2 × block_size) RAM.
 func (h *SeafHTTPHandler) streamFileFromBlocks(c *gin.Context, token *AccessToken, filename string, periodStartedAt time.Time) error {
-	blockIDs, fileSize, fileKey, fileIV, blockStore, err := h.lookupFileBlocks(httputil.GetRoutingHostname(c, h.configuredServerURL()), token)
+	blockIDs, fileSize, fileKey, fileIV, blockStore, storageClass, err := seafHTTPLookupFileBlocksFn(h, httputil.GetRoutingHostname(c, h.configuredServerURL()), token)
 	if err != nil {
 		return err
 	}
@@ -3659,7 +3686,7 @@ func (h *SeafHTTPHandler) streamFileFromBlocks(c *gin.Context, token *AccessToke
 	}
 
 	log.Printf("[streamFileFromBlocks] Streaming %d blocks, size=%d, encrypted=%v", len(blockIDs), fileSize, fileKey != nil)
-	representationID, err := h.resolveBlockRepresentationID(token.OrgID, token.RepoID)
+	representationID, err := seafHTTPResolveBlockRepresentationIDFn(h, token.OrgID, token.RepoID)
 	if err != nil {
 		return fmt.Errorf("resolve block representation: %w", err)
 	}
@@ -3667,10 +3694,14 @@ func (h *SeafHTTPHandler) streamFileFromBlocks(c *gin.Context, token *AccessToke
 	// Batch resolve all block IDs upfront (avoids per-block Cassandra queries).
 	// Strict: a stale SHA-1 sent to SHA-256 storage would truncate the stream
 	// mid-download, so we resolve BEFORE committing any headers and fail clean.
-	resolvedIDs, err := streaming.BatchResolveBlockIDs(h.db, token.OrgID, representationID, blockIDs)
+	resolvedIDs, err := seafHTTPBatchResolveBlockIDsFn(h.db, token.OrgID, representationID, blockIDs)
 	if err != nil {
 		log.Printf("[streamFileFromBlocks] block ID resolution failed for org=%s: %v", token.OrgID, err)
 		return fmt.Errorf("resolve block IDs: %w", err)
+	}
+	canonicalReader, err := seafHTTPNewCanonicalBlockReaderFn(c.Request.Context(), h.db, h.storageManager, token.OrgID, resolvedIDs, blockStore, storageClass)
+	if err != nil {
+		return fmt.Errorf("resolve canonical block locations: %w", err)
 	}
 
 	// Set headers before streaming — Content-Length lets clients show progress
@@ -3685,7 +3716,7 @@ func (h *SeafHTTPHandler) streamFileFromBlocks(c *gin.Context, token *AccessToke
 	c.Status(http.StatusOK)
 
 	// Stream with prefetching pipeline
-	streaming.StreamBlocks(c, c.Request.Context(), blockStore, resolvedIDs, fileKey, fileIV, "streamFileFromBlocks")
+	streaming.StreamBlocks(c, c.Request.Context(), canonicalReader, resolvedIDs, fileKey, fileIV, "streamFileFromBlocks")
 
 	log.Printf("[streamFileFromBlocks] Streaming complete: %d blocks", len(blockIDs))
 
@@ -3705,20 +3736,28 @@ func (h *SeafHTTPHandler) streamFileFromBlocks(c *gin.Context, token *AccessToke
 // DEPRECATED: Use streamFileFromBlocks for downloads. This is kept only for
 // upload metadata (commitUploadedFile) where the full content is already in memory.
 func (h *SeafHTTPHandler) getFileFromBlocks(c *gin.Context, token *AccessToken) ([]byte, error) {
-	blockIDs, _, fileKey, fileIV, blockStore, err := h.lookupFileBlocks(httputil.GetRoutingHostname(c, h.configuredServerURL()), token)
+	blockIDs, _, fileKey, fileIV, blockStore, storageClass, err := seafHTTPLookupFileBlocksFn(h, httputil.GetRoutingHostname(c, h.configuredServerURL()), token)
 	if err != nil {
 		return nil, err
 	}
 
 	ctx := c.Request.Context()
-	var content bytes.Buffer
-	for _, blockID := range blockIDs {
-		internalID, err := h.resolveBlockID(token.OrgID, token.RepoID, blockID)
-		if err != nil {
-			return nil, err
-		}
+	representationID, err := seafHTTPResolveBlockRepresentationIDFn(h, token.OrgID, token.RepoID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve block representation: %w", err)
+	}
+	resolvedIDs, err := seafHTTPBatchResolveBlockIDsFn(h.db, token.OrgID, representationID, blockIDs)
+	if err != nil {
+		return nil, fmt.Errorf("resolve block IDs: %w", err)
+	}
+	canonicalReader, err := seafHTTPNewCanonicalBlockReaderFn(ctx, h.db, h.storageManager, token.OrgID, resolvedIDs, blockStore, storageClass)
+	if err != nil {
+		return nil, fmt.Errorf("resolve canonical block locations: %w", err)
+	}
 
-		blockData, err := blockStore.GetBlock(ctx, internalID)
+	var content bytes.Buffer
+	for i, blockID := range blockIDs {
+		blockData, err := canonicalReader.GetBlock(ctx, resolvedIDs[i])
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve block %s: %w", blockID, err)
 		}
@@ -3957,7 +3996,7 @@ func (h *SeafHTTPHandler) HandleZipDownload(c *gin.Context) {
 	}
 
 	hostname := httputil.GetRoutingHostname(c, h.configuredServerURL())
-	blockStore, _, err := h.resolveLibraryBlockStore(hostname, token.OrgID, token.RepoID)
+	blockStore, storageClass, err := h.resolveLibraryBlockStore(hostname, token.OrgID, token.RepoID)
 	if err != nil {
 		log.Printf("[HandleZipDownload] Failed to resolve block store: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to prepare zip download"})
@@ -3975,6 +4014,16 @@ func (h *SeafHTTPHandler) HandleZipDownload(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to prepare zip download"})
 		return
 	}
+	allResolvedIDs := make([]string, 0)
+	for _, file := range preparedFiles {
+		allResolvedIDs = append(allResolvedIDs, file.resolvedIDs...)
+	}
+	canonicalReader, err := seafHTTPNewCanonicalBlockReaderFn(c.Request.Context(), h.db, h.storageManager, token.OrgID, allResolvedIDs, blockStore, storageClass)
+	if err != nil {
+		log.Printf("[HandleZipDownload] Failed to resolve canonical block locations: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to prepare zip download"})
+		return
+	}
 
 	// Stream ZIP to response
 	zipFilename := dirName + ".zip"
@@ -3988,7 +4037,7 @@ func (h *SeafHTTPHandler) HandleZipDownload(c *gin.Context) {
 	// Snapshot writer size before streaming so we can calculate the delta afterward.
 	bytesBefore := int64(c.Writer.Size())
 
-	if err := h.addDirToZip(c.Request.Context(), zipWriter, blockStore, preparedFiles, fileKey, fileIV); err != nil {
+	if err := h.addDirToZip(c.Request.Context(), zipWriter, canonicalReader, preparedFiles, fileKey, fileIV); err != nil {
 		log.Printf("[HandleZipDownload] ZIP stream aborted: %v", err)
 		return
 	}
@@ -4091,7 +4140,7 @@ func (h *SeafHTTPHandler) prepareZipDirectory(repoID, orgID, dirFSID, prefix str
 	return prepared, nil
 }
 
-func (h *SeafHTTPHandler) addDirToZip(ctx context.Context, zw *zip.Writer, blockStore *storage.BlockStore, files []zipPreparedFile, fileKey []byte, fileIV []byte) error {
+func (h *SeafHTTPHandler) addDirToZip(ctx context.Context, zw *zip.Writer, blockStore streaming.BlockReader, files []zipPreparedFile, fileKey []byte, fileIV []byte) error {
 	for _, file := range files {
 		if err := h.addFileToZip(ctx, zw, blockStore, file, fileKey, fileIV); err != nil {
 			return err
@@ -4104,7 +4153,7 @@ func (h *SeafHTTPHandler) addDirToZip(ctx context.Context, zw *zip.Writer, block
 // Uses zip.Store (no compression) for maximum throughput — the data is already
 // compressed by S3/MinIO or is binary data where deflate adds CPU cost for minimal gain.
 // For encrypted files, one block at a time is loaded, decrypted, and written.
-func (h *SeafHTTPHandler) addFileToZip(ctx context.Context, zw *zip.Writer, blockStore *storage.BlockStore, file zipPreparedFile, fileKey []byte, fileIV []byte) error {
+func (h *SeafHTTPHandler) addFileToZip(ctx context.Context, zw *zip.Writer, blockStore streaming.BlockReader, file zipPreparedFile, fileKey []byte, fileIV []byte) error {
 	header := &zip.FileHeader{
 		Name:   file.path,
 		Method: zip.Store,

--- a/internal/api/seafhttp_test.go
+++ b/internal/api/seafhttp_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Sesame-Disk/sesamefs/internal/metrics"
 	"github.com/Sesame-Disk/sesamefs/internal/middleware"
 	"github.com/Sesame-Disk/sesamefs/internal/storage"
+	"github.com/Sesame-Disk/sesamefs/internal/streaming"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"golang.org/x/time/rate"
@@ -1577,6 +1578,60 @@ func TestZipTraversalBudgetRejectsByteLimit(t *testing.T) {
 	}
 }
 
+func TestStreamFileFromBlocksResolvesCanonicalReaderBeforeSuccessResponse(t *testing.T) {
+	blockID := strings.Repeat("d", 64)
+	oldLookup := seafHTTPLookupFileBlocksFn
+	oldRepresentation := seafHTTPResolveBlockRepresentationIDFn
+	oldBatch := seafHTTPBatchResolveBlockIDsFn
+	oldCanonical := seafHTTPNewCanonicalBlockReaderFn
+	t.Cleanup(func() {
+		seafHTTPLookupFileBlocksFn = oldLookup
+		seafHTTPResolveBlockRepresentationIDFn = oldRepresentation
+		seafHTTPBatchResolveBlockIDsFn = oldBatch
+		seafHTTPNewCanonicalBlockReaderFn = oldCanonical
+	})
+
+	seafHTTPLookupFileBlocksFn = func(*SeafHTTPHandler, string, *AccessToken) ([]string, int64, []byte, []byte, *storage.BlockStore, string, error) {
+		return []string{blockID, blockID}, 18, nil, nil, nil, "hot", nil
+	}
+	seafHTTPResolveBlockRepresentationIDFn = func(*SeafHTTPHandler, string, string) (string, error) {
+		return db.PlainBlockRepresentationID, nil
+	}
+	seafHTTPBatchResolveBlockIDsFn = func(_ *db.DB, _, _ string, blockIDs []string) ([]string, error) {
+		return append([]string(nil), blockIDs...), nil
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/download", nil)
+	constructorCalls := 0
+	seafHTTPNewCanonicalBlockReaderFn = func(_ context.Context, _ *db.DB, _ *storage.Manager, _ string, blockIDs []string, _ *storage.BlockStore, class string) (streaming.CanonicalBlockReader, error) {
+		constructorCalls++
+		if c.Writer.Written() {
+			t.Fatal("success response was committed before canonical resolution")
+		}
+		if got := c.Writer.Header().Get("Content-Disposition"); got != "" {
+			t.Fatalf("Content-Disposition = %q before canonical resolution", got)
+		}
+		if len(blockIDs) != 2 || blockIDs[0] != blockID || blockIDs[1] != blockID || class != "hot" {
+			t.Fatalf("canonical constructor got ids=%v class=%q", blockIDs, class)
+		}
+		return nil, errors.New("canonical location failure")
+	}
+
+	h := &SeafHTTPHandler{db: &db.DB{}, storageManager: storage.NewManager()}
+	err := h.streamFileFromBlocks(c, &AccessToken{OrgID: "org", RepoID: "repo"}, "file.txt", time.Time{})
+	if err == nil || !strings.Contains(err.Error(), "canonical") {
+		t.Fatalf("streamFileFromBlocks error = %v, want canonical resolution error", err)
+	}
+	if constructorCalls != 1 {
+		t.Fatalf("canonical constructor calls = %d, want 1", constructorCalls)
+	}
+	if c.Writer.Written() {
+		t.Fatalf("response committed after canonical failure: status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
 func TestResolveLibraryBlockStoreUsesHostnameFallback(t *testing.T) {
 	manager := storage.NewManager()
 	manager.SetDefaultClass("hot-minio-local")
@@ -3095,7 +3150,7 @@ func TestFinalizeUploadStreamingDoesNotWrapS3PutInMetadataPermit(t *testing.T) {
 
 	putStarted := make(chan struct{})
 	probeUploadedBlockReuseForUploadFn = func(*db.DB, string, string) (db.BlockReuseProbe, error) {
-		return db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut}, nil
+		return db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut, StorageClass: "hot"}, nil
 	}
 	putUploadedBlockAutoDirectForUploadFn = func(_ context.Context, _ *storage.BlockStore, hash string, data []byte) (string, error) {
 		close(putStarted)
@@ -3129,7 +3184,10 @@ func TestFinalizeUploadStreamingDoesNotWrapS3PutInMetadataPermit(t *testing.T) {
 		return "commit-1", filename, 0, 0, nil
 	}
 
-	handler := NewSeafHTTPHandler(&storage.S3Store{}, nil, nil, nil, nil, nil)
+	s3Store := &storage.S3Store{}
+	storageManager := storage.NewManager()
+	storageManager.RegisterBackend("hot", s3Store, "")
+	handler := NewSeafHTTPHandler(s3Store, storageManager, nil, nil, nil, nil)
 	token := &AccessToken{OrgID: "00000000-0000-0000-0000-000000000001", RepoID: "repo1", UserID: "user1", Token: "token1"}
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
@@ -3266,7 +3324,10 @@ func finalizeUploadStreamingReuseFixture(t *testing.T, decision db.BlockReusePro
 		return "commit-1", filename, 0, 0, nil
 	}
 
-	handler := NewSeafHTTPHandler(&storage.S3Store{}, nil, nil, nil, nil, nil)
+	s3Store := &storage.S3Store{}
+	storageManager := storage.NewManager()
+	storageManager.RegisterBackend("hot", s3Store, "")
+	handler := NewSeafHTTPHandler(s3Store, storageManager, nil, nil, nil, nil)
 	token := &AccessToken{OrgID: "00000000-0000-0000-0000-000000000001", RepoID: "repo1", UserID: "user1", Token: "token1"}
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
@@ -3394,7 +3455,7 @@ func TestSeafHTTPHandlerUploadChunkedEncryptedLibraryUnlockRetryReusesTrackerAnd
 		return true, nil
 	}
 	probeUploadedBlockReuseForUploadFn = func(database *db.DB, orgID, blockID string) (db.BlockReuseProbe, error) {
-		return db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut}, nil
+		return db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut, StorageClass: "hot"}, nil
 	}
 
 	var putCalls, registerCalls, commitCalls atomic.Int32
@@ -3430,7 +3491,10 @@ func TestSeafHTTPHandlerUploadChunkedEncryptedLibraryUnlockRetryReusesTrackerAnd
 	}
 	upload.MarkQuotaPrecheck("/", 5, false)
 
-	handler := NewSeafHTTPHandler(&storage.S3Store{}, nil, nil, tokenStore, nil, nil)
+	s3Store := &storage.S3Store{}
+	storageManager := storage.NewManager()
+	storageManager.RegisterBackend("hot", s3Store, "")
+	handler := NewSeafHTTPHandler(s3Store, storageManager, nil, tokenStore, nil, nil)
 	r := gin.New()
 	r.POST("/seafhttp/upload-api/:token", handler.HandleUpload)
 
@@ -3563,7 +3627,7 @@ func TestFinalizeUploadStreamingNeedsPutUsesDirectPut(t *testing.T) {
 
 func TestFinalizeUploadStreamingRepairableStubRepairsBeforeDirectPut(t *testing.T) {
 	directPuts, reusableChecks, repairCalls, registerCalls, run := finalizeUploadStreamingReuseFixture(t,
-		db.BlockReuseProbe{Decision: db.BlockReuseRepairableStub})
+		db.BlockReuseProbe{Decision: db.BlockReuseRepairableStub, StorageClass: "hot"})
 
 	if _, err := run(); err != nil {
 		t.Fatalf("finalizeUploadStreaming error = %v, want nil", err)

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Sesame-Disk/sesamefs/internal/storage"
 	"github.com/Sesame-Disk/sesamefs/internal/streaming"
 	"github.com/Sesame-Disk/sesamefs/internal/traffic"
+	"github.com/aws/smithy-go"
 	"github.com/gin-gonic/gin"
 )
 
@@ -376,7 +377,32 @@ var syncPutBlockAutoDirectFn = func(ctx context.Context, blockStore *storage.Blo
 }
 var syncProbeUploadedBlockReuseFn = v2.ProbeUploadedBlockReuse
 var syncPrepareUploadedBlockProbeFn = v2.PrepareUploadedBlockProbe
+var syncResolveNeedsPutBlockStoreFn = v2.ResolveNeedsPutBlockStore
 var registerUploadedBlockAndMappingForSyncFn = v2.RegisterUploadedBlockAndMapping
+var syncNewCanonicalBlockReaderFn = streaming.NewCanonicalBlockReader
+var syncNewCanonicalBlockCheckReaderFn = streaming.NewCanonicalBlockCheckReader
+var syncTouchBlockLastAccessFn = func(database *db.DB, orgID, blockID string, accessedAt time.Time) {
+	_ = database.Session().Query(`
+		UPDATE blocks SET last_accessed = ? WHERE org_id = ? AND block_id = ?
+	`, accessedAt, orgID, blockID).Exec()
+}
+
+func isSyncCanonicalBlockNotFound(err error) bool {
+	if errors.Is(err, streaming.ErrCanonicalBlockMetadataNotFound) {
+		return true
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.ErrorCode() {
+	case "NoSuchKey", "NotFound":
+		return true
+	default:
+		return false
+	}
+}
 
 // formatRelativeTimeHTML delegates to httputil.FormatRelativeTimeHTML.
 var formatRelativeTimeHTML = httputil.FormatRelativeTimeHTML
@@ -1147,32 +1173,46 @@ func (h *SyncHandler) GetBlock(c *gin.Context) {
 		internalID = classifiedID.normalized
 	}
 
-	// Look up storage class from database
-	var storageClass string
+	var data []byte
 	if h.db != nil {
-		err := h.db.Session().Query(`
-			SELECT storage_class FROM blocks WHERE org_id = ? AND block_id = ?
-		`, orgID, internalID).Scan(&storageClass)
-
-		if err != nil || storageClass == "" {
-			storageClass = h.resolveBlockLookupFallbackClass(c, orgID, repoID, storageClass)
+		var fallbackStore *storage.BlockStore
+		var fallbackClass string
+		if h.storageManager == nil {
+			fallbackStore, fallbackClass, err = h.resolvePreferredBlockStore(c, orgID, repoID)
+			if err != nil || fallbackStore == nil {
+				c.JSON(http.StatusServiceUnavailable, gin.H{"error": "block storage not available"})
+				return
+			}
 		}
+		reader, resolveErr := syncNewCanonicalBlockReaderFn(c.Request.Context(), h.db, h.storageManager, orgID, []string{internalID}, fallbackStore, fallbackClass)
+		if resolveErr != nil {
+			if errors.Is(resolveErr, streaming.ErrCanonicalBlockMetadataNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "block not found"})
+			} else {
+				log.Printf("GetBlock: failed to resolve canonical block %s (internal: %s): %v", externalID, internalID, resolveErr)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to resolve block storage"})
+			}
+			return
+		}
+		data, err = reader.GetBlock(c.Request.Context(), internalID)
 	} else {
-		storageClass = h.resolveBlockLookupFallbackClass(c, orgID, repoID, storageClass)
+		// Preserve the legacy no-metadata routed fallback.
+		storageClass := h.resolveBlockLookupFallbackClass(c, orgID, repoID, "")
+		blockStore, _, resolveErr := h.resolveBlockStoreForLookup(c, orgID, repoID, storageClass)
+		if resolveErr != nil || blockStore == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "block storage not available"})
+			return
+		}
+		data, err = blockStore.GetBlock(c.Request.Context(), internalID)
 	}
-
-	blockStore, actualStorageClass, err := h.resolveBlockStoreForLookup(c, orgID, repoID, storageClass)
-	if err != nil || blockStore == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "block storage not available"})
-		return
-	}
-
-	// Retrieve block from storage using internal ID
-	data, err := blockStore.GetBlock(c.Request.Context(), internalID)
 	if err != nil {
-		log.Printf("GetBlock: block %s (internal: %s) not found in %s: %v\n",
-			externalID, internalID, actualStorageClass, err)
-		c.JSON(http.StatusNotFound, gin.H{"error": "block not found"})
+		if h.db != nil && !isSyncCanonicalBlockNotFound(err) {
+			log.Printf("GetBlock: failed to read canonical block %s (internal: %s): %v\n", externalID, internalID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read block storage"})
+		} else {
+			log.Printf("GetBlock: block %s (internal: %s) not found: %v\n", externalID, internalID, err)
+			c.JSON(http.StatusNotFound, gin.H{"error": "block not found"})
+		}
 		return
 	}
 
@@ -1194,9 +1234,7 @@ func (h *SyncHandler) GetBlock(c *gin.Context) {
 
 	// Update last accessed time (if DB available)
 	if h.db != nil {
-		_ = h.db.Session().Query(`
-			UPDATE blocks SET last_accessed = ? WHERE org_id = ? AND block_id = ?
-		`, time.Now(), orgID, internalID).Exec()
+		syncTouchBlockLastAccessFn(h.db, orgID, internalID, time.Now())
 	}
 
 	c.Data(http.StatusOK, "application/octet-stream", data)
@@ -1295,6 +1333,7 @@ func (h *SyncHandler) PutBlock(c *gin.Context) {
 		if classifiedID.isLegacySHA1 {
 			externalMappingID = classifiedID.normalized
 		}
+		materializedStorageClass := storageClass
 		// IMPORTANT: this store callback can be re-invoked by
 		// RetryUploadedBlockMaterialization (the retry path fires when store or
 		// materialize returns a retryable sentinel: ErrBlockDeleteInProgress or
@@ -1307,6 +1346,7 @@ func (h *SyncHandler) PutBlock(c *gin.Context) {
 		// branch, it MUST return a non-retryable error or the response will be
 		// written twice on retry.
 		if err := v2.RetryUploadedBlockMaterializationContext(c.Request.Context(), "PutBlock", internalID, func() error {
+			materializedStorageClass = storageClass
 			probe, probeErr := syncProbeUploadedBlockReuseFn(h.db, orgID, internalID)
 			if probeErr != nil {
 				return fmt.Errorf("probe block reuse for %s: %w", internalID, probeErr)
@@ -1317,6 +1357,7 @@ func (h *SyncHandler) PutBlock(c *gin.Context) {
 			}
 			switch probe.Decision {
 			case db.BlockReuseReusable:
+				materializedStorageClass = strings.TrimSpace(probe.StorageClass)
 				_, ensureErr := v2.EnsureReusableBlockPresent(c.Request.Context(), internalID, probe, data, h.storageManager, blockStore, storageClass, orgID)
 				return ensureErr
 			case db.BlockReuseNeedsPut:
@@ -1326,7 +1367,12 @@ func (h *SyncHandler) PutBlock(c *gin.Context) {
 						return errSyncStorageQuotaExceeded
 					}
 				}
-				if _, putErr := syncPutBlockAutoDirectFn(c.Request.Context(), blockStore, internalID, data); putErr != nil {
+				putStore, resolvedClass, _, resolveErr := syncResolveNeedsPutBlockStoreFn(h.storageManager, blockStore, storageClass, probe, orgID, internalID)
+				if resolveErr != nil {
+					return resolveErr
+				}
+				materializedStorageClass = resolvedClass
+				if _, putErr := syncPutBlockAutoDirectFn(c.Request.Context(), putStore, internalID, data); putErr != nil {
 					return fmt.Errorf("%w: %v", errSyncStoreBackend, putErr)
 				}
 				return nil
@@ -1335,7 +1381,7 @@ func (h *SyncHandler) PutBlock(c *gin.Context) {
 			}
 			return fmt.Errorf("unexpected block reuse decision %d for %s", probe.Decision, internalID)
 		}, func() error {
-			return registerUploadedBlockAndMappingForSyncFn(h.db, orgID, repoID, internalID, operationID, len(data), storageClass, "", externalMappingID)
+			return registerUploadedBlockAndMappingForSyncFn(h.db, orgID, repoID, internalID, operationID, len(data), materializedStorageClass, "", externalMappingID)
 		}, nil, nil); err != nil {
 			if errors.Is(err, v2.ErrBlockMappingWriteFailed) {
 				log.Printf("PutBlock: failed to store block mapping org=%s ext=%s int=%s: %v", orgID, externalID, internalID, err)
@@ -1497,14 +1543,33 @@ func (h *SyncHandler) CheckBlocks(c *gin.Context) {
 		internalIDs = append(internalIDs, internalID)
 	}
 
-	blockStore, _, err := h.resolvePreferredBlockStore(c, orgID, repoID)
-	if err != nil || blockStore == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "block storage not available"})
-		return
+	var existMap map[string]bool
+	if h.db != nil {
+		var fallbackStore *storage.BlockStore
+		var fallbackClass string
+		if h.storageManager == nil {
+			fallbackStore, fallbackClass, err = h.resolvePreferredBlockStore(c, orgID, repoID)
+			if err != nil || fallbackStore == nil {
+				c.JSON(http.StatusServiceUnavailable, gin.H{"error": "block storage not available"})
+				return
+			}
+		}
+		reader, resolveErr := syncNewCanonicalBlockCheckReaderFn(c.Request.Context(), h.db, h.storageManager, orgID, internalIDs, fallbackStore, fallbackClass)
+		if resolveErr != nil {
+			log.Printf("CheckBlocks: failed to resolve canonical block locations: %v", resolveErr)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check blocks"})
+			return
+		}
+		existMap, err = reader.CheckBlocksExist(c.Request.Context(), internalIDs, 10)
+	} else {
+		// Preserve the legacy no-metadata routed fallback.
+		blockStore, _, resolveErr := h.resolvePreferredBlockStore(c, orgID, repoID)
+		if resolveErr != nil || blockStore == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "block storage not available"})
+			return
+		}
+		existMap, err = blockStore.CheckBlocksParallel(c.Request.Context(), internalIDs, 10)
 	}
-
-	// Check which blocks exist using internal IDs
-	existMap, err := blockStore.CheckBlocksParallel(c.Request.Context(), internalIDs, 10)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check blocks"})
 		return

--- a/internal/api/sync_test.go
+++ b/internal/api/sync_test.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,8 +15,43 @@ import (
 
 	"github.com/Sesame-Disk/sesamefs/internal/db"
 	"github.com/Sesame-Disk/sesamefs/internal/storage"
+	"github.com/Sesame-Disk/sesamefs/internal/streaming"
+	"github.com/aws/smithy-go"
 	"github.com/gin-gonic/gin"
 )
+
+type syncCanonicalReaderStub struct {
+	data   map[string][]byte
+	exists map[string]bool
+	err    error
+}
+
+func (s *syncCanonicalReaderStub) GetBlock(_ context.Context, hash string) ([]byte, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.data[hash], nil
+}
+
+func (s *syncCanonicalReaderStub) GetBlockReader(ctx context.Context, hash string) (io.ReadCloser, error) {
+	data, err := s.GetBlock(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (s *syncCanonicalReaderStub) GetBlockSize(ctx context.Context, hash string) (int64, error) {
+	data, err := s.GetBlock(ctx, hash)
+	return int64(len(data)), err
+}
+
+func (s *syncCanonicalReaderStub) CheckBlocksExist(context.Context, []string, int) (map[string]bool, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.exists, nil
+}
 
 func init() {
 	gin.SetMode(gin.TestMode)
@@ -372,6 +409,116 @@ func TestSyncHandlerWithoutDB(t *testing.T) {
 				t.Errorf("status = %d, want %d, body: %s", w.Code, tt.wantStatus, w.Body.String())
 			}
 		})
+	}
+}
+
+func TestGetBlockUsesCanonicalReaderAndMapsResolutionErrors(t *testing.T) {
+	blockID := strings.Repeat("a", 64)
+	tests := []struct {
+		name       string
+		resolveErr error
+		readErr    error
+		wantStatus int
+		wantBody   string
+	}{
+		{name: "canonical read", wantStatus: http.StatusOK, wantBody: "canonical"},
+		{name: "missing metadata", resolveErr: streaming.ErrCanonicalBlockMetadataNotFound, wantStatus: http.StatusNotFound},
+		{name: "location failure", resolveErr: errors.New("location database unavailable"), wantStatus: http.StatusInternalServerError},
+		{name: "physical block missing", readErr: fmt.Errorf("get canonical object: %w", &smithy.GenericAPIError{Code: "NoSuchKey", Message: "missing"}), wantStatus: http.StatusNotFound},
+		{name: "backend GET failure", readErr: errors.New("storage backend unavailable"), wantStatus: http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			old := syncNewCanonicalBlockReaderFn
+			oldTouch := syncTouchBlockLastAccessFn
+			t.Cleanup(func() {
+				syncNewCanonicalBlockReaderFn = old
+				syncTouchBlockLastAccessFn = oldTouch
+			})
+			syncTouchBlockLastAccessFn = func(*db.DB, string, string, time.Time) {}
+			calls := 0
+			syncNewCanonicalBlockReaderFn = func(_ context.Context, _ *db.DB, _ *storage.Manager, orgID string, blockIDs []string, fallback *storage.BlockStore, fallbackClass string) (streaming.CanonicalBlockReader, error) {
+				calls++
+				if orgID == "" || len(blockIDs) != 1 || blockIDs[0] != blockID {
+					t.Fatalf("canonical resolution got org=%q blocks=%v", orgID, blockIDs)
+				}
+				if fallback != nil || fallbackClass != "" {
+					t.Fatalf("manager-backed canonical read got fallback=%v class=%q", fallback, fallbackClass)
+				}
+				if tt.resolveErr != nil {
+					return nil, tt.resolveErr
+				}
+				return &syncCanonicalReaderStub{
+					data: map[string][]byte{blockID: []byte("canonical")},
+					err:  tt.readErr,
+				}, nil
+			}
+
+			r := setupSyncTestRouter()
+			h := &SyncHandler{db: &db.DB{}, storageManager: storage.NewManager()}
+			r.GET("/seafhttp/repo/:repo_id/block/:block_id", h.GetBlock)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/seafhttp/repo/repo/block/"+blockID, nil))
+
+			if calls != 1 {
+				t.Fatalf("canonical constructor calls = %d, want 1", calls)
+			}
+			if w.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body=%s", w.Code, tt.wantStatus, w.Body.String())
+			}
+			if tt.wantBody != "" && w.Body.String() != tt.wantBody {
+				t.Fatalf("body = %q, want %q", w.Body.String(), tt.wantBody)
+			}
+		})
+	}
+}
+
+func TestCheckBlocksUsesCanonicalCheckReader(t *testing.T) {
+	presentID := strings.Repeat("b", 64)
+	missingID := strings.Repeat("c", 64)
+	old := syncNewCanonicalBlockCheckReaderFn
+	t.Cleanup(func() { syncNewCanonicalBlockCheckReaderFn = old })
+	calls := 0
+	syncNewCanonicalBlockCheckReaderFn = func(_ context.Context, _ *db.DB, _ *storage.Manager, _ string, blockIDs []string, _ *storage.BlockStore, _ string) (streaming.CanonicalBlockReader, error) {
+		calls++
+		if len(blockIDs) != 2 || blockIDs[0] != presentID || blockIDs[1] != missingID {
+			t.Fatalf("canonical check ids = %v", blockIDs)
+		}
+		return &syncCanonicalReaderStub{exists: map[string]bool{presentID: true, missingID: false}}, nil
+	}
+
+	r := setupSyncTestRouter()
+	h := &SyncHandler{db: &db.DB{}, storageManager: storage.NewManager()}
+	r.POST("/seafhttp/repo/:repo_id/check-blocks", h.CheckBlocks)
+	w := httptest.NewRecorder()
+	body := fmt.Sprintf(`["%s","%s"]`, presentID, missingID)
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/seafhttp/repo/repo/check-blocks", strings.NewReader(body)))
+
+	if calls != 1 {
+		t.Fatalf("canonical check constructor calls = %d, want 1", calls)
+	}
+	if w.Code != http.StatusOK || strings.TrimSpace(w.Body.String()) != fmt.Sprintf(`["%s"]`, missingID) {
+		t.Fatalf("response = %d %s, want missing block", w.Code, w.Body.String())
+	}
+}
+
+func TestCheckBlocksCanonicalResolutionFailureFailsClosed(t *testing.T) {
+	blockID := strings.Repeat("e", 64)
+	old := syncNewCanonicalBlockCheckReaderFn
+	t.Cleanup(func() { syncNewCanonicalBlockCheckReaderFn = old })
+	syncNewCanonicalBlockCheckReaderFn = func(context.Context, *db.DB, *storage.Manager, string, []string, *storage.BlockStore, string) (streaming.CanonicalBlockReader, error) {
+		return nil, errors.New("canonical storage class unavailable")
+	}
+
+	r := setupSyncTestRouter()
+	h := &SyncHandler{db: &db.DB{}, storageManager: storage.NewManager()}
+	r.POST("/seafhttp/repo/:repo_id/check-blocks", h.CheckBlocks)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/seafhttp/repo/repo/check-blocks", strings.NewReader(blockID)))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusInternalServerError, w.Body.String())
 	}
 }
 

--- a/internal/api/v2/blocks.go
+++ b/internal/api/v2/blocks.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Sesame-Disk/sesamefs/internal/metrics"
 	"github.com/Sesame-Disk/sesamefs/internal/middleware"
 	"github.com/Sesame-Disk/sesamefs/internal/storage"
+	"github.com/Sesame-Disk/sesamefs/internal/streaming"
 	"github.com/Sesame-Disk/sesamefs/internal/traffic"
 	"github.com/gin-gonic/gin"
 	"golang.org/x/sync/errgroup"
@@ -39,6 +40,8 @@ var checkBlocksProbeReuseFn = func(database *db.DB, orgID, hash string) (db.Bloc
 }
 
 var checkBlocksClassifyOwnershipFn = classifyBlockOwnership
+
+var checkBlocksNewCanonicalReaderFn = streaming.NewCanonicalBlockCheckReader
 
 // checkBlocksReusableCandidatesParallel probes the metadata plane first and
 // returns only the hashes whose blocks are logically reusable
@@ -82,8 +85,8 @@ func checkBlocksReusableCandidatesParallel(ctx context.Context, database *db.DB,
 
 // checkBlocksReadyParallel classifies, per hash already known reusable in the
 // metadata plane, whether the block is truly commit-ready for session-mode
-// /blocks/check: physically present in S3 and owned by this session or
-// permanently referenced (classifyBlockOwnership — the same helper
+// /blocks/check: physically present in its canonical store and owned by this
+// session or permanently referenced (classifyBlockOwnership — the same helper
 // file_from_blocks.go's classifyBlockForCommit uses). This is the commit's
 // classifier minus the size check (check has no declared per-block sizes to
 // compare against; sizes only arrive in the commit manifest), so a block
@@ -647,7 +650,11 @@ func dedupePreserveOrder(values []string) []string {
 
 func (h *BlockHandler) checkBlocksForSession(c *gin.Context, session db.BlockUploadSession, hashes []string) (CheckBlocksResponse, error) {
 	orgID := c.GetString("org_id")
-	uniqueHashes := dedupePreserveOrder(hashes)
+	normalizedHashes := make([]string, len(hashes))
+	for i, hash := range hashes {
+		normalizedHashes[i] = db.NormalizeBlockID(hash)
+	}
+	uniqueHashes := dedupePreserveOrder(normalizedHashes)
 	reusableByHash, reusableHashes, err := checkBlocksReusableCandidatesParallel(c.Request.Context(), h.db, orgID, uniqueHashes, blockProbeConcurrency)
 	if err != nil {
 		return CheckBlocksResponse{}, err
@@ -657,12 +664,15 @@ func (h *BlockHandler) checkBlocksForSession(c *gin.Context, session db.BlockUpl
 		return CheckBlocksResponse{Existing: nil, Missing: append([]string(nil), hashes...)}, nil
 	}
 
-	blockStore, _ := h.getBlockStoreForRepo(c, session.OrgID, session.RepoID)
+	blockStore, storageClass := h.getBlockStoreForRepo(c, session.OrgID, session.RepoID)
 	if blockStore == nil {
 		return CheckBlocksResponse{}, errSessionCheckBlockStoreUnavailable
 	}
-
-	existsMap, err := blockStore.CheckBlocksParallel(c.Request.Context(), reusableHashes, blockProbeConcurrency)
+	reader, err := checkBlocksNewCanonicalReaderFn(c.Request.Context(), h.db, h.storageManager, orgID, reusableHashes, blockStore, storageClass)
+	if err != nil {
+		return CheckBlocksResponse{}, err
+	}
+	existsMap, err := reader.CheckBlocksExist(c.Request.Context(), reusableHashes, blockProbeConcurrency)
 	if err != nil {
 		return CheckBlocksResponse{}, err
 	}
@@ -674,8 +684,9 @@ func (h *BlockHandler) checkBlocksForSession(c *gin.Context, session db.BlockUpl
 	}
 
 	var existing, missing []string
-	for _, hash := range hashes {
-		if reusableByHash[hash] && ready[hash] {
+	for i, hash := range hashes {
+		normalizedHash := normalizedHashes[i]
+		if reusableByHash[normalizedHash] && ready[normalizedHash] {
 			existing = append(existing, hash)
 		} else {
 			missing = append(missing, hash)
@@ -696,8 +707,8 @@ func (h *BlockHandler) checkBlocksForSession(c *gin.Context, session db.BlockUpl
 // mapping path now uses the same fail-closed conflict contract. isNew labels the
 // staging metric (finding 8) by whether the underlying S3 PUT was a fresh
 // write or a dedup no-op — governance work happens either way (R9).
-func (h *BlockHandler) materializeUploadedBlock(session db.BlockUploadSession, sha256ID, sha1ID string, size int, storageClass string, isNew bool) error {
-	if err := RegisterWebUploadedBlockAndMapping(h.db, session.OrgID, session.RepoID, sha256ID, session.SessionID, size, storageClass, "", sha1ID); err != nil {
+func (h *BlockHandler) materializeUploadedBlock(session db.BlockUploadSession, sha256ID, sha1ID string, size int, storageClass, storageKey string, isNew bool) error {
+	if err := RegisterWebUploadedBlockAndMapping(h.db, session.OrgID, session.RepoID, sha256ID, session.SessionID, size, storageClass, storageKey, sha1ID); err != nil {
 		return err
 	}
 	metrics.BlockUploadStagedBlocksTotal.WithLabelValues(strconv.FormatBool(isNew)).Inc()
@@ -773,13 +784,6 @@ func (h *BlockHandler) CheckBlocks(c *gin.Context) {
 		return
 	}
 
-	// Session mode (web flow, R3 + finding 3): a block counts as "existing" only
-	// when checkBlocksReadyParallel agrees it is truly commit-ready — live,
-	// physically present in S3, AND owned by this session or permanently
-	// referenced — the same classifier the commit uses (minus the size check,
-	// which check cannot evaluate without the manifest's declared sizes).
-	// Anything less is reported missing so the client (re)uploads it under the
-	// session and materializes its own reference.
 	if resolution == uploadSessionValid {
 		resp, err := h.checkBlocksForSession(c, session, req.Hashes)
 		if err != nil {
@@ -794,16 +798,19 @@ func (h *BlockHandler) CheckBlocks(c *gin.Context) {
 		return
 	}
 
-	// Get appropriate BlockStore based on hostname routing
+	normalizedHashes := make([]string, len(req.Hashes))
+	for i, hash := range req.Hashes {
+		normalizedHashes[i] = db.NormalizeBlockID(hash)
+	}
+	uniqueHashes := dedupePreserveOrder(normalizedHashes)
+	// Keep the legacy no-session oracle paired with its metadata-free upload
+	// endpoint. PR-7 will govern and canonicalize both together.
 	blockStore, _ := h.getBlockStore(c)
 	if blockStore == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "block storage not available"})
 		return
 	}
-
-	// Legacy physical-existence oracle (desktop/mobile sync, no session).
-	uniqueHashes := dedupePreserveOrder(req.Hashes)
-	existsMap, err := blockStore.CheckBlocksParallel(c.Request.Context(), uniqueHashes, 20)
+	existsMap, err := blockStore.CheckBlocksParallel(c.Request.Context(), uniqueHashes, blockProbeConcurrency)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check blocks"})
 		return
@@ -811,8 +818,8 @@ func (h *BlockHandler) CheckBlocks(c *gin.Context) {
 
 	// Separate into existing and missing
 	var existing, missing []string
-	for _, hash := range req.Hashes {
-		if existsMap[hash] {
+	for i, hash := range req.Hashes {
+		if existsMap[normalizedHashes[i]] {
 			existing = append(existing, hash)
 		} else {
 			missing = append(missing, hash)
@@ -921,7 +928,7 @@ func (h *BlockHandler) UploadBlock(c *gin.Context) {
 	// (sha1Hash above) and stores it in blocks.sha1, so there is no X-Block-Hash-SHA1
 	// to cross-check anymore.
 	clientHash := c.GetHeader("X-Block-Hash")
-	if clientHash != "" && clientHash != hash {
+	if clientHash != "" && (!isHex64(clientHash) || db.NormalizeBlockID(clientHash) != hash) {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error":         "hash mismatch",
 			"algorithm":     "sha256",
@@ -931,109 +938,104 @@ func (h *BlockHandler) UploadBlock(c *gin.Context) {
 		return
 	}
 
-	// Resolve the BlockStore. With a session, use the session repo's storage
-	// class so the block lands in the SAME backend file-from-blocks will verify
-	// for that repo (HIGH-2); otherwise use hostname/default routing.
-	var blockStore *storage.BlockStore
-	var storageClass string
+	// Session uploads probe metadata before storage so an existing placement is
+	// repaired in its canonical backend rather than the repo-preferred backend.
 	if resolution == uploadSessionValid {
-		blockStore, storageClass = h.getBlockStoreForRepo(c, session.OrgID, session.RepoID)
-	} else {
-		blockStore, storageClass = h.getBlockStore(c)
+		preferredStore, preferredClass := h.getBlockStoreForRepo(c, session.OrgID, session.RepoID)
+		if preferredStore == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "block storage not available"})
+			return
+		}
+		probe, probeErr := probeUploadedBlockReuseFn(h.db, session.OrgID, hash)
+		if probeErr == nil {
+			probe, probeErr = prepareUploadedBlockProbeFn(h.db, session.OrgID, hash, probe)
+		}
+		if probeErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to inspect block metadata"})
+			return
+		}
+
+		reservationResponded := false
+		beforePut := func() error {
+			// Per-session staged-block admission (item 1). This callback runs only
+			// when the canonical object actually needs to be written.
+			if bucketCount, bucketCap, enabled := h.stagedBlockBucketCap(session); enabled {
+				bucket := db.StagedBlockBucket(hash, bucketCount)
+				staged, reserveErr := h.db.CountSessionStagedBlocksInBucket(session.SessionID, bucket, bucketCap+1)
+				if reserveErr != nil {
+					reservationResponded = true
+					c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check staged blocks"})
+					return reserveErr
+				}
+				if staged >= bucketCap {
+					reserved, reserveErr := h.db.SessionStagedBlockExists(session.SessionID, bucket, hash)
+					if reserveErr != nil {
+						reservationResponded = true
+						c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check staged blocks"})
+						return reserveErr
+					}
+					if !reserved {
+						metrics.BlockUploadSessionAdmissionRejectionsTotal.WithLabelValues("staged_blocks").Inc()
+						c.Header("Retry-After", "1")
+						reservationResponded = true
+						c.JSON(http.StatusTooManyRequests, gin.H{"error": "session staging limit reached; commit the file or start a new upload", "code": blockUploadStagingCapReachedCode})
+						return errors.New("session staging limit reached")
+					}
+				} else if reserveErr := h.db.ReserveSessionStagedBlock(session.SessionID, bucket, hash, int64(len(data))); reserveErr != nil {
+					reservationResponded = true
+					c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to reserve staged block"})
+					return reserveErr
+				}
+			}
+			return nil
+		}
+
+		storageKey, storageClass, didPut, storeErr := StoreUploadedBlockForProbe(c.Request.Context(), hash, probe, data, h.storageManager, preferredStore, preferredClass, session.OrgID, beforePut)
+		if storeErr != nil {
+			if reservationResponded {
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to store block"})
+			return
+		}
+		if rec := traffic.Get(); rec != nil {
+			traffic.RecordCheckedTransfer(rec, uploadTrafficStatus, c.GetString("org_id"), c.GetString("user_id"), traffic.WebUpload, int64(len(data)))
+		}
+		if respondBlockMaterializeError(c, h.materializeUploadedBlock(session, hash, sha1Hash, len(data), storageClass, storageKey, didPut)) {
+			return
+		}
+		status := http.StatusOK
+		if didPut {
+			status = http.StatusCreated
+		}
+		c.JSON(status, UploadBlockResponse{Hash: hash, Size: int64(len(data)), New: didPut})
+		return
 	}
+
+	blockStore, _ := h.getBlockStore(c)
 	if blockStore == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "block storage not available"})
 		return
 	}
-
-	// Check if block already exists
 	exists, err := blockStore.BlockExists(c.Request.Context(), hash)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check block existence"})
 		return
 	}
-
 	if exists {
-		// Block already exists (deduplication) — data was still transferred over the network.
 		if rec := traffic.Get(); rec != nil {
 			traffic.RecordCheckedTransfer(rec, uploadTrafficStatus, c.GetString("org_id"), c.GetString("user_id"), traffic.WebUpload, int64(len(data)))
 		}
-		// R9: materialize even when S3 already has the object — the goal is to
-		// GOVERN the block (metadata + provisional ref) so the session can commit
-		// it and GC can reclaim it, not merely to store bytes.
-		if resolution == uploadSessionValid {
-			if respondBlockMaterializeError(c, h.materializeUploadedBlock(session, hash, sha1Hash, len(data), storageClass, false)) {
-				return
-			}
-		}
-		c.JSON(http.StatusOK, UploadBlockResponse{
-			Hash: hash,
-			Size: int64(len(data)),
-			New:  false,
-		})
+		c.JSON(http.StatusOK, UploadBlockResponse{Hash: hash, Size: int64(len(data)), New: false})
 		return
 	}
 
-	// Session (web) flow: per-session staged-block admission (item 1). This block
-	// is NEW (it did not exist above), so reserve a ledger slot BEFORE storing it
-	// (reserve-before-PUT, fail-closed): if the session's bucket is already at its
-	// cap, reject; otherwise record the reservation and proceed. The reserve is
-	// idempotent by (session, bucket, block_id) — a retried block never
-	// double-counts — and self-expires with the session TTL (no Cassandra COUNTER).
-	// If the PUT below fails after the reserve, the row lingers and TTL reclaims it.
-	if resolution == uploadSessionValid {
-		if bucketCount, bucketCap, enabled := h.stagedBlockBucketCap(session); enabled {
-			bucket := db.StagedBlockBucket(hash, bucketCount)
-			staged, err := h.db.CountSessionStagedBlocksInBucket(session.SessionID, bucket, bucketCap+1)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check staged blocks"})
-				return
-			}
-			if staged >= bucketCap {
-				// The bucket is full — but let a RETRY of an already-reserved block
-				// through (its PUT may have failed): it is already counted, so
-				// admitting it does not grow the bound. Only a genuinely new block
-				// is rejected.
-				reserved, err := h.db.SessionStagedBlockExists(session.SessionID, bucket, hash)
-				if err != nil {
-					c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check staged blocks"})
-					return
-				}
-				if !reserved {
-					metrics.BlockUploadSessionAdmissionRejectionsTotal.WithLabelValues("staged_blocks").Inc()
-					c.Header("Retry-After", "1")
-					c.JSON(http.StatusTooManyRequests, gin.H{
-						"error": "session staging limit reached; commit the file or start a new upload",
-						"code":  blockUploadStagingCapReachedCode,
-					})
-					return
-				}
-			} else if err := h.db.ReserveSessionStagedBlock(session.SessionID, bucket, hash, int64(len(data))); err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to reserve staged block"})
-				return
-			}
-		}
-	}
-
-	// Logical storage quota is NOT applied per block in the session (web) flow.
-	// R5: the user's repo/storage quota is a property of the FINAL file delta and
-	// is decided exactly once at file-from-blocks (finalizeStoredUploadMetadata) —
-	// a staged block is transient, governed by a provisional ref + TTL. Charging
-	// it here would wrongly reject e.g. a same-size overwrite (logical delta ≈ 0)
-	// at the first new block. Traffic is still charged per block (above).
-	//
-	// NOTE: this is NOT the LOGICAL quota. CheckStorageQuota reads
-	// storage_used/quota counters, not physical staging. Total uncommitted staged
-	// bytes ARE now bounded for the session flow by the per-session staged-block
-	// ledger above (item 1) plus the per-user session cap; the legacy no-session
-	// path below keeps its own per-block logical check because it predates this
-	// flow. See docs/WEB-BLOCK-UPLOAD.md.
-	if resolution != uploadSessionValid {
-		if checker := traffic.GetChecker(); checker != nil {
-			if st, _ := checker.CheckStorageQuota(c.GetString("org_id"), c.GetString("user_id"), int64(len(data))); !st.Allowed {
-				c.JSON(http.StatusForbidden, gin.H{"error": "storage quota exceeded"})
-				return
-			}
+	// The legacy no-session path retains its per-block logical quota check. Session
+	// uploads returned above and charge the final file delta only at commit.
+	if checker := traffic.GetChecker(); checker != nil {
+		if st, _ := checker.CheckStorageQuota(c.GetString("org_id"), c.GetString("user_id"), int64(len(data))); !st.Allowed {
+			c.JSON(http.StatusForbidden, gin.H{"error": "storage quota exceeded"})
+			return
 		}
 	}
 
@@ -1053,13 +1055,6 @@ func (h *BlockHandler) UploadBlock(c *gin.Context) {
 	// Record traffic for newly stored block.
 	if rec := traffic.Get(); rec != nil {
 		traffic.RecordCheckedTransfer(rec, uploadTrafficStatus, c.GetString("org_id"), c.GetString("user_id"), traffic.WebUpload, int64(len(data)))
-	}
-
-	// R9: govern the freshly stored block under the session.
-	if resolution == uploadSessionValid {
-		if respondBlockMaterializeError(c, h.materializeUploadedBlock(session, hash, sha1Hash, len(data), storageClass, true)) {
-			return
-		}
 	}
 
 	c.JSON(http.StatusCreated, UploadBlockResponse{

--- a/internal/api/v2/blocks_test.go
+++ b/internal/api/v2/blocks_test.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -16,11 +18,36 @@ import (
 	"github.com/Sesame-Disk/sesamefs/internal/config"
 	"github.com/Sesame-Disk/sesamefs/internal/db"
 	"github.com/Sesame-Disk/sesamefs/internal/storage"
+	"github.com/Sesame-Disk/sesamefs/internal/streaming"
 	"github.com/gin-gonic/gin"
 )
 
 func init() {
 	gin.SetMode(gin.TestMode)
+}
+
+type checkBlocksTestCanonicalReader struct {
+	exists map[string]bool
+	err    error
+}
+
+func (r *checkBlocksTestCanonicalReader) CheckBlocksExist(context.Context, []string, int) (map[string]bool, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.exists, nil
+}
+
+func (*checkBlocksTestCanonicalReader) GetBlock(context.Context, string) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (*checkBlocksTestCanonicalReader) GetBlockReader(context.Context, string) (io.ReadCloser, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (*checkBlocksTestCanonicalReader) GetBlockSize(context.Context, string) (int64, error) {
+	return 0, errors.New("not implemented")
 }
 
 func TestCheckBlocks_InvalidJSON(t *testing.T) {
@@ -121,13 +148,14 @@ func TestCheckBlocks_InvalidSHA256(t *testing.T) {
 }
 
 func TestCheckBlocks_NilBlockStore(t *testing.T) {
+	hash := strings.Repeat("a", 64)
 	r := gin.New()
 	r.Use(gin.Recovery())
 
 	h := &BlockHandler{storageManager: nil, config: nil}
 	r.POST("/api/v2/blocks/check", h.CheckBlocks)
 
-	body := CheckBlocksRequest{Hashes: []string{strings.Repeat("a", 64)}}
+	body := CheckBlocksRequest{Hashes: []string{hash}}
 	jsonBody, _ := json.Marshal(body)
 	req, _ := http.NewRequest("POST", "/api/v2/blocks/check", bytes.NewBuffer(jsonBody))
 	req.Header.Set("Content-Type", "application/json")
@@ -422,7 +450,132 @@ func TestCheckBlocksReusableCandidatesParallel_ProbesMetadataFirst(t *testing.T)
 	}
 }
 
-func TestCheckBlocksReadyParallel_OnlyChecksOwnershipForPhysicallyPresentCandidates(t *testing.T) {
+func TestCheckBlocks_NoSessionUsesLegacyStoreAndNormalizesHashes(t *testing.T) {
+	origNewReader := checkBlocksNewCanonicalReaderFn
+	t.Cleanup(func() { checkBlocksNewCanonicalReaderFn = origNewReader })
+	var canonicalReaderCalls atomic.Int32
+	checkBlocksNewCanonicalReaderFn = func(context.Context, *db.DB, *storage.Manager, string, []string, *storage.BlockStore, string) (streaming.CanonicalBlockReader, error) {
+		canonicalReaderCalls.Add(1)
+		return nil, errors.New("no-session check must remain paired with legacy upload")
+	}
+
+	const orgID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+	existingHash := strings.Repeat("a", 64)
+	uppercaseExistingHash := strings.ToUpper(existingHash)
+	missingHash := strings.Repeat("b", 64)
+	wantExistingPath := "/test-bucket/blocks/" + orgID + "/aa/aa/" + existingHash
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead && r.URL.Path == wantExistingPath {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+	s3Store, err := storage.NewS3Store(context.Background(), storage.S3Config{
+		Endpoint: server.URL, Bucket: "test-bucket", Region: "us-east-1",
+		AccessKeyID: "test", SecretAccessKey: "test", UsePathStyle: true,
+	})
+	if err != nil {
+		t.Fatalf("NewS3Store() error = %v", err)
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("org_id", orgID)
+		c.Next()
+	})
+	r.POST("/api/v2/blocks/check", (&BlockHandler{db: &db.DB{}, storage: s3Store}).CheckBlocks)
+	body, _ := json.Marshal(CheckBlocksRequest{Hashes: []string{uppercaseExistingHash, missingHash, existingHash, missingHash}})
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/blocks/check", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", w.Code, w.Body.String())
+	}
+	if canonicalReaderCalls.Load() != 0 {
+		t.Fatalf("canonical reader calls = %d, want 0 for no-session flow", canonicalReaderCalls.Load())
+	}
+	var response CheckBlocksResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	wantExisting := []string{uppercaseExistingHash, existingHash}
+	wantMissing := []string{missingHash, missingHash}
+	if fmt.Sprint(response.Existing) != fmt.Sprint(wantExisting) {
+		t.Fatalf("existing = %v, want %v", response.Existing, wantExisting)
+	}
+	if fmt.Sprint(response.Missing) != fmt.Sprint(wantMissing) {
+		t.Fatalf("missing = %v, want %v", response.Missing, wantMissing)
+	}
+}
+
+func TestCheckBlocks_NoSessionNilDBUsesOrgScopedPreferredStore(t *testing.T) {
+	origNewReader := checkBlocksNewCanonicalReaderFn
+	t.Cleanup(func() { checkBlocksNewCanonicalReaderFn = origNewReader })
+	var canonicalReaderCalls atomic.Int32
+	checkBlocksNewCanonicalReaderFn = func(context.Context, *db.DB, *storage.Manager, string, []string, *storage.BlockStore, string) (streaming.CanonicalBlockReader, error) {
+		canonicalReaderCalls.Add(1)
+		return nil, errors.New("canonical reader must not be constructed without a DB")
+	}
+
+	const orgID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+	existingHash := strings.Repeat("a", 64)
+	missingHash := strings.Repeat("b", 64)
+	wantExistingPath := "/test-bucket/blocks/" + orgID + "/aa/aa/" + existingHash
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead && r.URL.Path == wantExistingPath {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	s3Store, err := storage.NewS3Store(context.Background(), storage.S3Config{
+		Endpoint:        server.URL,
+		Bucket:          "test-bucket",
+		Region:          "us-east-1",
+		AccessKeyID:     "test",
+		SecretAccessKey: "test",
+		UsePathStyle:    true,
+	})
+	if err != nil {
+		t.Fatalf("NewS3Store() error = %v", err)
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("org_id", orgID)
+		c.Next()
+	})
+	r.POST("/api/v2/blocks/check", (&BlockHandler{storage: s3Store}).CheckBlocks)
+	body, _ := json.Marshal(CheckBlocksRequest{Hashes: []string{existingHash, missingHash, existingHash}})
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/blocks/check", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", w.Code, w.Body.String())
+	}
+	if canonicalReaderCalls.Load() != 0 {
+		t.Fatalf("canonical reader calls = %d, want 0 without a DB", canonicalReaderCalls.Load())
+	}
+	var response CheckBlocksResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := fmt.Sprint(response.Existing), fmt.Sprint([]string{existingHash, existingHash}); got != want {
+		t.Fatalf("existing = %v, want duplicates in request order", response.Existing)
+	}
+	if got, want := fmt.Sprint(response.Missing), fmt.Sprint([]string{missingHash}); got != want {
+		t.Fatalf("missing = %v, want %v", response.Missing, []string{missingHash})
+	}
+}
+
+func TestCheckBlocksReadyParallel_UsesCanonicalExistenceBeforeOwnership(t *testing.T) {
 	origClassify := checkBlocksClassifyOwnershipFn
 	defer func() {
 		checkBlocksClassifyOwnershipFn = origClassify
@@ -453,7 +606,75 @@ func TestCheckBlocksReadyParallel_OnlyChecksOwnershipForPhysicallyPresentCandida
 		t.Fatal("missing block reported ready")
 	}
 	if !ready["present"] {
-		t.Fatal("present reusable block should be ready")
+		t.Fatal("block present in the canonical store and owned by the session should be ready")
+	}
+}
+
+func TestCheckBlocksForSession_UsesCanonicalStoreBeforeOwnership(t *testing.T) {
+	origProbe := checkBlocksProbeReuseFn
+	origClassify := checkBlocksClassifyOwnershipFn
+	origNewReader := checkBlocksNewCanonicalReaderFn
+	t.Cleanup(func() {
+		checkBlocksProbeReuseFn = origProbe
+		checkBlocksClassifyOwnershipFn = origClassify
+		checkBlocksNewCanonicalReaderFn = origNewReader
+	})
+	checkBlocksProbeReuseFn = func(*db.DB, string, string) (db.BlockReuseProbe, error) {
+		return db.BlockReuseProbe{Decision: db.BlockReuseReusable, StorageClass: "canonical"}, nil
+	}
+
+	const orgID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+	existingHash := strings.Repeat("a", 64)
+	missingHash := strings.Repeat("b", 64)
+	checkBlocksNewCanonicalReaderFn = func(_ context.Context, _ *db.DB, _ *storage.Manager, gotOrgID string, hashes []string, fallback *storage.BlockStore, fallbackClass string) (streaming.CanonicalBlockReader, error) {
+		if gotOrgID != orgID || fallback == nil || fallbackClass != "legacy" {
+			return nil, fmt.Errorf("unexpected canonical routing: org=%q fallback=%p class=%q", gotOrgID, fallback, fallbackClass)
+		}
+		if len(hashes) != 2 || !slices.Contains(hashes, existingHash) || !slices.Contains(hashes, missingHash) {
+			return nil, fmt.Errorf("canonical hashes = %v, want both reusable hashes", hashes)
+		}
+		return &checkBlocksTestCanonicalReader{exists: map[string]bool{existingHash: true, missingHash: false}}, nil
+	}
+
+	var ownershipCalls atomic.Int32
+	checkBlocksClassifyOwnershipFn = func(_ *db.DB, gotOrgID, referrer, blockID string) (bool, error) {
+		ownershipCalls.Add(1)
+		if gotOrgID != orgID || referrer != db.BlockReferrerForUpload("sess-1") || blockID != existingHash {
+			return false, fmt.Errorf("unexpected ownership classification: org=%q referrer=%q block=%q", gotOrgID, referrer, blockID)
+		}
+		return true, nil
+	}
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+	s3Store, err := storage.NewS3Store(context.Background(), storage.S3Config{
+		Endpoint: server.URL, Bucket: "test-bucket", Region: "us-east-1",
+		AccessKeyID: "test", SecretAccessKey: "test", UsePathStyle: true,
+	})
+	if err != nil {
+		t.Fatalf("NewS3Store() error = %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v2/blocks/check", nil)
+	c.Set("org_id", orgID)
+	h := &BlockHandler{storage: s3Store, db: &db.DB{}}
+	response, err := h.checkBlocksForSession(c, db.BlockUploadSession{
+		SessionID: "sess-1",
+		OrgID:     orgID,
+		RepoID:    "repo-1",
+	}, []string{existingHash, missingHash, existingHash})
+	if err != nil {
+		t.Fatalf("checkBlocksForSession() error = %v", err)
+	}
+	if ownershipCalls.Load() != 1 {
+		t.Fatalf("ownership calls = %d, want 1 for the physically present canonical candidate", ownershipCalls.Load())
+	}
+	if got, want := fmt.Sprint(response.Existing), fmt.Sprint([]string{existingHash, existingHash}); got != want {
+		t.Fatalf("existing = %v, want %v", response.Existing, []string{existingHash, existingHash})
+	}
+	if got, want := fmt.Sprint(response.Missing), fmt.Sprint([]string{missingHash}); got != want {
+		t.Fatalf("missing = %v, want %v", response.Missing, []string{missingHash})
 	}
 }
 
@@ -671,7 +892,7 @@ func TestUploadBlockMaterializePropagatesFence(t *testing.T) {
 
 	h := &BlockHandler{}
 	session := db.BlockUploadSession{SessionID: "sess-1", OrgID: "org-1", RepoID: "repo-1"}
-	err := h.materializeUploadedBlock(session, strings.Repeat("a", 64), strings.Repeat("b", 40), 5, "hot", true)
+	err := h.materializeUploadedBlock(session, strings.Repeat("a", 64), strings.Repeat("b", 40), 5, "hot", "blocks/org/a", true)
 	if !errors.Is(err, ErrBlockDeleteInProgress) {
 		t.Fatalf("materializeUploadedBlock err = %v, want ErrBlockDeleteInProgress propagated", err)
 	}

--- a/internal/api/v2/canonical_reads_test.go
+++ b/internal/api/v2/canonical_reads_test.go
@@ -1,0 +1,154 @@
+package v2
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestFileViewCanonicalReadRouting(t *testing.T) {
+	targets := map[string]map[string]canonicalReadExpectations{
+		"fileview.go": {
+			"ServeRawFile":         {constructors: 2, batchResolutions: 2, directReaderCalls: 1, sizeQueries: 1, readSeekers: 1, streams: 1},
+			"DownloadHistoricFile": {constructors: 1, batchResolutions: 1, streams: 1},
+			"ServeHistoricFileRaw": {constructors: 1, batchResolutions: 1, streams: 1},
+		},
+		"sharelink_view.go": {
+			"handleShareLinkRaw":    {constructors: 1, batchResolutions: 1, sizeQueries: 1, readSeekers: 1, streams: 1},
+			"readFileContentAsText": {constructors: 1, batchResolutions: 1, directBlockCalls: 2},
+		},
+	}
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to resolve current file path")
+	}
+	pkgDir := filepath.Dir(thisFile)
+
+	for filename, functions := range targets {
+		t.Run(filename, func(t *testing.T) {
+			fset := token.NewFileSet()
+			fileNode, err := parser.ParseFile(fset, filepath.Join(pkgDir, filename), nil, 0)
+			if err != nil {
+				t.Fatalf("parse %s: %v", filename, err)
+			}
+
+			for functionName, want := range functions {
+				t.Run(functionName, func(t *testing.T) {
+					fn := findFunction(t, fileNode, functionName)
+					assertCanonicalReadRouting(t, fn, want)
+				})
+			}
+		})
+	}
+}
+
+type canonicalReadExpectations struct {
+	constructors      int
+	batchResolutions  int
+	directReaderCalls int
+	directBlockCalls  int
+	sizeQueries       int
+	readSeekers       int
+	streams           int
+}
+
+func findFunction(t *testing.T, fileNode *ast.File, name string) *ast.FuncDecl {
+	t.Helper()
+	for _, decl := range fileNode.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == name {
+			return fn
+		}
+	}
+	t.Fatalf("function %s not found", name)
+	return nil
+}
+
+func assertCanonicalReadRouting(t *testing.T, fn *ast.FuncDecl, want canonicalReadExpectations) {
+	t.Helper()
+	var got canonicalReadExpectations
+	var lastBatchPosition token.Pos
+
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		receiver, _ := selector.X.(*ast.Ident)
+		switch selector.Sel.Name {
+		case "BatchResolveBlockIDs":
+			if receiver != nil && receiver.Name == "streaming" {
+				got.batchResolutions++
+				lastBatchPosition = call.Pos()
+			}
+		case "NewCanonicalBlockReader":
+			if receiver == nil || receiver.Name != "streaming" {
+				break
+			}
+			got.constructors++
+			if lastBatchPosition == token.NoPos || lastBatchPosition > call.Pos() {
+				t.Errorf("NewCanonicalBlockReader must follow BatchResolveBlockIDs")
+			}
+			assertIdentifierArgument(t, call, 5, "blockStore")
+			assertIdentifierArgument(t, call, 6, "blockStoreClass")
+		case "GetBlockReader":
+			got.directReaderCalls++
+			if receiver == nil || receiver.Name != "canonicalReader" {
+				t.Errorf("GetBlockReader receiver = %v, want canonicalReader", selector.X)
+			}
+		case "GetBlock":
+			got.directBlockCalls++
+			if receiver == nil || receiver.Name != "canonicalReader" {
+				t.Errorf("GetBlock receiver = %v, want canonicalReader", selector.X)
+			}
+		case "QueryBlockSizes":
+			if receiver != nil && receiver.Name == "streaming" {
+				got.sizeQueries++
+				assertIdentifierArgument(t, call, 3, "canonicalReader")
+			}
+		case "NewBlockReadSeeker":
+			if receiver != nil && receiver.Name == "streaming" {
+				got.readSeekers++
+				assertIdentifierArgument(t, call, 1, "canonicalReader")
+			}
+		case "StreamBlocks":
+			if receiver != nil && receiver.Name == "streaming" {
+				got.streams++
+				assertIdentifierArgument(t, call, 2, "canonicalReader")
+			}
+		}
+		return true
+	})
+
+	if got != want {
+		t.Errorf("canonical read call counts = %+v, want %+v", got, want)
+	}
+}
+
+func assertIdentifierArgument(t *testing.T, call *ast.CallExpr, index int, want string) {
+	t.Helper()
+	if len(call.Args) <= index {
+		t.Errorf("%s call has %d arguments, want argument %d", callName(call), len(call.Args), index)
+		return
+	}
+	identifier, ok := call.Args[index].(*ast.Ident)
+	if !ok || identifier.Name != want {
+		t.Errorf("%s argument %d = %T, want identifier %s", callName(call), index, call.Args[index], want)
+	}
+}
+
+func callName(call *ast.CallExpr) string {
+	if selector, ok := call.Fun.(*ast.SelectorExpr); ok {
+		return selector.Sel.Name
+	}
+	return "call"
+}

--- a/internal/api/v2/file_from_blocks.go
+++ b/internal/api/v2/file_from_blocks.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Sesame-Disk/sesamefs/internal/db"
 	"github.com/Sesame-Disk/sesamefs/internal/metrics"
+	"github.com/Sesame-Disk/sesamefs/internal/streaming"
 	"github.com/Sesame-Disk/sesamefs/internal/traffic"
 	"github.com/gin-gonic/gin"
 	"golang.org/x/sync/errgroup"
@@ -180,6 +181,8 @@ func validateManifest(req *fileFromBlocksRequest, blockSize int64) error {
 		if !isHex64(b.SHA256) {
 			return fmt.Errorf("block %d: invalid sha256", i)
 		}
+		b.SHA256 = db.NormalizeBlockID(b.SHA256)
+		req.Blocks[i].SHA256 = b.SHA256
 		if prev, ok := sizeSeen[b.SHA256]; ok && prev != b.Size {
 			return fmt.Errorf("block %d: sha256 %s declared with conflicting sizes (%d and %d)", i, b.SHA256, prev, b.Size)
 		}
@@ -322,11 +325,12 @@ func (h *FileHandler) CreateFileFromBlocks(c *gin.Context) {
 		return
 	}
 
-	// Resolve the block store so we can confirm PHYSICAL presence per block.
+	// Resolve the preferred block store only as the single-store fallback. Each
+	// block's metadata determines the canonical backend checked below.
 	// ProbeBlockReuse proves liveness/governance but not that the S3 object still
 	// exists (metadata can outlive a lost object); a commit must require both, or
 	// it could publish a file pointing at a missing block.
-	blockStore, _, err := h.resolveLibraryBlockStore(c, orgID, repoID)
+	blockStore, blockStoreClass, err := h.resolveLibraryBlockStore(c, orgID, repoID)
 	if err != nil || blockStore == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "block storage not available"})
 		return
@@ -339,7 +343,13 @@ func (h *FileHandler) CreateFileFromBlocks(c *gin.Context) {
 		}
 		sizeByHash[b.SHA256] = b.Size
 	}
-	existsMap, err := blockStore.CheckBlocksParallel(c.Request.Context(), uniqueHashes, blockVerifyConcurrency)
+	canonicalReader, err := streaming.NewCanonicalBlockCheckReader(c.Request.Context(), h.db, h.storageManager, orgID, uniqueHashes, blockStore, blockStoreClass)
+	if err != nil {
+		metrics.BlockUploadVerifyErrorsTotal.WithLabelValues("presence").Inc()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to resolve block placement"})
+		return
+	}
+	existsMap, err := canonicalReader.CheckBlocksExist(c.Request.Context(), uniqueHashes, blockVerifyConcurrency)
 	if err != nil {
 		metrics.BlockUploadVerifyErrorsTotal.WithLabelValues("presence").Inc()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to verify block presence"})

--- a/internal/api/v2/file_from_blocks_test.go
+++ b/internal/api/v2/file_from_blocks_test.go
@@ -102,6 +102,24 @@ func TestValidateManifest_RejectsConflictingSizeForSameSHA256(t *testing.T) {
 	}
 }
 
+func TestValidateManifest_NormalizesSHA256BeforeDuplicateValidation(t *testing.T) {
+	hash := hex64(7)
+	req := &fileFromBlocksRequest{
+		Filename: "f.bin",
+		Size:     WebUploadBlockSize * 2,
+		Blocks: []fileFromBlocksBlock{
+			{SHA256: strings.ToUpper(hash), Size: WebUploadBlockSize},
+			{SHA256: hash, Size: WebUploadBlockSize - 1},
+		},
+	}
+	if err := validateManifest(req, WebUploadBlockSize); err == nil {
+		t.Fatal("mixed-case duplicate with conflicting sizes must be rejected")
+	}
+	if req.Blocks[0].SHA256 != hash {
+		t.Fatalf("normalized sha256 = %q, want %q", req.Blocks[0].SHA256, hash)
+	}
+}
+
 func TestValidateManifest_HonorsConfiguredBlockSize(t *testing.T) {
 	// The non-final block size is validated against the CONFIGURED CAS block size,
 	// not a hardcoded 8 MB. With a 4 MB configured size, a 4 MB non-final block is

--- a/internal/api/v2/files.go
+++ b/internal/api/v2/files.go
@@ -1252,6 +1252,7 @@ func (h *FileHandler) CreateFile(c *gin.Context) {
 	// same bytes on later CAS retries.
 	var templateBlockStore *storage.BlockStore
 	var templateStorageClass string
+	var templateMaterializedStorageClass string
 	var templateBlockStored bool
 
 	if len(templateContent) > 0 {
@@ -1336,11 +1337,13 @@ func (h *FileHandler) CreateFile(c *gin.Context) {
 				}
 				templateBlockStore = blockStore
 				templateStorageClass = storageClass
+				templateMaterializedStorageClass = storageClass
 			}
 			if err := retryCreateFileTemplateBlockMaterialization(func() error {
 				if templateBlockStored {
 					return nil
 				}
+				templateMaterializedStorageClass = templateStorageClass
 				probe, probeErr := probeUploadedBlockReuseFn(h.db, orgID, templateBlockData.Hash)
 				if probeErr != nil {
 					return fmt.Errorf("probe template block reuse for %s: %w", templateBlockData.Hash, probeErr)
@@ -1351,13 +1354,19 @@ func (h *FileHandler) CreateFile(c *gin.Context) {
 				}
 				switch probe.Decision {
 				case db.BlockReuseReusable:
+					templateMaterializedStorageClass = strings.TrimSpace(probe.StorageClass)
 					if _, ensureErr := EnsureReusableBlockPresent(c.Request.Context(), templateBlockData.Hash, probe, templateBlockData.Data, h.storageManager, templateBlockStore, templateStorageClass, orgID); ensureErr != nil {
 						return fmt.Errorf("failed to verify reusable template block: %w", ensureErr)
 					}
 					templateBlockStored = true
 					return nil
 				case db.BlockReuseNeedsPut:
-					if _, err := putUploadedBlockAutoDirectFn(c.Request.Context(), templateBlockStore, templateBlockData.Hash, templateBlockData.Data); err != nil {
+					putStore, resolvedClass, _, resolveErr := ResolveNeedsPutBlockStore(h.storageManager, templateBlockStore, templateStorageClass, probe, orgID, templateBlockData.Hash)
+					if resolveErr != nil {
+						return resolveErr
+					}
+					templateMaterializedStorageClass = resolvedClass
+					if _, err := putUploadedBlockAutoDirectFn(c.Request.Context(), putStore, templateBlockData.Hash, templateBlockData.Data); err != nil {
 						return fmt.Errorf("failed to store file content: %w", err)
 					}
 					templateBlockStored = true
@@ -1374,7 +1383,7 @@ func (h *FileHandler) CreateFile(c *gin.Context) {
 				// blocks.sha1 are written from the real bytes — required for desktop
 				// downloads (which fetch by SHA-1) and for staging to resolve the
 				// fs_object's SHA-1 block id back to its storage identity.
-				if err := RegisterUploadedBlockAndMapping(h.db, orgID, repoID, templateBlockData.Hash, uploadOperationID, int(fileSize), templateStorageClass, "", externalBlockID); err != nil {
+				if err := RegisterUploadedBlockAndMapping(h.db, orgID, repoID, templateBlockData.Hash, uploadOperationID, int(fileSize), templateMaterializedStorageClass, "", externalBlockID); err != nil {
 					return fmt.Errorf("failed to register template block metadata: %w", err)
 				}
 				templateBlockPinned = true
@@ -3437,7 +3446,9 @@ func (h *FileHandler) UploadFile(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "storage not available"})
 		return
 	}
+	materializedStorageClass := storageClass
 	if err := RetryUploadedBlockMaterializationContext(c.Request.Context(), "UploadFile", sha256ID, func() error {
+		materializedStorageClass = storageClass
 		probe, probeErr := probeUploadedBlockReuseFn(h.db, orgID, sha256ID)
 		if probeErr != nil {
 			return fmt.Errorf("probe block reuse for %s: %w", sha256ID, probeErr)
@@ -3448,10 +3459,16 @@ func (h *FileHandler) UploadFile(c *gin.Context) {
 		}
 		switch probe.Decision {
 		case db.BlockReuseReusable:
+			materializedStorageClass = strings.TrimSpace(probe.StorageClass)
 			_, ensureErr := EnsureReusableBlockPresent(c.Request.Context(), sha256ID, probe, storedContent, h.storageManager, blockStore, storageClass, orgID)
 			return ensureErr
 		case db.BlockReuseNeedsPut:
-			if _, putErr := putUploadedBlockAutoDirectFn(c.Request.Context(), blockStore, sha256ID, storedContent); putErr != nil {
+			putStore, resolvedClass, _, resolveErr := ResolveNeedsPutBlockStore(h.storageManager, blockStore, storageClass, probe, orgID, sha256ID)
+			if resolveErr != nil {
+				return resolveErr
+			}
+			materializedStorageClass = resolvedClass
+			if _, putErr := putUploadedBlockAutoDirectFn(c.Request.Context(), putStore, sha256ID, storedContent); putErr != nil {
 				return fmt.Errorf("failed to store block: %w", putErr)
 			}
 			return nil
@@ -3463,7 +3480,7 @@ func (h *FileHandler) UploadFile(c *gin.Context) {
 		// Register block metadata + a provisional reference (kept alive by TTL until
 		// the fs_object commit below creates the permanent reference), then write the
 		// external SHA-1 mapping only after the block is durable in Cassandra.
-		return RegisterUploadedBlockAndMapping(h.db, orgID, repoID, sha256ID, uploadOperationID, len(storedContent), storageClass, "", fileID)
+		return RegisterUploadedBlockAndMapping(h.db, orgID, repoID, sha256ID, uploadOperationID, len(storedContent), materializedStorageClass, "", fileID)
 	}, nil, nil); err != nil {
 		log.Printf("[UploadFile] CRITICAL: failed to materialize block org=%s block=%s ext=%s: %v", orgID, sha256ID[:16], fileID[:16], err)
 		if errors.Is(err, ErrBlockDeleteInProgress) {

--- a/internal/api/v2/fileview.go
+++ b/internal/api/v2/fileview.go
@@ -554,7 +554,7 @@ func (h *FileViewHandler) ServeRawFile(c *gin.Context) {
 	}
 
 	// Get block store
-	blockStore, _, err := resolveLibraryBlockStoreForRequest(c, h.db, h.config, h.storageManager, h.storage, orgID, repoID)
+	blockStore, blockStoreClass, err := resolveLibraryBlockStoreForRequest(c, h.db, h.config, h.storageManager, h.storage, orgID, repoID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "storage not available"})
 		return
@@ -601,9 +601,15 @@ func (h *FileViewHandler) ServeRawFile(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read file"})
 			return
 		}
+		canonicalReader, err := streaming.NewCanonicalBlockReader(ctx, h.db, h.storageManager, orgID, iworkResolvedIDs, blockStore, blockStoreClass)
+		if err != nil {
+			log.Printf("[ServeRawFile] canonical block reader construction failed for org=%s: %v", orgID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read file"})
+			return
+		}
 		for idx, _ := range blockIDs {
 			internalID := iworkResolvedIDs[idx]
-			reader, err := blockStore.GetBlockReader(ctx, internalID)
+			reader, err := canonicalReader.GetBlockReader(ctx, internalID)
 			if err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read file"})
 				return
@@ -664,6 +670,12 @@ func (h *FileViewHandler) ServeRawFile(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read file"})
 		return
 	}
+	canonicalReader, err := streaming.NewCanonicalBlockReader(ctx, h.db, h.storageManager, orgID, resolvedIDs, blockStore, blockStoreClass)
+	if err != nil {
+		log.Printf("[ServeRawFile] canonical block reader construction failed for org=%s: %v", orgID, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read file"})
+		return
+	}
 
 	var fileKeyParam []byte
 	var fileIVParam []byte
@@ -675,14 +687,14 @@ func (h *FileViewHandler) ServeRawFile(c *gin.Context) {
 	// For video/audio files, use BlockReadSeeker so http.ServeContent can handle
 	// Range requests (HTTP 206) without buffering the entire file. Only O(1 block) RAM.
 	if isVideoFile(ext) || isAudioFile(ext) {
-		blockSizes, err := streaming.QueryBlockSizes(ctx, h.db, orgID, blockStore, resolvedIDs)
+		blockSizes, err := streaming.QueryBlockSizes(ctx, h.db, orgID, canonicalReader, resolvedIDs)
 		if err != nil {
 			log.Printf("[ServeRawFile] Failed to query block sizes: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read file metadata"})
 			return
 		}
 
-		rs := streaming.NewBlockReadSeeker(ctx, blockStore, resolvedIDs, blockSizes, fileSize, fileKeyParam, fileIVParam)
+		rs := streaming.NewBlockReadSeeker(ctx, canonicalReader, resolvedIDs, blockSizes, fileSize, fileKeyParam, fileIVParam)
 		c.Header("Content-Disposition", resolveContentDisposition(ext, filename))
 		c.Header("Content-Type", mimeType)
 		http.ServeContent(c.Writer, c.Request, filename, time.Time{}, rs)
@@ -697,7 +709,7 @@ func (h *FileViewHandler) ServeRawFile(c *gin.Context) {
 	}
 	c.Status(http.StatusOK)
 
-	streaming.StreamBlocks(c, ctx, blockStore, resolvedIDs, fileKeyParam, fileIVParam, "ServeRawFile")
+	streaming.StreamBlocks(c, ctx, canonicalReader, resolvedIDs, fileKeyParam, fileIVParam, "ServeRawFile")
 }
 
 // sanitizeFilename removes characters that could cause header injection in Content-Disposition.
@@ -974,7 +986,7 @@ func (h *FileViewHandler) DownloadHistoricFile(c *gin.Context) {
 		return
 	}
 
-	blockStore, _, err := resolveLibraryBlockStoreForRequest(c, h.db, h.config, h.storageManager, h.storage, orgID, repoID)
+	blockStore, blockStoreClass, err := resolveLibraryBlockStoreForRequest(c, h.db, h.config, h.storageManager, h.storage, orgID, repoID)
 	if err != nil {
 		log.Printf("[DownloadHistoricFile] Block store not available: %v", err)
 		redirectToFrontendErrorPage(c, http.StatusInternalServerError, "Internal Error", "Block storage not available.")
@@ -998,6 +1010,12 @@ func (h *FileViewHandler) DownloadHistoricFile(c *gin.Context) {
 		redirectToFrontendErrorPage(c, http.StatusInternalServerError, "Internal Error", "Could not read the requested file revision.")
 		return
 	}
+	canonicalReader, err := streaming.NewCanonicalBlockReader(c.Request.Context(), h.db, h.storageManager, orgID, resolvedIDs, blockStore, blockStoreClass)
+	if err != nil {
+		log.Printf("[DownloadHistoricFile] canonical block reader construction failed for org=%s: %v", orgID, err)
+		redirectToFrontendErrorPage(c, http.StatusInternalServerError, "Internal Error", "Could not read the requested file revision.")
+		return
+	}
 
 	// Stream blocks directly to HTTP response
 	c.Header("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, sanitizeFilename(filename)))
@@ -1005,7 +1023,7 @@ func (h *FileViewHandler) DownloadHistoricFile(c *gin.Context) {
 	c.Status(http.StatusOK)
 
 	bytesBefore := int64(c.Writer.Size())
-	streaming.StreamBlocks(c, c.Request.Context(), blockStore, resolvedIDs, fileKey, fileIV, "DownloadHistoricFile")
+	streaming.StreamBlocks(c, c.Request.Context(), canonicalReader, resolvedIDs, fileKey, fileIV, "DownloadHistoricFile")
 
 	// Record download traffic using actual bytes written.
 	if rec := traffic.Get(); rec != nil {
@@ -1155,7 +1173,7 @@ func (h *FileViewHandler) ServeHistoricFileRaw(c *gin.Context) {
 		return
 	}
 
-	blockStore, _, err := resolveLibraryBlockStoreForRequest(c, h.db, h.config, h.storageManager, h.storage, orgID, repoID)
+	blockStore, blockStoreClass, err := resolveLibraryBlockStoreForRequest(c, h.db, h.config, h.storageManager, h.storage, orgID, repoID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "storage not available"})
 		return
@@ -1181,6 +1199,12 @@ func (h *FileViewHandler) ServeHistoricFileRaw(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read file"})
 		return
 	}
+	canonicalReader, err := streaming.NewCanonicalBlockReader(c.Request.Context(), h.db, h.storageManager, orgID, resolvedIDs, blockStore, blockStoreClass)
+	if err != nil {
+		log.Printf("[ServeHistoricFileRaw] canonical block reader construction failed for org=%s: %v", orgID, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read file"})
+		return
+	}
 
 	// Determine MIME type
 	mimeType := resolveInlineContentType(ext)
@@ -1192,5 +1216,5 @@ func (h *FileViewHandler) ServeHistoricFileRaw(c *gin.Context) {
 	}
 	c.Status(http.StatusOK)
 
-	streaming.StreamBlocks(c, c.Request.Context(), blockStore, resolvedIDs, fileKey, fileIV, "ServeHistoricFileRaw")
+	streaming.StreamBlocks(c, c.Request.Context(), canonicalReader, resolvedIDs, fileKey, fileIV, "ServeHistoricFileRaw")
 }

--- a/internal/api/v2/onlyoffice.go
+++ b/internal/api/v2/onlyoffice.go
@@ -1208,7 +1208,10 @@ func (h *OnlyOfficeHandler) saveEditedDocument(ctx context.Context, repoID, file
 	}
 
 	var storageKey string
+	materializedStorageClass := storageClass
 	if err := RetryUploadedBlockMaterializationContext(ctx, "OnlyOffice", internalBlockID, func() error {
+		materializedStorageClass = storageClass
+		storageKey = ""
 		probe, probeErr := probeUploadedBlockReuseFn(h.db, orgID, internalBlockID)
 		if probeErr != nil {
 			return fmt.Errorf("probe block reuse for %s: %w", internalBlockID, probeErr)
@@ -1219,12 +1222,18 @@ func (h *OnlyOfficeHandler) saveEditedDocument(ctx context.Context, repoID, file
 		}
 		switch probe.Decision {
 		case db.BlockReuseReusable:
+			materializedStorageClass = strings.TrimSpace(probe.StorageClass)
 			var ensureErr error
 			storageKey, ensureErr = EnsureReusableBlockPresent(ctx, internalBlockID, probe, content, h.storageManager, blockStore, storageClass, orgID)
 			return ensureErr
 		case db.BlockReuseNeedsPut:
+			putStore, resolvedClass, _, resolveErr := ResolveNeedsPutBlockStore(h.storageManager, blockStore, storageClass, probe, orgID, internalBlockID)
+			if resolveErr != nil {
+				return resolveErr
+			}
+			materializedStorageClass = resolvedClass
 			var putErr error
-			storageKey, putErr = putUploadedBlockAutoDirectFn(ctx, blockStore, internalBlockID, content)
+			storageKey, putErr = putUploadedBlockAutoDirectFn(ctx, putStore, internalBlockID, content)
 			if putErr != nil {
 				return fmt.Errorf("failed to store block: %w", putErr)
 			}
@@ -1237,7 +1246,7 @@ func (h *OnlyOfficeHandler) saveEditedDocument(ctx context.Context, repoID, file
 		// Materialize block metadata/provisional ref first and then the sync mapping.
 		// Keep the pending-cleanup row on mapping failure so the reconciler can finish
 		// cleanup even if the immediate rollback path was only partially successful.
-		return RegisterUploadedBlockAndMapping(h.db, orgID, repoID, internalBlockID, rollbackID, len(content), storageClass, storageKey, externalBlockID)
+		return RegisterUploadedBlockAndMapping(h.db, orgID, repoID, internalBlockID, rollbackID, len(content), materializedStorageClass, storageKey, externalBlockID)
 	}, nil, nil); err != nil {
 		if errors.Is(err, ErrBlockMappingWriteFailed) {
 			log.Printf("OnlyOffice: CRITICAL - failed to create block mapping org=%s ext=%s int=%s: %v", orgID, externalBlockID[:16], internalBlockID[:16], err)

--- a/internal/api/v2/sharelink_view.go
+++ b/internal/api/v2/sharelink_view.go
@@ -871,7 +871,7 @@ func (h *ShareLinkViewHandler) handleShareLinkRaw(c *gin.Context, sl *shareLinkD
 		return
 	}
 
-	blockStore, _, err := resolveLibraryBlockStoreForRequest(c, h.db, h.config, h.storageManager, h.storage, sl.orgID, sl.libraryID)
+	blockStore, blockStoreClass, err := resolveLibraryBlockStoreForRequest(c, h.db, h.config, h.storageManager, h.storage, sl.orgID, sl.libraryID)
 	if err != nil {
 		slog.Error("Block store not available for share link raw", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "storage not available"})
@@ -922,6 +922,12 @@ func (h *ShareLinkViewHandler) handleShareLinkRaw(c *gin.Context, sl *shareLinkD
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read file"})
 		return
 	}
+	canonicalReader, err := streaming.NewCanonicalBlockReader(c.Request.Context(), h.db, h.storageManager, sl.orgID, resolvedIDs, blockStore, blockStoreClass)
+	if err != nil {
+		slog.Error("canonical block reader construction failed for share link", "org", sl.orgID, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read file"})
+		return
+	}
 
 	var fileKeyParam []byte
 	var fileIVParam []byte
@@ -935,14 +941,14 @@ func (h *ShareLinkViewHandler) handleShareLinkRaw(c *gin.Context, sl *shareLinkD
 	// For video/audio files, use BlockReadSeeker so http.ServeContent can handle
 	// Range requests (HTTP 206) without buffering the entire file. Only O(1 block) RAM.
 	if isVideoFile(ext) || isAudioFile(ext) {
-		blockSizes, err := streaming.QueryBlockSizes(ctx, h.db, sl.orgID, blockStore, resolvedIDs)
+		blockSizes, err := streaming.QueryBlockSizes(ctx, h.db, sl.orgID, canonicalReader, resolvedIDs)
 		if err != nil {
 			slog.Error("Failed to query block sizes for share link", "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read file metadata"})
 			return
 		}
 
-		rs := streaming.NewBlockReadSeeker(ctx, blockStore, resolvedIDs, blockSizes, fileSize, fileKeyParam, fileIVParam)
+		rs := streaming.NewBlockReadSeeker(ctx, canonicalReader, resolvedIDs, blockSizes, fileSize, fileKeyParam, fileIVParam)
 		c.Header("Content-Disposition", resolveContentDisposition(ext, filename))
 		c.Header("Content-Type", mimeType)
 		http.ServeContent(c.Writer, c.Request, filename, time.Time{}, rs)
@@ -957,7 +963,7 @@ func (h *ShareLinkViewHandler) handleShareLinkRaw(c *gin.Context, sl *shareLinkD
 	}
 	c.Status(http.StatusOK)
 
-	streaming.StreamBlocks(c, ctx, blockStore, resolvedIDs, fileKeyParam, fileIVParam, "ShareLinkRaw")
+	streaming.StreamBlocks(c, ctx, canonicalReader, resolvedIDs, fileKeyParam, fileIVParam, "ShareLinkRaw")
 }
 
 // serveSharedDirPage renders the shared directory view
@@ -999,7 +1005,7 @@ func (h *ShareLinkViewHandler) readFileContentAsText(sl *shareLinkData) string {
 		return ""
 	}
 
-	blockStore, _, err := resolveLibraryBlockStoreForRequest(nil, h.db, h.config, h.storageManager, h.storage, sl.orgID, sl.libraryID)
+	blockStore, blockStoreClass, err := resolveLibraryBlockStoreForRequest(nil, h.db, h.config, h.storageManager, h.storage, sl.orgID, sl.libraryID)
 	if err != nil {
 		return ""
 	}
@@ -1033,12 +1039,17 @@ func (h *ShareLinkViewHandler) readFileContentAsText(sl *shareLinkData) string {
 		slog.Error("block ID resolution failed for inline text content", "org", sl.orgID, "error", err)
 		return ""
 	}
+	canonicalReader, err := streaming.NewCanonicalBlockReader(ctx, h.db, h.storageManager, sl.orgID, resolvedIDs, blockStore, blockStoreClass)
+	if err != nil {
+		slog.Error("canonical block reader construction failed for inline text content", "org", sl.orgID, "error", err)
+		return ""
+	}
 	var buf strings.Builder
 	for idx := range blockIDs {
 		internalID := resolvedIDs[idx]
 
 		if encrypted && fileKey != nil {
-			blockData, err := blockStore.GetBlock(ctx, internalID)
+			blockData, err := canonicalReader.GetBlock(ctx, internalID)
 			if err != nil {
 				return ""
 			}
@@ -1048,7 +1059,7 @@ func (h *ShareLinkViewHandler) readFileContentAsText(sl *shareLinkData) string {
 			}
 			buf.Write(blockData)
 		} else {
-			blockData, err := blockStore.GetBlock(ctx, internalID)
+			blockData, err := canonicalReader.GetBlock(ctx, internalID)
 			if err != nil {
 				return ""
 			}

--- a/internal/api/v2/upload_reuse.go
+++ b/internal/api/v2/upload_reuse.go
@@ -37,7 +37,7 @@ func IsRetryableBlockMaterializationError(err error) bool {
 // materialize-phase metadata write is never labeled "probe" (finding F14).
 const (
 	blockMaterializationReasonFence    = "gc_fence"
-	blockMaterializationReasonProbe    = "probe"          // store phase (probe/HEAD/PUT)
+	blockMaterializationReasonProbe    = "probe"           // store phase (probe/HEAD/PUT)
 	blockMaterializationReasonMaterial = "materialization" // metadata materialize phase
 )
 
@@ -105,11 +105,94 @@ func ResolveCanonicalBlockStore(storageManager *storage.Manager, fallbackStore *
 	}
 	if fallbackStore != nil {
 		fallbackClass = strings.TrimSpace(fallbackClass)
-		if fallbackClass == "" || strings.EqualFold(fallbackClass, canonicalClass) {
+		if fallbackClass != "" && fallbackClass == canonicalClass {
 			return fallbackStore, nil
 		}
 	}
 	return nil, fmt.Errorf("canonical storage class %s is not available", canonicalClass)
+}
+
+// ResolveNeedsPutBlockStore chooses the physical destination for a NeedsPut
+// probe. A first writer has no storage metadata and keeps the preferred store.
+// Existing metadata is immutable placement state and must resolve without
+// health failover to the exact org-scoped class and derived key.
+func ResolveNeedsPutBlockStore(storageManager *storage.Manager, preferredStore *storage.BlockStore, preferredClass string, probe db.BlockReuseProbe, orgID, blockID string) (*storage.BlockStore, string, string, error) {
+	if probe.Decision != db.BlockReuseNeedsPut {
+		return nil, "", "", fmt.Errorf("block %s does not need a PUT", blockID)
+	}
+
+	canonicalClass := strings.TrimSpace(probe.StorageClass)
+	if canonicalClass == "" {
+		if preferredStore == nil {
+			return nil, "", "", fmt.Errorf("preferred block store is unavailable for %s", blockID)
+		}
+		preferredClass = strings.TrimSpace(preferredClass)
+		if preferredClass == "" {
+			return nil, "", "", fmt.Errorf("preferred storage class is empty for %s", blockID)
+		}
+		return preferredStore, preferredClass, preferredStore.StorageKeyForHash(blockID), nil
+	}
+
+	canonicalStore, err := resolveCanonicalBlockStoreFn(storageManager, preferredStore, preferredClass, canonicalClass, orgID)
+	if err != nil {
+		return nil, "", "", fmt.Errorf("resolve canonical block store for %s: %w", blockID, err)
+	}
+	storageKey := canonicalStore.StorageKeyForHash(blockID)
+	if storedKey := strings.TrimSpace(probe.StorageKey); storedKey != "" && storedKey != storageKey {
+		return nil, "", "", fmt.Errorf("canonical block %s storage key %q does not match derived org-scoped key %q", blockID, storedKey, storageKey)
+	}
+	return canonicalStore, canonicalClass, storageKey, nil
+}
+
+// StoreUploadedBlockForProbe executes the physical action selected by a
+// prepared Cassandra probe and returns the placement to materialize. beforePut
+// runs only when a physical write is about to occur.
+func StoreUploadedBlockForProbe(ctx context.Context, blockID string, probe db.BlockReuseProbe, data []byte, storageManager *storage.Manager, preferredStore *storage.BlockStore, preferredClass, orgID string, beforePut func() error) (storageKey, storageClass string, didPut bool, err error) {
+	switch probe.Decision {
+	case db.BlockReuseReusable:
+		canonicalStore, resolveErr := resolveCanonicalBlockStoreFn(storageManager, preferredStore, preferredClass, probe.StorageClass, orgID)
+		if resolveErr != nil {
+			return "", strings.TrimSpace(probe.StorageClass), false, fmt.Errorf("resolve canonical block store for %s: %w", blockID, resolveErr)
+		}
+		storageKey = canonicalStore.StorageKeyForHash(blockID)
+		if storedKey := strings.TrimSpace(probe.StorageKey); storedKey != "" && storedKey != storageKey {
+			return "", strings.TrimSpace(probe.StorageClass), false, fmt.Errorf("canonical block %s storage key %q does not match derived org-scoped key %q", blockID, storedKey, storageKey)
+		}
+		exists, existsErr := reusableCanonicalObjectExistsFn(ctx, canonicalStore, storageKey)
+		if existsErr != nil {
+			return storageKey, strings.TrimSpace(probe.StorageClass), false, fmt.Errorf("verify canonical block %s in %s: %w", blockID, probe.StorageClass, existsErr)
+		}
+		if exists {
+			return storageKey, strings.TrimSpace(probe.StorageClass), false, nil
+		}
+		if beforePut != nil {
+			if beforeErr := beforePut(); beforeErr != nil {
+				return storageKey, strings.TrimSpace(probe.StorageClass), false, beforeErr
+			}
+		}
+		if _, putErr := repairCanonicalBlockDirectFn(ctx, canonicalStore, storageKey, data); putErr != nil {
+			return storageKey, strings.TrimSpace(probe.StorageClass), false, fmt.Errorf("repair canonical block %s in %s: %w", blockID, probe.StorageClass, putErr)
+		}
+		return storageKey, strings.TrimSpace(probe.StorageClass), true, nil
+	case db.BlockReuseNeedsPut:
+		putStore, resolvedClass, resolvedKey, resolveErr := ResolveNeedsPutBlockStore(storageManager, preferredStore, preferredClass, probe, orgID, blockID)
+		if resolveErr != nil {
+			return "", "", false, resolveErr
+		}
+		if beforePut != nil {
+			if beforeErr := beforePut(); beforeErr != nil {
+				return resolvedKey, resolvedClass, false, beforeErr
+			}
+		}
+		if _, putErr := repairCanonicalBlockDirectFn(ctx, putStore, resolvedKey, data); putErr != nil {
+			return resolvedKey, resolvedClass, false, fmt.Errorf("store block %s in %s: %w", blockID, resolvedClass, putErr)
+		}
+		return resolvedKey, resolvedClass, true, nil
+	case db.BlockReuseBlockedByGC:
+		return "", "", false, ErrBlockDeleteInProgress
+	default:
+		return "", "", false, fmt.Errorf("unsupported block reuse decision %d for %s", probe.Decision, blockID)
+	}
 }
 
 // EnsureReusableBlockPresent verifies that the canonical physical copy exists for
@@ -119,29 +202,8 @@ func EnsureReusableBlockPresent(ctx context.Context, blockID string, probe db.Bl
 	if probe.Decision != db.BlockReuseReusable {
 		return "", fmt.Errorf("block %s is not reusable", blockID)
 	}
-
-	canonicalStore, err := resolveCanonicalBlockStoreFn(storageManager, fallbackStore, fallbackClass, probe.StorageClass, orgID)
-	if err != nil {
-		return "", fmt.Errorf("resolve canonical block store for %s: %w", blockID, err)
-	}
-
-	storageKey := canonicalStore.StorageKeyForHash(blockID)
-	if storedKey := strings.TrimSpace(probe.StorageKey); storedKey != "" && storedKey != storageKey {
-		return "", fmt.Errorf("canonical block %s storage key %q does not match derived org-scoped key %q", blockID, storedKey, storageKey)
-	}
-
-	exists, err := reusableCanonicalObjectExistsFn(ctx, canonicalStore, storageKey)
-	if err != nil {
-		return storageKey, fmt.Errorf("verify canonical block %s in %s: %w", blockID, probe.StorageClass, err)
-	}
-	if exists {
-		return storageKey, nil
-	}
-
-	if _, err := repairCanonicalBlockDirectFn(ctx, canonicalStore, storageKey, data); err != nil {
-		return storageKey, fmt.Errorf("repair canonical block %s in %s: %w", blockID, probe.StorageClass, err)
-	}
-	return storageKey, nil
+	storageKey, _, _, err := StoreUploadedBlockForProbe(ctx, blockID, probe, data, storageManager, fallbackStore, fallbackClass, orgID, nil)
+	return storageKey, err
 }
 
 // RetryUploadedBlockMaterialization retries the full store->materialize cycle

--- a/internal/api/v2/upload_reuse_test.go
+++ b/internal/api/v2/upload_reuse_test.go
@@ -579,3 +579,218 @@ func TestResolveCanonicalBlockStoreUsesExactOrgScopedClass(t *testing.T) {
 		t.Fatalf("StorageKeyForHash() = %q, want %q", got, want)
 	}
 }
+
+func TestResolveCanonicalBlockStoreRejectsInexactFallbackClass(t *testing.T) {
+	const orgID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+	fallback, err := storage.NewOrgBlockStore(&storage.S3Store{}, "blocks/", orgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, fallbackClass := range []string{"", "   ", "CANONICAL"} {
+		t.Run(fmt.Sprintf("class_%q", fallbackClass), func(t *testing.T) {
+			got, err := ResolveCanonicalBlockStore(nil, fallback, fallbackClass, "canonical", orgID)
+			if got != nil || err == nil {
+				t.Fatalf("ResolveCanonicalBlockStore() = (%p, %v), want nil and error", got, err)
+			}
+		})
+	}
+}
+
+func TestResolveNeedsPutBlockStoreUsesPreferredPlacementForFirstWriter(t *testing.T) {
+	const orgID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+	preferred, err := storage.NewOrgBlockStore(&storage.S3Store{}, "blocks/", orgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotStore, gotClass, gotKey, err := ResolveNeedsPutBlockStore(nil, preferred, "preferred", db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut}, orgID, "abcd1234")
+	if err != nil {
+		t.Fatalf("ResolveNeedsPutBlockStore() error = %v", err)
+	}
+	if gotStore != preferred || gotClass != "preferred" || gotKey != preferred.StorageKeyForHash("abcd1234") {
+		t.Fatalf("placement = %p/%q/%q, want preferred/%q/%q", gotStore, gotClass, gotKey, "preferred", preferred.StorageKeyForHash("abcd1234"))
+	}
+}
+
+func TestResolveNeedsPutBlockStoreUsesExistingCanonicalPlacement(t *testing.T) {
+	oldResolve := resolveCanonicalBlockStoreFn
+	t.Cleanup(func() { resolveCanonicalBlockStoreFn = oldResolve })
+
+	const orgID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+	preferred, err := storage.NewOrgBlockStore(&storage.S3Store{}, "blocks/", orgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := storage.NewOrgBlockStore(&storage.S3Store{}, "blocks/", orgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantKey := canonical.StorageKeyForHash("abcd1234")
+	resolveCanonicalBlockStoreFn = func(_ *storage.Manager, fallback *storage.BlockStore, fallbackClass, canonicalClass, gotOrgID string) (*storage.BlockStore, error) {
+		if fallback != preferred || fallbackClass != "preferred" || canonicalClass != "archive" || gotOrgID != orgID {
+			t.Fatalf("resolve args = %p/%q/%q/%q", fallback, fallbackClass, canonicalClass, gotOrgID)
+		}
+		return canonical, nil
+	}
+
+	gotStore, gotClass, gotKey, err := ResolveNeedsPutBlockStore(nil, preferred, "preferred", db.BlockReuseProbe{
+		Decision: db.BlockReuseNeedsPut, StorageClass: "archive", StorageKey: wantKey,
+	}, orgID, "abcd1234")
+	if err != nil {
+		t.Fatalf("ResolveNeedsPutBlockStore() error = %v", err)
+	}
+	if gotStore != canonical || gotClass != "archive" || gotKey != wantKey {
+		t.Fatalf("placement = %p/%q/%q, want canonical/archive/%q", gotStore, gotClass, gotKey, wantKey)
+	}
+}
+
+func TestStoreUploadedBlockForProbeCanonicalFailuresDoNotPut(t *testing.T) {
+	oldResolve := resolveCanonicalBlockStoreFn
+	oldPut := repairCanonicalBlockDirectFn
+	t.Cleanup(func() {
+		resolveCanonicalBlockStoreFn = oldResolve
+		repairCanonicalBlockDirectFn = oldPut
+	})
+
+	putCalls := 0
+	repairCanonicalBlockDirectFn = func(context.Context, *storage.BlockStore, string, []byte) (string, error) {
+		putCalls++
+		return "", nil
+	}
+
+	t.Run("first writer empty preferred class", func(t *testing.T) {
+		_, _, _, err := StoreUploadedBlockForProbe(context.Background(), "block-1", db.BlockReuseProbe{
+			Decision: db.BlockReuseNeedsPut,
+		}, []byte("data"), nil, &storage.BlockStore{}, "  ", "org-1", nil)
+		if err == nil || putCalls != 0 {
+			t.Fatalf("error/putCalls = %v/%d, want error/0", err, putCalls)
+		}
+	})
+
+	t.Run("unavailable canonical class has no fallback", func(t *testing.T) {
+		resolveCanonicalBlockStoreFn = func(*storage.Manager, *storage.BlockStore, string, string, string) (*storage.BlockStore, error) {
+			return nil, errors.New("class unavailable")
+		}
+		_, _, _, err := StoreUploadedBlockForProbe(context.Background(), "block-1", db.BlockReuseProbe{
+			Decision: db.BlockReuseNeedsPut, StorageClass: "archive",
+		}, []byte("data"), nil, &storage.BlockStore{}, "preferred", "org-1", nil)
+		if err == nil || putCalls != 0 {
+			t.Fatalf("error/putCalls = %v/%d, want error/0", err, putCalls)
+		}
+	})
+
+	t.Run("cross-org key mismatch", func(t *testing.T) {
+		const orgID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+		canonical, err := storage.NewOrgBlockStore(&storage.S3Store{}, "blocks/", orgID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resolveCanonicalBlockStoreFn = func(*storage.Manager, *storage.BlockStore, string, string, string) (*storage.BlockStore, error) {
+			return canonical, nil
+		}
+		_, _, _, err = StoreUploadedBlockForProbe(context.Background(), "abcd1234", db.BlockReuseProbe{
+			Decision: db.BlockReuseNeedsPut, StorageClass: "archive", StorageKey: "blocks/00000000-0000-0000-0000-000000000001/ab/cd/abcd1234",
+		}, []byte("data"), nil, canonical, "preferred", orgID, nil)
+		if err == nil || putCalls != 0 {
+			t.Fatalf("error/putCalls = %v/%d, want mismatch error/0", err, putCalls)
+		}
+	})
+}
+
+func TestStoreUploadedBlockForProbeReturnsCanonicalPlacementAndFence(t *testing.T) {
+	oldResolve := resolveCanonicalBlockStoreFn
+	oldPut := repairCanonicalBlockDirectFn
+	t.Cleanup(func() {
+		resolveCanonicalBlockStoreFn = oldResolve
+		repairCanonicalBlockDirectFn = oldPut
+	})
+
+	const orgID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+	canonical, err := storage.NewOrgBlockStore(&storage.S3Store{}, "blocks/", orgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantKey := canonical.StorageKeyForHash("abcd1234")
+	resolveCanonicalBlockStoreFn = func(*storage.Manager, *storage.BlockStore, string, string, string) (*storage.BlockStore, error) {
+		return canonical, nil
+	}
+	putCalls := 0
+	admissionCalls := 0
+	repairCanonicalBlockDirectFn = func(_ context.Context, gotStore *storage.BlockStore, gotKey string, data []byte) (string, error) {
+		putCalls++
+		if gotStore != canonical || gotKey != wantKey || string(data) != "data" {
+			t.Fatalf("PUT = %p/%q/%q", gotStore, gotKey, data)
+		}
+		return gotKey, nil
+	}
+
+	gotKey, gotClass, didPut, err := StoreUploadedBlockForProbe(context.Background(), "abcd1234", db.BlockReuseProbe{
+		Decision: db.BlockReuseNeedsPut, StorageClass: "archive", StorageKey: wantKey,
+	}, []byte("data"), nil, canonical, "preferred", orgID, func() error {
+		admissionCalls++
+		return nil
+	})
+	if err != nil || gotKey != wantKey || gotClass != "archive" || !didPut || putCalls != 1 || admissionCalls != 1 {
+		t.Fatalf("result = %q/%q/%v/%v puts=%d admission=%d", gotKey, gotClass, didPut, err, putCalls, admissionCalls)
+	}
+
+	_, _, _, err = StoreUploadedBlockForProbe(context.Background(), "abcd1234", db.BlockReuseProbe{Decision: db.BlockReuseBlockedByGC}, []byte("data"), nil, canonical, "preferred", orgID, nil)
+	if !errors.Is(err, ErrBlockDeleteInProgress) || putCalls != 1 || admissionCalls != 1 {
+		t.Fatalf("fence error/put/admission = %v/%d/%d, want ErrBlockDeleteInProgress/1/1", err, putCalls, admissionCalls)
+	}
+}
+
+func TestRetryUploadedBlockMaterializationResetsPlacementPerAttempt(t *testing.T) {
+	fastBlockMaterializationRetries(t)
+
+	const orgID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+	preferred, err := storage.NewOrgBlockStore(&storage.S3Store{}, "blocks/", orgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := storage.NewOrgBlockStore(&storage.S3Store{}, "blocks/", orgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldResolve := resolveCanonicalBlockStoreFn
+	t.Cleanup(func() { resolveCanonicalBlockStoreFn = oldResolve })
+	resolveCanonicalBlockStoreFn = func(*storage.Manager, *storage.BlockStore, string, string, string) (*storage.BlockStore, error) {
+		return canonical, nil
+	}
+
+	placementClass := "preferred"
+	attempt := 0
+	materializeCalls := 0
+	err = RetryUploadedBlockMaterialization("PlacementReset", "abcd1234", func() error {
+		attempt++
+		placementClass = "preferred"
+		probe := db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut}
+		if attempt == 1 {
+			probe.StorageClass = "archive"
+		}
+		_, resolvedClass, _, resolveErr := ResolveNeedsPutBlockStore(nil, preferred, "preferred", probe, orgID, "abcd1234")
+		if resolveErr == nil {
+			placementClass = resolvedClass
+		}
+		return resolveErr
+	}, func() error {
+		materializeCalls++
+		if materializeCalls == 1 {
+			if placementClass != "archive" {
+				t.Fatalf("first attempt class = %q, want archive", placementClass)
+			}
+			return ErrBlockMaterializationTransient
+		}
+		if placementClass != "preferred" {
+			t.Fatalf("second attempt class = %q, want preferred (no stale canonical class)", placementClass)
+		}
+		return nil
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("RetryUploadedBlockMaterialization() error = %v", err)
+	}
+	if attempt != 2 || materializeCalls != 2 {
+		t.Fatalf("store/materialize calls = %d/%d, want 2/2", attempt, materializeCalls)
+	}
+}

--- a/internal/db/block_storage_location.go
+++ b/internal/db/block_storage_location.go
@@ -1,0 +1,41 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
+)
+
+// BlockStorageLocation is the canonical physical location recorded for a block.
+type BlockStorageLocation struct {
+	SizeBytes    int64
+	StorageClass string
+	StorageKey   string
+	GCState      string
+	CreatedAt    *time.Time
+}
+
+// GetBlockStorageLocation reads one block's canonical physical location.
+func (db *DB) GetBlockStorageLocation(ctx context.Context, orgID, blockID string) (BlockStorageLocation, bool, error) {
+	return scanBlockStorageLocation(func(dest ...interface{}) error {
+		return db.Session().Query(`
+			SELECT size_bytes, storage_class, storage_key, gc_state, created_at
+			FROM blocks
+			WHERE org_id = ? AND block_id = ?
+		`, orgID, blockID).WithContext(ctx).Scan(dest...)
+	})
+}
+
+func scanBlockStorageLocation(scan func(dest ...interface{}) error) (BlockStorageLocation, bool, error) {
+	var location BlockStorageLocation
+	err := scan(&location.SizeBytes, &location.StorageClass, &location.StorageKey, &location.GCState, &location.CreatedAt)
+	if err != nil {
+		if errors.Is(err, gocql.ErrNotFound) {
+			return BlockStorageLocation{}, false, nil
+		}
+		return BlockStorageLocation{}, false, err
+	}
+	return location, true, nil
+}

--- a/internal/db/block_storage_location_test.go
+++ b/internal/db/block_storage_location_test.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
+)
+
+func TestScanBlockStorageLocation(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		createdAt := time.Now().UTC()
+		location, found, err := scanBlockStorageLocation(func(dest ...interface{}) error {
+			*(dest[0].(*int64)) = 123
+			*(dest[1].(*string)) = "hot"
+			*(dest[2].(*string)) = "canonical/key"
+			*(dest[3].(*string)) = BlockGCStateDeleting
+			*(dest[4].(**time.Time)) = &createdAt
+			return nil
+		})
+		if err != nil || !found {
+			t.Fatalf("scanBlockStorageLocation() = (%+v, %t, %v), want found", location, found, err)
+		}
+		want := BlockStorageLocation{SizeBytes: 123, StorageClass: "hot", StorageKey: "canonical/key", GCState: BlockGCStateDeleting, CreatedAt: &createdAt}
+		if location != want {
+			t.Fatalf("location = %+v, want %+v", location, want)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		location, found, err := scanBlockStorageLocation(func(...interface{}) error { return gocql.ErrNotFound })
+		if err != nil || found || location != (BlockStorageLocation{}) {
+			t.Fatalf("scanBlockStorageLocation() = (%+v, %t, %v), want zero, false, nil", location, found, err)
+		}
+	})
+
+	t.Run("database error", func(t *testing.T) {
+		databaseErr := errors.New("cassandra unavailable")
+		_, found, err := scanBlockStorageLocation(func(...interface{}) error { return databaseErr })
+		if found || !errors.Is(err, databaseErr) {
+			t.Fatalf("scanBlockStorageLocation() = (_, %t, %v), want false and database error", found, err)
+		}
+	})
+}

--- a/internal/integration/gc_upload_fence_test.go
+++ b/internal/integration/gc_upload_fence_test.go
@@ -1,0 +1,210 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Sesame-Disk/sesamefs/internal/db"
+	"github.com/Sesame-Disk/sesamefs/internal/storage"
+)
+
+func TestNeedsPutUsesCanonicalMinIOBucket(t *testing.T) {
+	ctx := context.Background()
+	newStore := func(bucket string) *storage.S3Store {
+		t.Helper()
+		store, err := storage.NewS3Store(ctx, storage.S3Config{
+			Endpoint:        envOrDefault("S3_ENDPOINT", "http://minio:9000"),
+			Bucket:          bucket,
+			Region:          envOrDefault("S3_REGION", "us-east-1"),
+			AccessKeyID:     envOrDefault("S3_ACCESS_KEY_ID", "minioadmin"),
+			SecretAccessKey: envOrDefault("S3_SECRET_ACCESS_KEY", "minioadmin"),
+			UsePathStyle:    true,
+		})
+		if err != nil {
+			t.Fatalf("NewS3Store(%s): %v", bucket, err)
+		}
+		if err := store.HeadBucket(ctx); err != nil {
+			t.Fatalf("required MinIO bucket %s unavailable: %v", bucket, err)
+		}
+		return store
+	}
+
+	preferredBucket := envOrDefault("S3_TEST_PREFERRED_BUCKET", "sesamefs-eu")
+	canonicalBucket := envOrDefault("S3_TEST_CANONICAL_BUCKET", "sesamefs-usa")
+	if preferredBucket == canonicalBucket {
+		t.Fatalf("preferred and canonical MinIO buckets must differ, both are %q", preferredBucket)
+	}
+	preferredS3 := newStore(preferredBucket)
+	canonicalS3 := newStore(canonicalBucket)
+	name := fmt.Sprintf("inttest-canonical-needs-put-%d", time.Now().UnixNano())
+	createResp := adminClient.PostJSONWithHost(t, "/api2/repos/", map[string]string{
+		"name":       name,
+		"storage_id": "hot-s3-eu",
+	}, "eu.sesamefs.local")
+	expectStatus(t, createResp, http.StatusOK)
+	created := responseJSON(t, createResp)
+	repoID, _ := created["repo_id"].(string)
+	if repoID == "" {
+		t.Fatalf("create library response missing repo_id: %v", created)
+	}
+	t.Cleanup(func() {
+		resp := adminClient.Delete(t, fmt.Sprintf("/api/v2.1/repos/%s/", repoID))
+		resp.Body.Close()
+	})
+
+	database := shareProjectionDBForTest(t)
+	var orgID string
+	if err := database.Session().Query(`SELECT org_id FROM libraries_by_id WHERE library_id = ?`, repoID).Scan(&orgID); err != nil {
+		t.Fatalf("resolve library org: %v", err)
+	}
+	preferredStore, err := storage.NewOrgBlockStore(preferredS3, "blocks/", orgID)
+	if err != nil {
+		t.Fatalf("preferred block store: %v", err)
+	}
+	canonicalStore, err := storage.NewOrgBlockStore(canonicalS3, "blocks/", orgID)
+	if err != nil {
+		t.Fatalf("canonical block store: %v", err)
+	}
+	data := []byte("canonical NeedsPut integration payload")
+	sha1Bytes := sha1.Sum(data)
+	externalBlockID := hex.EncodeToString(sha1Bytes[:])
+	hashBytes := sha256.Sum256(data)
+	blockID := hex.EncodeToString(hashBytes[:])
+	canonicalKey := canonicalStore.StorageKeyForHash(blockID)
+	preferredKey := preferredStore.StorageKeyForHash(blockID)
+
+	operationID := "sync:" + repoID + ":" + blockID
+	referrer := db.BlockReferrerForUpload(operationID)
+	webFilename := "canonical-session.bin"
+	webFSID := webFileFSID(t, []string{externalBlockID}, len(data))
+	webReferrer := db.BlockReferrerForFSObject(repoID, webFSID)
+	t.Cleanup(func() {
+		for _, cleanupReferrer := range []string{referrer, webReferrer} {
+			if err := database.RemoveBlockReference(orgID, blockID, cleanupReferrer); err != nil {
+				t.Errorf("cleanup block reference %s: %v", cleanupReferrer, err)
+			}
+		}
+		if err := database.DeleteProvisionalBlockReferenceExpiry(orgID, blockID, referrer, time.Time{}); err != nil {
+			t.Errorf("cleanup provisional expiry: %v", err)
+		}
+		if err := database.Session().Query(`DELETE FROM block_id_mappings WHERE org_id = ? AND representation_id = ? AND external_id = ?`, orgID, db.PlainBlockRepresentationID, externalBlockID).Exec(); err != nil {
+			t.Errorf("cleanup block mapping: %v", err)
+		}
+		if err := database.Session().Query(`DELETE FROM blocks WHERE org_id = ? AND block_id = ?`, orgID, blockID).Exec(); err != nil {
+			t.Errorf("cleanup block metadata: %v", err)
+		}
+		if err := preferredStore.DeleteBlock(ctx, blockID); err != nil {
+			t.Errorf("cleanup preferred object: %v", err)
+		}
+		if err := canonicalStore.DeleteBlock(ctx, blockID); err != nil {
+			t.Errorf("cleanup canonical object: %v", err)
+		}
+	})
+	if err := preferredStore.DeleteBlock(ctx, blockID); err != nil {
+		t.Fatalf("remove stale preferred object: %v", err)
+	}
+	if err := canonicalStore.DeleteBlock(ctx, blockID); err != nil {
+		t.Fatalf("remove stale canonical object: %v", err)
+	}
+
+	if err := database.UpsertBlockMetadata(orgID, blockID, len(data), "hot-s3-usa", canonicalKey); err != nil {
+		t.Fatalf("seed canonical block metadata: %v", err)
+	}
+	if hasReferences, err := database.BlockHasReferences(orgID, blockID); err != nil || hasReferences {
+		t.Fatalf("seeded block references = %v, %v; want false, nil", hasReferences, err)
+	}
+	probe, err := database.ProbeBlockReuse(orgID, blockID)
+	if err != nil {
+		t.Fatalf("ProbeBlockReuse(NeedsPut): %v", err)
+	}
+	if probe.Decision != db.BlockReuseNeedsPut || probe.StorageClass != "hot-s3-usa" || probe.StorageKey != canonicalKey {
+		t.Fatalf("probe = %+v, want existing canonical NeedsPut metadata", probe)
+	}
+
+	putResp := doSyncProtocolRequestForTest(t, http.MethodPut, fmt.Sprintf("/seafhttp/repo/%s/block/%s", repoID, externalBlockID), data, "application/octet-stream")
+	expectStatus(t, putResp, http.StatusOK)
+	canonicalExists, err := canonicalStore.ObjectExists(ctx, canonicalKey)
+	if err != nil {
+		t.Fatalf("canonical ObjectExists(%q): %v", canonicalKey, err)
+	}
+	preferredExists, err := preferredStore.ObjectExists(ctx, preferredKey)
+	if err != nil {
+		t.Fatalf("preferred ObjectExists(%q): %v", preferredKey, err)
+	}
+	if !canonicalExists || preferredExists {
+		t.Fatalf("canonical/preferred existence = %v/%v, want true/false", canonicalExists, preferredExists)
+	}
+
+	location, found, err := database.GetBlockStorageLocation(ctx, orgID, blockID)
+	if err != nil || !found {
+		t.Fatalf("GetBlockStorageLocation() = %+v, %v, %v", location, found, err)
+	}
+	if location.StorageClass != "hot-s3-usa" || location.StorageKey != canonicalKey {
+		t.Fatalf("canonical metadata = %+v, want hot-s3-usa/%s", location, canonicalKey)
+	}
+	if mapped, ok, err := database.GetBlockIDMapping(orgID, db.PlainBlockRepresentationID, externalBlockID); err != nil || !ok || mapped != blockID {
+		t.Fatalf("mapping = %q, %v, %v; want %s/true/nil", mapped, ok, err, blockID)
+	}
+
+	getResp := doSyncProtocolRequestForTest(t, http.MethodGet, fmt.Sprintf("/seafhttp/repo/%s/block/%s", repoID, externalBlockID), nil, "")
+	expectStatus(t, getResp, http.StatusOK)
+	got, err := io.ReadAll(getResp.Body)
+	getResp.Body.Close()
+	if err != nil {
+		t.Fatalf("read Sync GET body: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("Sync GET bytes = %q, want %q", got, data)
+	}
+
+	// Recreate the original session regression: metadata remains pinned to USA,
+	// its canonical object disappears, and the library still prefers EU. The web
+	// session must repair USA, verify USA at commit, and remain readable afterward.
+	if err := canonicalStore.DeleteBlock(ctx, blockID); err != nil {
+		t.Fatalf("remove canonical object before session repair: %v", err)
+	}
+	sessionID := webCreateBlockSession(t, adminClient, repoID, "/", int64(len(data)))
+	existing, missing := webCheckBlocks(t, adminClient, sessionID, []string{strings.ToUpper(blockID)})
+	if len(existing) != 0 || len(missing) != 1 || missing[0] != strings.ToUpper(blockID) {
+		t.Fatalf("session check existing/missing = %v/%v, want []/[%s]", existing, missing, strings.ToUpper(blockID))
+	}
+	uploadResp := webUploadBlock(t, adminClient, sessionID, data)
+	if uploadResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(uploadResp.Body)
+		uploadResp.Body.Close()
+		t.Fatalf("session upload status %d: %s", uploadResp.StatusCode, body)
+	}
+	uploadResp.Body.Close()
+	canonicalExists, err = canonicalStore.ObjectExists(ctx, canonicalKey)
+	if err != nil {
+		t.Fatalf("canonical ObjectExists after session upload: %v", err)
+	}
+	preferredExists, err = preferredStore.ObjectExists(ctx, preferredKey)
+	if err != nil {
+		t.Fatalf("preferred ObjectExists after session upload: %v", err)
+	}
+	if !canonicalExists || preferredExists {
+		t.Fatalf("session canonical/preferred existence = %v/%v, want true/false", canonicalExists, preferredExists)
+	}
+	commitResp := webCommit(t, adminClient, repoID, map[string]interface{}{
+		"session": sessionID, "parent_dir": "/", "filename": webFilename,
+		"replace": false, "size": len(data),
+		"blocks": []map[string]interface{}{{"sha256": strings.ToUpper(blockID), "size": len(data)}},
+	})
+	expectStatus(t, commitResp, http.StatusOK)
+	commitResp.Body.Close()
+	if downloaded := downloadRepoFile(t, adminClient, repoID, "/"+webFilename); !bytes.Equal(downloaded, data) {
+		t.Fatalf("web session download bytes = %q, want %q", downloaded, data)
+	}
+}

--- a/internal/storage/blocks.go
+++ b/internal/storage/blocks.go
@@ -183,9 +183,12 @@ func (bs *BlockStore) StorageKeyForHash(hash string) string {
 
 // GetBlock retrieves a block by its hash
 func (bs *BlockStore) GetBlock(ctx context.Context, hash string) ([]byte, error) {
-	key := bs.hashToKey(hash)
+	return bs.GetBlockByStorageKey(ctx, bs.hashToKey(hash))
+}
 
-	reader, err := bs.s3.Get(ctx, key)
+// GetBlockByStorageKey retrieves a block from an explicit storage key.
+func (bs *BlockStore) GetBlockByStorageKey(ctx context.Context, storageKey string) ([]byte, error) {
+	reader, err := bs.GetBlockReaderByStorageKey(ctx, storageKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get block: %w", err)
 	}
@@ -201,14 +204,22 @@ func (bs *BlockStore) GetBlock(ctx context.Context, hash string) ([]byte, error)
 
 // GetBlockReader returns a reader for a block (for streaming large blocks)
 func (bs *BlockStore) GetBlockReader(ctx context.Context, hash string) (io.ReadCloser, error) {
-	key := bs.hashToKey(hash)
-	return bs.s3.Get(ctx, key)
+	return bs.GetBlockReaderByStorageKey(ctx, bs.hashToKey(hash))
+}
+
+// GetBlockReaderByStorageKey returns a reader for an explicit storage key.
+func (bs *BlockStore) GetBlockReaderByStorageKey(ctx context.Context, storageKey string) (io.ReadCloser, error) {
+	return bs.s3.Get(ctx, storageKey)
 }
 
 // GetBlockSize returns the size in bytes of a block using S3 HEAD (no data transfer).
 func (bs *BlockStore) GetBlockSize(ctx context.Context, hash string) (int64, error) {
-	key := bs.hashToKey(hash)
-	return bs.s3.GetObjectSize(ctx, key)
+	return bs.GetBlockSizeByStorageKey(ctx, bs.hashToKey(hash))
+}
+
+// GetBlockSizeByStorageKey returns the size of an explicit storage key using S3 HEAD.
+func (bs *BlockStore) GetBlockSizeByStorageKey(ctx context.Context, storageKey string) (int64, error) {
+	return bs.s3.GetObjectSize(ctx, storageKey)
 }
 
 // BlockExists checks if a block exists

--- a/internal/storage/blocks_test.go
+++ b/internal/storage/blocks_test.go
@@ -1,8 +1,12 @@
 package storage
 
 import (
+	"context"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -367,6 +371,74 @@ func TestOrgBlockStoreHashToKey_IsOrgScoped(t *testing.T) {
 	// StorageKeyForHash (the public locator) must agree with the internal key.
 	if a.StorageKeyForHash(testHash64) != keyA {
 		t.Errorf("StorageKeyForHash disagrees with hashToKey for org A")
+	}
+}
+
+func TestBlockStoreExplicitStorageKeyReads(t *testing.T) {
+	var mu sync.Mutex
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		mu.Unlock()
+		w.Header().Set("Content-Length", "7")
+		if r.Method == http.MethodGet {
+			_, _ = io.WriteString(w, "payload")
+		}
+	}))
+	defer server.Close()
+
+	s3Store, err := NewS3Store(context.Background(), S3Config{
+		Endpoint:        server.URL,
+		Bucket:          "test-bucket",
+		Region:          "us-east-1",
+		AccessKeyID:     "test",
+		SecretAccessKey: "test",
+		UsePathStyle:    true,
+	})
+	if err != nil {
+		t.Fatalf("NewS3Store() error = %v", err)
+	}
+	blockStore, err := NewOrgBlockStore(s3Store, "blocks/", testOrgA)
+	if err != nil {
+		t.Fatalf("NewOrgBlockStore() error = %v", err)
+	}
+	ctx := context.Background()
+	const key = "explicit/canonical/key"
+
+	data, err := blockStore.GetBlockByStorageKey(ctx, key)
+	if err != nil || string(data) != "payload" {
+		t.Fatalf("GetBlockByStorageKey() = %q, %v", data, err)
+	}
+	reader, err := blockStore.GetBlockReaderByStorageKey(ctx, key)
+	if err != nil {
+		t.Fatalf("GetBlockReaderByStorageKey() error = %v", err)
+	}
+	readerData, readErr := io.ReadAll(reader)
+	_ = reader.Close()
+	if readErr != nil || string(readerData) != "payload" {
+		t.Fatalf("explicit reader = %q, %v", readerData, readErr)
+	}
+	size, err := blockStore.GetBlockSizeByStorageKey(ctx, key)
+	if err != nil || size != 7 {
+		t.Fatalf("GetBlockSizeByStorageKey() = %d, %v, want 7, nil", size, err)
+	}
+	exists, err := blockStore.ObjectExists(ctx, key)
+	if err != nil || !exists {
+		t.Fatalf("ObjectExists() = %t, %v, want true, nil", exists, err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	wantPath := "/test-bucket/explicit/canonical/key"
+	want := []string{"GET " + wantPath, "GET " + wantPath, "HEAD " + wantPath, "HEAD " + wantPath}
+	if len(requests) != len(want) {
+		t.Fatalf("requests = %v, want %v", requests, want)
+	}
+	for i := range want {
+		if requests[i] != want[i] {
+			t.Fatalf("requests = %v, want %v", requests, want)
+		}
 	}
 }
 

--- a/internal/streaming/block_read_seeker.go
+++ b/internal/streaming/block_read_seeker.go
@@ -226,9 +226,28 @@ func (r *BlockReadSeeker) ensureBlock(idx int) error {
 // of `IN` resolved to its own partition.
 func QueryBlockSizes(ctx context.Context, database *db.DB, orgID string, blockStore BlockReader, blockIDs []string) ([]int64, error) {
 	sizes := make([]int64, len(blockIDs))
+	toLookup := make([]int, 0, len(blockIDs))
 
 	if len(blockIDs) == 0 {
 		return sizes, nil
+	}
+	if cached, ok := blockStore.(interface {
+		CachedBlockSize(string) (int64, bool)
+	}); ok {
+		for i, blockID := range blockIDs {
+			var found bool
+			sizes[i], found = cached.CachedBlockSize(blockID)
+			if !found {
+				toLookup = append(toLookup, i)
+			}
+		}
+		if len(toLookup) == 0 {
+			return sizes, nil
+		}
+	} else {
+		for i := range blockIDs {
+			toLookup = append(toLookup, i)
+		}
 	}
 
 	// Step 1: parallel single-row reads from Cassandra.
@@ -239,13 +258,14 @@ func QueryBlockSizes(ctx context.Context, database *db.DB, orgID string, blockSt
 	}
 
 	concurrency := blockSizesConcurrency
-	if concurrency > len(blockIDs) {
-		concurrency = len(blockIDs)
+	if concurrency > len(toLookup) {
+		concurrency = len(toLookup)
 	}
 	sem := make(chan struct{}, concurrency)
-	results := make(chan lookupResult, len(blockIDs))
+	results := make(chan lookupResult, len(toLookup))
 
-	for i, blockID := range blockIDs {
+	for _, i := range toLookup {
+		blockID := blockIDs[i]
 		sem <- struct{}{}
 		go func(idx int, bid string) {
 			defer func() { <-sem }()
@@ -265,7 +285,7 @@ func QueryBlockSizes(ctx context.Context, database *db.DB, orgID string, blockSt
 	}
 
 	var missing []int
-	for i := 0; i < len(blockIDs); i++ {
+	for range toLookup {
 		r := <-results
 		if r.ok {
 			sizes[r.idx] = r.size

--- a/internal/streaming/canonical_block_reader.go
+++ b/internal/streaming/canonical_block_reader.go
@@ -1,0 +1,353 @@
+package streaming
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Sesame-Disk/sesamefs/internal/db"
+	"github.com/Sesame-Disk/sesamefs/internal/storage"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	canonicalBlockLocationConcurrency    = 32
+	canonicalBlockLocationLookupAttempts = 3
+)
+
+var canonicalBlockLocationRetryDelay = 25 * time.Millisecond
+
+var ErrCanonicalBlockMetadataNotFound = errors.New("canonical block metadata not found")
+
+var canonicalBlockLocationLookup = func(ctx context.Context, database *db.DB, orgID, blockID string) (db.BlockStorageLocation, bool, error) {
+	if database == nil || database.Session() == nil {
+		return db.BlockStorageLocation{}, false, fmt.Errorf("canonical block location database is unavailable")
+	}
+	return database.GetBlockStorageLocation(ctx, orgID, blockID)
+}
+
+var canonicalBlockStoreLookup = func(manager *storage.Manager, orgID, storageClass string) (*storage.BlockStore, error) {
+	return manager.GetBlockStoreForOrg(orgID, storageClass)
+}
+
+var canonicalBlockGet = func(ctx context.Context, store *storage.BlockStore, storageKey string) ([]byte, error) {
+	return store.GetBlockByStorageKey(ctx, storageKey)
+}
+
+var canonicalBlockGetReader = func(ctx context.Context, store *storage.BlockStore, storageKey string) (io.ReadCloser, error) {
+	return store.GetBlockReaderByStorageKey(ctx, storageKey)
+}
+
+var canonicalBlockGetSize = func(ctx context.Context, store *storage.BlockStore, storageKey string) (int64, error) {
+	return store.GetBlockSizeByStorageKey(ctx, storageKey)
+}
+
+var canonicalBlockExists = func(ctx context.Context, store *storage.BlockStore, storageKey string) (bool, error) {
+	return store.ObjectExists(ctx, storageKey)
+}
+
+// CanonicalBlockReader extends BlockReader with canonical physical existence checks.
+type CanonicalBlockReader interface {
+	BlockReader
+	CheckBlocksExist(context.Context, []string, int) (map[string]bool, error)
+}
+
+type canonicalBlockReader struct {
+	locations map[string]canonicalBlockLocation
+}
+
+type canonicalBlockLocation struct {
+	store      *storage.BlockStore
+	storageKey string
+	sizeBytes  int64
+	missing    bool
+}
+
+var _ BlockReader = (*canonicalBlockReader)(nil)
+
+// NewCanonicalBlockReader resolves every unique block's canonical location.
+// Missing metadata is retried three times to tolerate a short publication race.
+func NewCanonicalBlockReader(
+	ctx context.Context,
+	database *db.DB,
+	manager *storage.Manager,
+	orgID string,
+	blockIDs []string,
+	fallback *storage.BlockStore,
+	fallbackClass string,
+) (CanonicalBlockReader, error) {
+	return newCanonicalBlockReader(ctx, database, manager, orgID, blockIDs, fallback, fallbackClass, true)
+}
+
+// NewCanonicalBlockCheckReader resolves locations for existence checks. Missing
+// or deleting metadata is absent and is not retried or sent to a fallback store.
+func NewCanonicalBlockCheckReader(
+	ctx context.Context,
+	database *db.DB,
+	manager *storage.Manager,
+	orgID string,
+	blockIDs []string,
+	fallback *storage.BlockStore,
+	fallbackClass string,
+) (CanonicalBlockReader, error) {
+	return newCanonicalBlockReader(ctx, database, manager, orgID, blockIDs, fallback, fallbackClass, false)
+}
+
+func newCanonicalBlockReader(
+	ctx context.Context,
+	database *db.DB,
+	manager *storage.Manager,
+	orgID string,
+	blockIDs []string,
+	fallback *storage.BlockStore,
+	fallbackClass string,
+	strictRead bool,
+) (CanonicalBlockReader, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	reader := &canonicalBlockReader{locations: make(map[string]canonicalBlockLocation, len(blockIDs))}
+	uniqueBlockIDs := make([]string, 0, len(blockIDs))
+	for _, rawBlockID := range blockIDs {
+		blockID := db.NormalizeBlockID(rawBlockID)
+		if !db.IsSHA256BlockID(blockID) {
+			return nil, fmt.Errorf("block %q is not a resolved SHA-256 block id", rawBlockID)
+		}
+		if _, exists := reader.locations[blockID]; exists {
+			continue
+		}
+		reader.locations[blockID] = canonicalBlockLocation{}
+		uniqueBlockIDs = append(uniqueBlockIDs, blockID)
+	}
+
+	var mu sync.Mutex
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(canonicalBlockLocationConcurrency)
+	for _, id := range uniqueBlockIDs {
+		if err := gctx.Err(); err != nil {
+			if waitErr := g.Wait(); waitErr != nil {
+				return nil, waitErr
+			}
+			return nil, err
+		}
+		blockID := id
+		g.Go(func() error {
+			metadata, found, err := lookupCanonicalBlockLocation(gctx, database, orgID, blockID, strictRead)
+			if err != nil {
+				return fmt.Errorf("read canonical location for block %s: %w", blockID, err)
+			}
+			if !found {
+				if strictRead {
+					return fmt.Errorf("%w: %s", ErrCanonicalBlockMetadataNotFound, blockID)
+				}
+				mu.Lock()
+				reader.locations[blockID] = canonicalBlockLocation{missing: true}
+				mu.Unlock()
+				return nil
+			}
+			if metadata.GCState == db.BlockGCStateDeleting || metadata.GCState == db.BlockGCStateRepairingStub {
+				if strictRead {
+					return fmt.Errorf("canonical block %s is not readable in gc state %q", blockID, metadata.GCState)
+				}
+				mu.Lock()
+				reader.locations[blockID] = canonicalBlockLocation{missing: true}
+				mu.Unlock()
+				return nil
+			}
+			if metadata.GCState != "" {
+				return fmt.Errorf("canonical block %s has unknown gc state %q", blockID, metadata.GCState)
+			}
+			if metadata.CreatedAt == nil {
+				if !strictRead && strings.TrimSpace(metadata.StorageClass) == "" {
+					mu.Lock()
+					reader.locations[blockID] = canonicalBlockLocation{missing: true}
+					mu.Unlock()
+					return nil
+				}
+				return fmt.Errorf("canonical block %s has storage metadata without a creation timestamp", blockID)
+			}
+
+			storageClass := strings.TrimSpace(metadata.StorageClass)
+			if storageClass == "" {
+				return fmt.Errorf("canonical storage class is empty for block %s", blockID)
+			}
+
+			var store *storage.BlockStore
+			switch {
+			case manager != nil:
+				store, err = canonicalBlockStoreLookup(manager, orgID, storageClass)
+				if err != nil {
+					return fmt.Errorf("resolve canonical storage class %q for block %s: %w", storageClass, blockID, err)
+				}
+			case fallback != nil && storageClass == strings.TrimSpace(fallbackClass):
+				store = fallback
+			default:
+				return fmt.Errorf("canonical storage class %q for block %s is unavailable", storageClass, blockID)
+			}
+			if store == nil {
+				return fmt.Errorf("no block store available for block %s", blockID)
+			}
+
+			storageKey := store.StorageKeyForHash(blockID)
+			if persistedKey := strings.TrimSpace(metadata.StorageKey); persistedKey != "" && persistedKey != storageKey {
+				return fmt.Errorf("canonical storage key %q for block %s does not match derived org-scoped key %q", persistedKey, blockID, storageKey)
+			}
+
+			mu.Lock()
+			reader.locations[blockID] = canonicalBlockLocation{
+				store:      store,
+				storageKey: storageKey,
+				sizeBytes:  metadata.SizeBytes,
+			}
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	for blockID, location := range reader.locations {
+		if !location.missing && (location.store == nil || location.storageKey == "") {
+			return nil, fmt.Errorf("canonical location for block %s was not resolved", blockID)
+		}
+	}
+	return reader, nil
+}
+
+func lookupCanonicalBlockLocation(ctx context.Context, database *db.DB, orgID, blockID string, retryMissing bool) (db.BlockStorageLocation, bool, error) {
+	for attempt := 1; attempt <= canonicalBlockLocationLookupAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return db.BlockStorageLocation{}, false, err
+		}
+		metadata, found, err := canonicalBlockLocationLookup(ctx, database, orgID, blockID)
+		if err != nil {
+			return db.BlockStorageLocation{}, false, err
+		}
+		if found || !retryMissing {
+			return metadata, found, nil
+		}
+		if attempt == canonicalBlockLocationLookupAttempts {
+			break
+		}
+		timer := time.NewTimer(canonicalBlockLocationRetryDelay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return db.BlockStorageLocation{}, false, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return db.BlockStorageLocation{}, false, nil
+}
+
+func (r *canonicalBlockReader) CheckBlocksExist(ctx context.Context, blockIDs []string, concurrency int) (map[string]bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if concurrency < 1 || concurrency > canonicalBlockLocationConcurrency {
+		concurrency = canonicalBlockLocationConcurrency
+	}
+
+	result := make(map[string]bool, len(blockIDs))
+	unique := make([]string, 0, len(blockIDs))
+	for _, rawBlockID := range blockIDs {
+		blockID := db.NormalizeBlockID(rawBlockID)
+		if !db.IsSHA256BlockID(blockID) {
+			return nil, fmt.Errorf("block %q is not a resolved SHA-256 block id", rawBlockID)
+		}
+		if _, seen := result[blockID]; seen {
+			continue
+		}
+		result[blockID] = false
+		unique = append(unique, blockID)
+	}
+
+	var mu sync.Mutex
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(concurrency)
+	for _, id := range unique {
+		blockID := id
+		g.Go(func() error {
+			location, ok := r.locations[blockID]
+			if !ok {
+				return fmt.Errorf("block %q was not pre-resolved", blockID)
+			}
+			if location.missing {
+				return nil
+			}
+			exists, err := canonicalBlockExists(gctx, location.store, location.storageKey)
+			if err != nil {
+				return fmt.Errorf("check canonical block %s: %w", blockID, err)
+			}
+			mu.Lock()
+			result[blockID] = exists
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (r *canonicalBlockReader) GetBlock(ctx context.Context, hash string) ([]byte, error) {
+	location, err := r.location(hash)
+	if err != nil {
+		return nil, err
+	}
+	return canonicalBlockGet(ctx, location.store, location.storageKey)
+}
+
+func (r *canonicalBlockReader) GetBlockReader(ctx context.Context, hash string) (io.ReadCloser, error) {
+	location, err := r.location(hash)
+	if err != nil {
+		return nil, err
+	}
+	return canonicalBlockGetReader(ctx, location.store, location.storageKey)
+}
+
+func (r *canonicalBlockReader) GetBlockSize(ctx context.Context, hash string) (int64, error) {
+	location, err := r.location(hash)
+	if err != nil {
+		return 0, err
+	}
+	if location.sizeBytes > 0 {
+		return location.sizeBytes, nil
+	}
+	return canonicalBlockGetSize(ctx, location.store, location.storageKey)
+}
+
+func (r *canonicalBlockReader) CachedBlockSize(hash string) (int64, bool) {
+	location, err := r.location(hash)
+	if err != nil || location.sizeBytes <= 0 {
+		return 0, false
+	}
+	return location.sizeBytes, true
+}
+
+func (r *canonicalBlockReader) location(blockID string) (canonicalBlockLocation, error) {
+	blockID = db.NormalizeBlockID(blockID)
+	if !db.IsSHA256BlockID(blockID) {
+		return canonicalBlockLocation{}, fmt.Errorf("block %q is not a resolved SHA-256 block id", blockID)
+	}
+	location, ok := r.locations[blockID]
+	if !ok {
+		return canonicalBlockLocation{}, fmt.Errorf("block %q was not pre-resolved", blockID)
+	}
+	if location.missing {
+		return canonicalBlockLocation{}, fmt.Errorf("%w: %s", ErrCanonicalBlockMetadataNotFound, blockID)
+	}
+	return location, nil
+}

--- a/internal/streaming/canonical_block_reader.go
+++ b/internal/streaming/canonical_block_reader.go
@@ -15,7 +15,10 @@ import (
 )
 
 const (
-	canonicalBlockLocationConcurrency    = 32
+	canonicalBlockLocationConcurrency = 32
+	// canonicalBlockLocationLookupAttempts counts TOTAL attempts, not retries:
+	// 3 attempts means the first lookup plus 2 retries, and therefore only 2
+	// waits of canonicalBlockLocationRetryDelay.
 	canonicalBlockLocationLookupAttempts = 3
 )
 
@@ -70,7 +73,10 @@ type canonicalBlockLocation struct {
 var _ BlockReader = (*canonicalBlockReader)(nil)
 
 // NewCanonicalBlockReader resolves every unique block's canonical location.
-// Missing metadata is retried three times to tolerate a short publication race.
+// Missing metadata is looked up canonicalBlockLocationLookupAttempts times in
+// total — 3 attempts, so 2 retries separated by 2 waits of
+// canonicalBlockLocationRetryDelay (~50ms overall) — to tolerate a short
+// publication race.
 func NewCanonicalBlockReader(
 	ctx context.Context,
 	database *db.DB,

--- a/internal/streaming/canonical_block_reader_test.go
+++ b/internal/streaming/canonical_block_reader_test.go
@@ -133,7 +133,9 @@ func TestCanonicalBlockReaderRoutesCanonicalLocationsAndDeduplicates(t *testing.
 	}
 }
 
-func TestCanonicalBlockReaderStrictMissingRetriesThreeTimes(t *testing.T) {
+// A persistently missing row is looked up 3 times in total (1 attempt + 2
+// retries), not retried 3 times.
+func TestCanonicalBlockReaderStrictMissingUsesThreeTotalAttempts(t *testing.T) {
 	resetCanonicalReaderHooks(t)
 	blockID := canonicalReaderTestID(303)
 	var calls atomic.Int32
@@ -157,7 +159,8 @@ func TestCanonicalBlockReaderStrictRetryCanObserveMetadata(t *testing.T) {
 	store := canonicalReaderTestStore(t)
 	var calls atomic.Int32
 	canonicalBlockLocationLookup = func(context.Context, *db.DB, string, string) (db.BlockStorageLocation, bool, error) {
-		if calls.Add(1) < 3 {
+		// Fail every attempt but the last one the budget allows.
+		if calls.Add(1) < canonicalBlockLocationLookupAttempts {
 			return db.BlockStorageLocation{}, false, nil
 		}
 		return db.BlockStorageLocation{StorageClass: "fallback", StorageKey: store.StorageKeyForHash(blockID), CreatedAt: canonicalReaderTestCreatedAt()}, true, nil
@@ -167,8 +170,8 @@ func TestCanonicalBlockReaderStrictRetryCanObserveMetadata(t *testing.T) {
 	if err != nil || reader == nil {
 		t.Fatalf("NewCanonicalBlockReader() = (%v, %v), want reader", reader, err)
 	}
-	if calls.Load() != 3 {
-		t.Fatalf("lookup calls = %d, want 3", calls.Load())
+	if calls.Load() != canonicalBlockLocationLookupAttempts {
+		t.Fatalf("lookup calls = %d, want %d", calls.Load(), canonicalBlockLocationLookupAttempts)
 	}
 }
 

--- a/internal/streaming/canonical_block_reader_test.go
+++ b/internal/streaming/canonical_block_reader_test.go
@@ -1,0 +1,464 @@
+package streaming
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Sesame-Disk/sesamefs/internal/db"
+	"github.com/Sesame-Disk/sesamefs/internal/storage"
+)
+
+const canonicalReaderTestOrg = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+
+func canonicalReaderTestID(n int) string {
+	return fmt.Sprintf("%064x", n)
+}
+
+func canonicalReaderTestCreatedAt() *time.Time {
+	createdAt := time.Unix(1, 0).UTC()
+	return &createdAt
+}
+
+func canonicalReaderTestStore(t *testing.T) *storage.BlockStore {
+	t.Helper()
+	store, err := storage.NewOrgBlockStore(nil, "blocks/", canonicalReaderTestOrg)
+	if err != nil {
+		t.Fatalf("NewOrgBlockStore() error = %v", err)
+	}
+	return store
+}
+
+func resetCanonicalReaderHooks(t *testing.T) {
+	t.Helper()
+	oldLocationLookup := canonicalBlockLocationLookup
+	oldStoreLookup := canonicalBlockStoreLookup
+	oldGet := canonicalBlockGet
+	oldGetReader := canonicalBlockGetReader
+	oldGetSize := canonicalBlockGetSize
+	oldExists := canonicalBlockExists
+	oldRetryDelay := canonicalBlockLocationRetryDelay
+	canonicalBlockLocationRetryDelay = 0
+	t.Cleanup(func() {
+		canonicalBlockLocationLookup = oldLocationLookup
+		canonicalBlockStoreLookup = oldStoreLookup
+		canonicalBlockGet = oldGet
+		canonicalBlockGetReader = oldGetReader
+		canonicalBlockGetSize = oldGetSize
+		canonicalBlockExists = oldExists
+		canonicalBlockLocationRetryDelay = oldRetryDelay
+	})
+}
+
+func TestCanonicalBlockReaderRoutesCanonicalLocationsAndDeduplicates(t *testing.T) {
+	resetCanonicalReaderHooks(t)
+	idA := canonicalReaderTestID(101)
+	idB := canonicalReaderTestID(202)
+	storeA := canonicalReaderTestStore(t)
+	storeB := canonicalReaderTestStore(t)
+	keyA := storeA.StorageKeyForHash(idA)
+	keyB := storeB.StorageKeyForHash(idB)
+	metadata := map[string]db.BlockStorageLocation{
+		idA: {SizeBytes: 11, StorageClass: "class-a", StorageKey: keyA, CreatedAt: canonicalReaderTestCreatedAt()},
+		idB: {SizeBytes: 22, StorageClass: "class-b", StorageKey: keyB, CreatedAt: canonicalReaderTestCreatedAt()},
+	}
+	lookupCalls := map[string]int{}
+	var lookupMu sync.Mutex
+	canonicalBlockLocationLookup = func(_ context.Context, _ *db.DB, orgID, blockID string) (db.BlockStorageLocation, bool, error) {
+		if orgID != canonicalReaderTestOrg {
+			return db.BlockStorageLocation{}, false, fmt.Errorf("orgID = %q", orgID)
+		}
+		lookupMu.Lock()
+		lookupCalls[blockID]++
+		lookupMu.Unlock()
+		location, found := metadata[blockID]
+		return location, found, nil
+	}
+	canonicalBlockStoreLookup = func(_ *storage.Manager, orgID, class string) (*storage.BlockStore, error) {
+		if orgID != canonicalReaderTestOrg {
+			return nil, fmt.Errorf("orgID = %q", orgID)
+		}
+		switch class {
+		case "class-a":
+			return storeA, nil
+		case "class-b":
+			return storeB, nil
+		default:
+			return nil, fmt.Errorf("unexpected class %q", class)
+		}
+	}
+	canonicalBlockGet = func(_ context.Context, store *storage.BlockStore, key string) ([]byte, error) {
+		if store != storeA || key != keyA {
+			return nil, fmt.Errorf("wrong GetBlock route")
+		}
+		return []byte("a"), nil
+	}
+	canonicalBlockGetReader = func(_ context.Context, store *storage.BlockStore, key string) (io.ReadCloser, error) {
+		if store != storeB || key != keyB {
+			return nil, fmt.Errorf("wrong GetBlockReader route")
+		}
+		return io.NopCloser(strings.NewReader("b")), nil
+	}
+	canonicalBlockGetSize = func(context.Context, *storage.BlockStore, string) (int64, error) {
+		return 0, errors.New("metadata size should avoid HEAD")
+	}
+
+	reader, err := NewCanonicalBlockReader(context.Background(), nil, storage.NewManager(), canonicalReaderTestOrg, []string{idA, idB, idA}, nil, "")
+	if err != nil {
+		t.Fatalf("NewCanonicalBlockReader() error = %v", err)
+	}
+	if lookupCalls[idA] != 1 || lookupCalls[idB] != 1 {
+		t.Fatalf("lookup calls = %v, want one per unique ID", lookupCalls)
+	}
+	if data, err := reader.GetBlock(context.Background(), idA); err != nil || string(data) != "a" {
+		t.Fatalf("GetBlock() = %q, %v", data, err)
+	}
+	blockReader, err := reader.GetBlockReader(context.Background(), idB)
+	if err != nil {
+		t.Fatalf("GetBlockReader() error = %v", err)
+	}
+	data, err := io.ReadAll(blockReader)
+	_ = blockReader.Close()
+	if err != nil || string(data) != "b" {
+		t.Fatalf("reader = %q, %v", data, err)
+	}
+	if size, err := reader.GetBlockSize(context.Background(), idA); err != nil || size != 11 {
+		t.Fatalf("GetBlockSize() = %d, %v, want 11, nil", size, err)
+	}
+}
+
+func TestCanonicalBlockReaderStrictMissingRetriesThreeTimes(t *testing.T) {
+	resetCanonicalReaderHooks(t)
+	blockID := canonicalReaderTestID(303)
+	var calls atomic.Int32
+	canonicalBlockLocationLookup = func(context.Context, *db.DB, string, string) (db.BlockStorageLocation, bool, error) {
+		calls.Add(1)
+		return db.BlockStorageLocation{}, false, nil
+	}
+
+	reader, err := NewCanonicalBlockReader(context.Background(), nil, nil, canonicalReaderTestOrg, []string{blockID}, canonicalReaderTestStore(t), "fallback")
+	if reader != nil || !errors.Is(err, ErrCanonicalBlockMetadataNotFound) {
+		t.Fatalf("NewCanonicalBlockReader() = (%v, %v), want metadata-not-found", reader, err)
+	}
+	if calls.Load() != canonicalBlockLocationLookupAttempts {
+		t.Fatalf("lookup calls = %d, want %d", calls.Load(), canonicalBlockLocationLookupAttempts)
+	}
+}
+
+func TestCanonicalBlockReaderStrictRetryCanObserveMetadata(t *testing.T) {
+	resetCanonicalReaderHooks(t)
+	blockID := canonicalReaderTestID(304)
+	store := canonicalReaderTestStore(t)
+	var calls atomic.Int32
+	canonicalBlockLocationLookup = func(context.Context, *db.DB, string, string) (db.BlockStorageLocation, bool, error) {
+		if calls.Add(1) < 3 {
+			return db.BlockStorageLocation{}, false, nil
+		}
+		return db.BlockStorageLocation{StorageClass: "fallback", StorageKey: store.StorageKeyForHash(blockID), CreatedAt: canonicalReaderTestCreatedAt()}, true, nil
+	}
+
+	reader, err := NewCanonicalBlockReader(context.Background(), nil, nil, canonicalReaderTestOrg, []string{blockID}, store, "fallback")
+	if err != nil || reader == nil {
+		t.Fatalf("NewCanonicalBlockReader() = (%v, %v), want reader", reader, err)
+	}
+	if calls.Load() != 3 {
+		t.Fatalf("lookup calls = %d, want 3", calls.Load())
+	}
+}
+
+func TestCanonicalBlockReaderDatabaseErrorFailsWithoutRetry(t *testing.T) {
+	resetCanonicalReaderHooks(t)
+	databaseErr := errors.New("cassandra timeout")
+	var calls atomic.Int32
+	canonicalBlockLocationLookup = func(context.Context, *db.DB, string, string) (db.BlockStorageLocation, bool, error) {
+		calls.Add(1)
+		return db.BlockStorageLocation{}, false, databaseErr
+	}
+
+	reader, err := NewCanonicalBlockReader(context.Background(), nil, nil, canonicalReaderTestOrg, []string{canonicalReaderTestID(305)}, canonicalReaderTestStore(t), "fallback")
+	if reader != nil || !errors.Is(err, databaseErr) {
+		t.Fatalf("NewCanonicalBlockReader() = (%v, %v), want database error", reader, err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("lookup calls = %d, want 1", calls.Load())
+	}
+}
+
+func TestCanonicalBlockCheckReaderDoesNotRetryMissingOrDeleting(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		location db.BlockStorageLocation
+		found    bool
+	}{
+		{name: "missing"},
+		{name: "deleting", location: db.BlockStorageLocation{GCState: db.BlockGCStateDeleting}, found: true},
+		{name: "released stub", location: db.BlockStorageLocation{}, found: true},
+		{name: "repairing stub", location: db.BlockStorageLocation{GCState: db.BlockGCStateRepairingStub}, found: true},
+		{name: "repairing stub with storage metadata", location: db.BlockStorageLocation{GCState: db.BlockGCStateRepairingStub, StorageClass: "fallback", CreatedAt: canonicalReaderTestCreatedAt()}, found: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetCanonicalReaderHooks(t)
+			blockID := canonicalReaderTestID(400)
+			var calls atomic.Int32
+			canonicalBlockLocationLookup = func(context.Context, *db.DB, string, string) (db.BlockStorageLocation, bool, error) {
+				calls.Add(1)
+				return tc.location, tc.found, nil
+			}
+			canonicalBlockExists = func(context.Context, *storage.BlockStore, string) (bool, error) {
+				return false, errors.New("missing location must not probe storage")
+			}
+
+			reader, err := NewCanonicalBlockCheckReader(context.Background(), nil, storage.NewManager(), canonicalReaderTestOrg, []string{blockID}, nil, "")
+			if err != nil {
+				t.Fatalf("NewCanonicalBlockCheckReader() error = %v", err)
+			}
+			exists, err := reader.CheckBlocksExist(context.Background(), []string{blockID}, 1)
+			if err != nil || exists[blockID] {
+				t.Fatalf("CheckBlocksExist() = %v, %v, want absent", exists, err)
+			}
+			if calls.Load() != 1 {
+				t.Fatalf("lookup calls = %d, want 1", calls.Load())
+			}
+		})
+	}
+}
+
+func TestCanonicalBlockReaderStrictRejectsDeleting(t *testing.T) {
+	resetCanonicalReaderHooks(t)
+	blockID := canonicalReaderTestID(401)
+	store := canonicalReaderTestStore(t)
+	canonicalBlockLocationLookup = func(context.Context, *db.DB, string, string) (db.BlockStorageLocation, bool, error) {
+		return db.BlockStorageLocation{
+			StorageClass: "fallback",
+			StorageKey:   store.StorageKeyForHash(blockID),
+			GCState:      db.BlockGCStateDeleting,
+			CreatedAt:    canonicalReaderTestCreatedAt(),
+		}, true, nil
+	}
+	canonicalBlockGet = func(context.Context, *storage.BlockStore, string) ([]byte, error) {
+		t.Fatal("deleting block must not reach storage")
+		return nil, nil
+	}
+
+	reader, err := NewCanonicalBlockReader(context.Background(), nil, nil, canonicalReaderTestOrg, []string{blockID}, store, "fallback")
+	if reader != nil || err == nil {
+		t.Fatalf("NewCanonicalBlockReader() = (%v, %v), want deleting error", reader, err)
+	}
+}
+
+func TestCanonicalBlockReaderRejectsStorageMetadataWithoutCreationTimestamp(t *testing.T) {
+	resetCanonicalReaderHooks(t)
+	blockID := canonicalReaderTestID(402)
+	store := canonicalReaderTestStore(t)
+	canonicalBlockLocationLookup = func(context.Context, *db.DB, string, string) (db.BlockStorageLocation, bool, error) {
+		return db.BlockStorageLocation{StorageClass: "fallback", StorageKey: store.StorageKeyForHash(blockID)}, true, nil
+	}
+	if reader, err := NewCanonicalBlockCheckReader(context.Background(), nil, nil, canonicalReaderTestOrg, []string{blockID}, store, "fallback"); reader != nil || err == nil {
+		t.Fatalf("NewCanonicalBlockCheckReader() = (%v, %v), want malformed metadata error", reader, err)
+	}
+}
+
+func TestCanonicalBlockReaderRejectsUnknownGCState(t *testing.T) {
+	resetCanonicalReaderHooks(t)
+	blockID := canonicalReaderTestID(403)
+	store := canonicalReaderTestStore(t)
+	for _, gcState := range []string{"unknown", " deleting "} {
+		t.Run(gcState, func(t *testing.T) {
+			canonicalBlockLocationLookup = func(context.Context, *db.DB, string, string) (db.BlockStorageLocation, bool, error) {
+				return db.BlockStorageLocation{StorageClass: "fallback", StorageKey: store.StorageKeyForHash(blockID), GCState: gcState, CreatedAt: canonicalReaderTestCreatedAt()}, true, nil
+			}
+			if reader, err := NewCanonicalBlockCheckReader(context.Background(), nil, nil, canonicalReaderTestOrg, []string{blockID}, store, "fallback"); reader != nil || err == nil {
+				t.Fatalf("NewCanonicalBlockCheckReader() = (%v, %v), want unknown-state error", reader, err)
+			}
+		})
+	}
+}
+
+func TestCanonicalBlockReaderCancellationInterruptsRetryWait(t *testing.T) {
+	resetCanonicalReaderHooks(t)
+	canonicalBlockLocationRetryDelay = time.Hour
+	started := make(chan struct{})
+	var calls atomic.Int32
+	canonicalBlockLocationLookup = func(context.Context, *db.DB, string, string) (db.BlockStorageLocation, bool, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		return db.BlockStorageLocation{}, false, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	store := canonicalReaderTestStore(t)
+	go func() {
+		_, err := NewCanonicalBlockReader(ctx, nil, nil, canonicalReaderTestOrg, []string{canonicalReaderTestID(500)}, store, "fallback")
+		result <- err
+	}()
+	<-started
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancellation did not interrupt retry wait")
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("lookup calls = %d, want 1", calls.Load())
+	}
+}
+
+func TestCanonicalBlockReaderBoundsUniqueLocationLookups(t *testing.T) {
+	resetCanonicalReaderHooks(t)
+	const uniqueCount = 64
+	blockIDs := make([]string, 0, uniqueCount+1)
+	for i := 1; i <= uniqueCount; i++ {
+		blockIDs = append(blockIDs, canonicalReaderTestID(i))
+	}
+	blockIDs = append(blockIDs, blockIDs[0])
+	release := make(chan struct{})
+	reachedLimit := make(chan struct{})
+	var active atomic.Int32
+	var maximum atomic.Int32
+	var calls atomic.Int32
+	canonicalBlockLocationLookup = func(_ context.Context, _ *db.DB, _ string, _ string) (db.BlockStorageLocation, bool, error) {
+		calls.Add(1)
+		current := active.Add(1)
+		for {
+			old := maximum.Load()
+			if current <= old || maximum.CompareAndSwap(old, current) {
+				break
+			}
+		}
+		if current == canonicalBlockLocationConcurrency {
+			select {
+			case <-reachedLimit:
+			default:
+				close(reachedLimit)
+			}
+		}
+		<-release
+		active.Add(-1)
+		return db.BlockStorageLocation{StorageClass: "fallback", CreatedAt: canonicalReaderTestCreatedAt()}, true, nil
+	}
+	result := make(chan error, 1)
+	store := canonicalReaderTestStore(t)
+	go func() {
+		_, err := NewCanonicalBlockReader(context.Background(), nil, nil, canonicalReaderTestOrg, blockIDs, store, "fallback")
+		result <- err
+	}()
+	select {
+	case <-reachedLimit:
+	case <-time.After(time.Second):
+		t.Fatal("lookups did not reach configured concurrency")
+	}
+	close(release)
+	if err := <-result; err != nil {
+		t.Fatalf("NewCanonicalBlockReader() error = %v", err)
+	}
+	if maximum.Load() != canonicalBlockLocationConcurrency {
+		t.Fatalf("maximum concurrency = %d, want %d", maximum.Load(), canonicalBlockLocationConcurrency)
+	}
+	if calls.Load() != uniqueCount {
+		t.Fatalf("lookup calls = %d, want %d unique lookups", calls.Load(), uniqueCount)
+	}
+}
+
+func TestCanonicalBlockReaderRejectsInvalidIDAndMismatchedKey(t *testing.T) {
+	resetCanonicalReaderHooks(t)
+	if reader, err := NewCanonicalBlockReader(context.Background(), nil, nil, canonicalReaderTestOrg, []string{strings.Repeat("z", 64)}, canonicalReaderTestStore(t), "fallback"); reader != nil || err == nil {
+		t.Fatalf("invalid SHA-256 = (%v, %v), want rejection", reader, err)
+	}
+
+	blockID := canonicalReaderTestID(600)
+	store := canonicalReaderTestStore(t)
+	canonicalBlockLocationLookup = func(context.Context, *db.DB, string, string) (db.BlockStorageLocation, bool, error) {
+		return db.BlockStorageLocation{
+			StorageClass: "fallback",
+			StorageKey:   "blocks/6b2f9c1e-7a3d-4c5b-8e1f-0a9b8c7d6e5f/00/00/" + blockID,
+			CreatedAt:    canonicalReaderTestCreatedAt(),
+		}, true, nil
+	}
+	reader, err := NewCanonicalBlockReader(context.Background(), nil, nil, canonicalReaderTestOrg, []string{blockID}, store, "fallback")
+	if reader != nil || err == nil || !strings.Contains(err.Error(), "does not match derived org-scoped key") {
+		t.Fatalf("mismatched key = (%v, %v), want rejection", reader, err)
+	}
+}
+
+func TestCanonicalBlockReaderExactClassAndBackendErrorsFailClosed(t *testing.T) {
+	resetCanonicalReaderHooks(t)
+	blockID := canonicalReaderTestID(700)
+	backendErr := errors.New("canonical backend unavailable")
+	canonicalBlockLocationLookup = func(context.Context, *db.DB, string, string) (db.BlockStorageLocation, bool, error) {
+		return db.BlockStorageLocation{StorageClass: "canonical", CreatedAt: canonicalReaderTestCreatedAt()}, true, nil
+	}
+	canonicalBlockStoreLookup = func(*storage.Manager, string, string) (*storage.BlockStore, error) {
+		return nil, backendErr
+	}
+	reader, err := NewCanonicalBlockReader(context.Background(), nil, storage.NewManager(), canonicalReaderTestOrg, []string{blockID}, canonicalReaderTestStore(t), "canonical")
+	if reader != nil || !errors.Is(err, backendErr) {
+		t.Fatalf("manager lookup = (%v, %v), want backend error", reader, err)
+	}
+
+	fallback := canonicalReaderTestStore(t)
+	reader, err = NewCanonicalBlockReader(context.Background(), nil, nil, canonicalReaderTestOrg, []string{blockID}, fallback, "CANONICAL")
+	if reader != nil || err == nil {
+		t.Fatalf("case-mismatched fallback class = (%v, %v), want exact-class error", reader, err)
+	}
+
+	reader, err = NewCanonicalBlockReader(context.Background(), nil, nil, canonicalReaderTestOrg, []string{blockID}, fallback, "")
+	if reader != nil || err == nil {
+		t.Fatalf("empty fallback class = (%v, %v), want exact-class error", reader, err)
+	}
+}
+
+func TestCanonicalBlockReaderExistenceBackendErrorFailsClosed(t *testing.T) {
+	resetCanonicalReaderHooks(t)
+	blockID := canonicalReaderTestID(800)
+	store := canonicalReaderTestStore(t)
+	canonicalBlockLocationLookup = func(context.Context, *db.DB, string, string) (db.BlockStorageLocation, bool, error) {
+		return db.BlockStorageLocation{StorageClass: "fallback", CreatedAt: canonicalReaderTestCreatedAt()}, true, nil
+	}
+	backendErr := errors.New("HEAD failed")
+	var calls atomic.Int32
+	canonicalBlockExists = func(context.Context, *storage.BlockStore, string) (bool, error) {
+		calls.Add(1)
+		return false, backendErr
+	}
+	reader, err := NewCanonicalBlockCheckReader(context.Background(), nil, nil, canonicalReaderTestOrg, []string{blockID, blockID}, store, "fallback")
+	if err != nil {
+		t.Fatalf("NewCanonicalBlockCheckReader() error = %v", err)
+	}
+	exists, err := reader.CheckBlocksExist(context.Background(), []string{blockID, blockID}, 100)
+	if exists != nil || !errors.Is(err, backendErr) {
+		t.Fatalf("CheckBlocksExist() = (%v, %v), want nil and backend error", exists, err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("existence calls = %d, want one deduplicated call", calls.Load())
+	}
+}
+
+func TestCanonicalBlockReaderDerivesEmptyKeyAndUsesCachedSizes(t *testing.T) {
+	resetCanonicalReaderHooks(t)
+	blockID := canonicalReaderTestID(900)
+	store := canonicalReaderTestStore(t)
+	canonicalBlockLocationLookup = func(context.Context, *db.DB, string, string) (db.BlockStorageLocation, bool, error) {
+		return db.BlockStorageLocation{SizeBytes: 99, StorageClass: "fallback", CreatedAt: canonicalReaderTestCreatedAt()}, true, nil
+	}
+	canonicalBlockGetSize = func(context.Context, *storage.BlockStore, string) (int64, error) {
+		return 0, errors.New("cached size should avoid HEAD")
+	}
+	reader, err := NewCanonicalBlockReader(context.Background(), nil, nil, canonicalReaderTestOrg, []string{blockID}, store, "fallback")
+	if err != nil {
+		t.Fatalf("NewCanonicalBlockReader() error = %v", err)
+	}
+	sizes, err := QueryBlockSizes(context.Background(), nil, canonicalReaderTestOrg, reader, []string{blockID, blockID})
+	if err != nil || len(sizes) != 2 || sizes[0] != 99 || sizes[1] != 99 {
+		t.Fatalf("QueryBlockSizes() = %v, %v, want [99 99], nil", sizes, err)
+	}
+}


### PR DESCRIPTION
## Summary
- route existing-metadata block repairs and all read surfaces through immutable canonical storage metadata
- align web session check, upload, commit, and download placement across storage classes
- fail closed on malformed or GC-owned lifecycle metadata while preserving the legacy no-session pair for PR7
- add unit, race, and real Cassandra/two-MinIO-bucket coverage

## Verification
- go test -count=1 ./internal/db ./internal/storage ./internal/streaming ./internal/api/...
- go build ./...
- go vet ./...
- go vet -tags=integration ./...
- docker compose --profile test run --rm --build gotest go test -race -count=1 ./internal/db ./internal/storage ./internal/streaming ./internal/api/...
- docker compose --profile test run --rm --build go-integration-test
- focused TestNeedsPutUsesCanonicalMinIOBucket rerun after final lifecycle hardening
- git diff --check