### PR TITLE
Close three low-risk hardening gaps: cookie httpOnly, sync body caps, batch-move false-success

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,11 @@ shared MinIO. Same verbs via `./scripts/run-playwright.sh up | test | down`.
 > dev). Seed the dev cookie in the browser console, then reload:
 > `document.cookie = "sesamefs_auth=admin@sesamefs.local@dev-token-admin; path=/"; location.href="/dashboard/"`
 > Swap `admin`/`dev-token-admin` for `user`/`dev-token-user`, etc.
+>
+> If nothing happens, you already have a real session cookie: the server sets
+> `sesamefs_auth` with `HttpOnly` (`ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01`), and a browser
+> silently ignores a script writing over an `HttpOnly` cookie. Clear the site's cookies (or
+> use a fresh/incognito profile) and run the snippet again.
 
 See [docs/MULTIREGION-TESTING.md](docs/MULTIREGION-TESTING.md) for detailed scenarios,
 and [docs/BUG-FILE-DETAIL-MODIFIER-20260618.md](docs/BUG-FILE-DETAIL-MODIFIER-20260618.md)

--- a/configs/config-eu.cluster.yaml
+++ b/configs/config-eu.cluster.yaml
@@ -256,6 +256,12 @@ seafhttp:
   # Override: SEAFHTTP_SYNC_BLOCK_MAX_BYTES
   # NOT an aggregate bound: N concurrent uploads still cost N x this value.
   sync_block_max_bytes: 16777216 # 16 MiB
+  # Bounds one recv-fs body (a batch of packed FS objects the desktop client
+  # uploads at the end of a commit). Unlike sync_block_max_bytes, there is no
+  # measured client batch size to anchor this on, so the default is deliberately
+  # generous — raise it if a real large commit needs more headroom.
+  # Override: SEAFHTTP_RECV_FS_MAX_BYTES
+  recv_fs_max_bytes: 134217728 # 128 MiB
   # Aggregate bound on concurrent block uploads (subcontract B / X10). Without
   # these, sync_block_max_bytes above bounds ONE request while N concurrent
   # uploads still cost N x the cap.

--- a/configs/config-eu.cluster.yaml
+++ b/configs/config-eu.cluster.yaml
@@ -261,6 +261,9 @@ seafhttp:
   # measured client batch size to anchor this on, so the default is deliberately
   # generous — raise it if a real large commit needs more headroom.
   # Override: SEAFHTTP_RECV_FS_MAX_BYTES
+  # No ceiling, unlike sync_block_max_bytes: raising this is an informed operator
+  # choice, not a value that is self-evidently a mistake. Zero and negative are
+  # rejected at boot — an unbounded body is the defect this cap exists to close.
   recv_fs_max_bytes: 134217728 # 128 MiB
   # Aggregate bound on concurrent block uploads (subcontract B / X10). Without
   # these, sync_block_max_bytes above bounds ONE request while N concurrent

--- a/configs/config-eu.yaml
+++ b/configs/config-eu.yaml
@@ -251,6 +251,12 @@ seafhttp:
   # Override: SEAFHTTP_SYNC_BLOCK_MAX_BYTES
   # NOT an aggregate bound: N concurrent uploads still cost N x this value.
   sync_block_max_bytes: 16777216 # 16 MiB
+  # Bounds one recv-fs body (a batch of packed FS objects the desktop client
+  # uploads at the end of a commit). Unlike sync_block_max_bytes, there is no
+  # measured client batch size to anchor this on, so the default is deliberately
+  # generous — raise it if a real large commit needs more headroom.
+  # Override: SEAFHTTP_RECV_FS_MAX_BYTES
+  recv_fs_max_bytes: 134217728 # 128 MiB
   # Aggregate bound on concurrent block uploads (subcontract B / X10). Without
   # these, sync_block_max_bytes above bounds ONE request while N concurrent
   # uploads still cost N x the cap.

--- a/configs/config-eu.yaml
+++ b/configs/config-eu.yaml
@@ -256,6 +256,9 @@ seafhttp:
   # measured client batch size to anchor this on, so the default is deliberately
   # generous — raise it if a real large commit needs more headroom.
   # Override: SEAFHTTP_RECV_FS_MAX_BYTES
+  # No ceiling, unlike sync_block_max_bytes: raising this is an informed operator
+  # choice, not a value that is self-evidently a mistake. Zero and negative are
+  # rejected at boot — an unbounded body is the defect this cap exists to close.
   recv_fs_max_bytes: 134217728 # 128 MiB
   # Aggregate bound on concurrent block uploads (subcontract B / X10). Without
   # these, sync_block_max_bytes above bounds ONE request while N concurrent

--- a/configs/config-usa.cluster.yaml
+++ b/configs/config-usa.cluster.yaml
@@ -256,6 +256,12 @@ seafhttp:
   # Override: SEAFHTTP_SYNC_BLOCK_MAX_BYTES
   # NOT an aggregate bound: N concurrent uploads still cost N x this value.
   sync_block_max_bytes: 16777216 # 16 MiB
+  # Bounds one recv-fs body (a batch of packed FS objects the desktop client
+  # uploads at the end of a commit). Unlike sync_block_max_bytes, there is no
+  # measured client batch size to anchor this on, so the default is deliberately
+  # generous — raise it if a real large commit needs more headroom.
+  # Override: SEAFHTTP_RECV_FS_MAX_BYTES
+  recv_fs_max_bytes: 134217728 # 128 MiB
   # Aggregate bound on concurrent block uploads (subcontract B / X10). Without
   # these, sync_block_max_bytes above bounds ONE request while N concurrent
   # uploads still cost N x the cap.

--- a/configs/config-usa.cluster.yaml
+++ b/configs/config-usa.cluster.yaml
@@ -261,6 +261,9 @@ seafhttp:
   # measured client batch size to anchor this on, so the default is deliberately
   # generous — raise it if a real large commit needs more headroom.
   # Override: SEAFHTTP_RECV_FS_MAX_BYTES
+  # No ceiling, unlike sync_block_max_bytes: raising this is an informed operator
+  # choice, not a value that is self-evidently a mistake. Zero and negative are
+  # rejected at boot — an unbounded body is the defect this cap exists to close.
   recv_fs_max_bytes: 134217728 # 128 MiB
   # Aggregate bound on concurrent block uploads (subcontract B / X10). Without
   # these, sync_block_max_bytes above bounds ONE request while N concurrent

--- a/configs/config-usa.yaml
+++ b/configs/config-usa.yaml
@@ -251,6 +251,12 @@ seafhttp:
   # Override: SEAFHTTP_SYNC_BLOCK_MAX_BYTES
   # NOT an aggregate bound: N concurrent uploads still cost N x this value.
   sync_block_max_bytes: 16777216 # 16 MiB
+  # Bounds one recv-fs body (a batch of packed FS objects the desktop client
+  # uploads at the end of a commit). Unlike sync_block_max_bytes, there is no
+  # measured client batch size to anchor this on, so the default is deliberately
+  # generous — raise it if a real large commit needs more headroom.
+  # Override: SEAFHTTP_RECV_FS_MAX_BYTES
+  recv_fs_max_bytes: 134217728 # 128 MiB
   # Aggregate bound on concurrent block uploads (subcontract B / X10). Without
   # these, sync_block_max_bytes above bounds ONE request while N concurrent
   # uploads still cost N x the cap.

--- a/configs/config-usa.yaml
+++ b/configs/config-usa.yaml
@@ -256,6 +256,9 @@ seafhttp:
   # measured client batch size to anchor this on, so the default is deliberately
   # generous — raise it if a real large commit needs more headroom.
   # Override: SEAFHTTP_RECV_FS_MAX_BYTES
+  # No ceiling, unlike sync_block_max_bytes: raising this is an informed operator
+  # choice, not a value that is self-evidently a mistake. Zero and negative are
+  # rejected at boot — an unbounded body is the defect this cap exists to close.
   recv_fs_max_bytes: 134217728 # 128 MiB
   # Aggregate bound on concurrent block uploads (subcontract B / X10). Without
   # these, sync_block_max_bytes above bounds ONE request while N concurrent

--- a/configs/config.docker.yaml
+++ b/configs/config.docker.yaml
@@ -165,6 +165,9 @@ seafhttp:
   # measured client batch size to anchor this on, so the default is deliberately
   # generous — raise it if a real large commit needs more headroom.
   # Override: SEAFHTTP_RECV_FS_MAX_BYTES
+  # No ceiling, unlike sync_block_max_bytes: raising this is an informed operator
+  # choice, not a value that is self-evidently a mistake. Zero and negative are
+  # rejected at boot — an unbounded body is the defect this cap exists to close.
   recv_fs_max_bytes: 134217728 # 128 MiB
   # Aggregate bound on concurrent block uploads (subcontract B / X10). Without
   # these, sync_block_max_bytes above bounds ONE request while N concurrent

--- a/configs/config.docker.yaml
+++ b/configs/config.docker.yaml
@@ -160,6 +160,12 @@ seafhttp:
   # Override: SEAFHTTP_SYNC_BLOCK_MAX_BYTES
   # NOT an aggregate bound: N concurrent uploads still cost N x this value.
   sync_block_max_bytes: 16777216 # 16 MiB
+  # Bounds one recv-fs body (a batch of packed FS objects the desktop client
+  # uploads at the end of a commit). Unlike sync_block_max_bytes, there is no
+  # measured client batch size to anchor this on, so the default is deliberately
+  # generous — raise it if a real large commit needs more headroom.
+  # Override: SEAFHTTP_RECV_FS_MAX_BYTES
+  recv_fs_max_bytes: 134217728 # 128 MiB
   # Aggregate bound on concurrent block uploads (subcontract B / X10). Without
   # these, sync_block_max_bytes above bounds ONE request while N concurrent
   # uploads still cost N x the cap.

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -271,6 +271,12 @@ seafhttp:
   # Override: SEAFHTTP_SYNC_BLOCK_MAX_BYTES
   # NOT an aggregate bound: N concurrent uploads still cost N x this value.
   sync_block_max_bytes: 16777216 # 16 MiB
+  # Bounds one recv-fs body (a batch of packed FS objects the desktop client
+  # uploads at the end of a commit). Unlike sync_block_max_bytes, there is no
+  # measured client batch size to anchor this on, so the default is deliberately
+  # generous — raise it if a real large commit needs more headroom.
+  # Override: SEAFHTTP_RECV_FS_MAX_BYTES
+  recv_fs_max_bytes: 134217728 # 128 MiB
   # Aggregate bound on concurrent block uploads (subcontract B / X10). Without
   # these, sync_block_max_bytes above bounds ONE request while N concurrent
   # uploads still cost N x the cap.

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -276,6 +276,9 @@ seafhttp:
   # measured client batch size to anchor this on, so the default is deliberately
   # generous — raise it if a real large commit needs more headroom.
   # Override: SEAFHTTP_RECV_FS_MAX_BYTES
+  # No ceiling, unlike sync_block_max_bytes: raising this is an informed operator
+  # choice, not a value that is self-evidently a mistake. Zero and negative are
+  # rejected at boot — an unbounded body is the defect this cap exists to close.
   recv_fs_max_bytes: 134217728 # 128 MiB
   # Aggregate bound on concurrent block uploads (subcontract B / X10). Without
   # these, sync_block_max_bytes above bounds ONE request while N concurrent

--- a/configs/config.prod.yaml
+++ b/configs/config.prod.yaml
@@ -271,6 +271,9 @@ seafhttp:
   # measured client batch size to anchor this on, so the default is deliberately
   # generous — raise it if a real large commit needs more headroom.
   # Override: SEAFHTTP_RECV_FS_MAX_BYTES
+  # No ceiling, unlike sync_block_max_bytes: raising this is an informed operator
+  # choice, not a value that is self-evidently a mistake. Zero and negative are
+  # rejected at boot — an unbounded body is the defect this cap exists to close.
   recv_fs_max_bytes: 134217728 # 128 MiB
   # Aggregate bound on concurrent block uploads (subcontract B / X10). Without
   # these, sync_block_max_bytes above bounds ONE request while N concurrent

--- a/configs/config.prod.yaml
+++ b/configs/config.prod.yaml
@@ -266,6 +266,12 @@ seafhttp:
   # Override: SEAFHTTP_SYNC_BLOCK_MAX_BYTES
   # NOT an aggregate bound: N concurrent uploads still cost N x this value.
   sync_block_max_bytes: 16777216 # 16 MiB
+  # Bounds one recv-fs body (a batch of packed FS objects the desktop client
+  # uploads at the end of a commit). Unlike sync_block_max_bytes, there is no
+  # measured client batch size to anchor this on, so the default is deliberately
+  # generous — raise it if a real large commit needs more headroom.
+  # Override: SEAFHTTP_RECV_FS_MAX_BYTES
+  recv_fs_max_bytes: 134217728 # 128 MiB
   # Aggregate bound on concurrent block uploads (subcontract B / X10). Without
   # these, sync_block_max_bytes above bounds ONE request while N concurrent
   # uploads still cost N x the cap.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,30 @@ Session-by-session development history for SesameFS.
 
 ---
 
+## 2026-08-12 - Bound the four remaining unbounded sync request bodies (ISSUE-SYNC-UNBOUNDED-BODIES-01)
+
+- `PutCommit`, `PackFS`, `RecvFS`, `CheckFS` in `internal/api/sync.go` now read through the
+  shared `readLimitedRequestBody` helper (the same one PR-10 wired into `PutBlock`/
+  `check-blocks` for F12), closing X9. Previously all four buffered the entire request body
+  with an unbounded `io.ReadAll`, so an authenticated client could drive memory pressure
+  arbitrarily high through any of them.
+- `PutCommit`/`PackFS`/`CheckFS` use plain byte-size consts (1 MiB / 16 MiB / 16 MiB), matching
+  the existing `check-blocks` const since they carry the same small id-list-or-metadata shape.
+- `RecvFS` gets a new **configuration** knob instead — `config.SeafHTTP.RecvFSMaxBytes`
+  (`recv_fs_max_bytes` in YAML, `SEAFHTTP_RECV_FS_MAX_BYTES` env override, default 128 MiB) —
+  because it carries a real batch of packed FS objects with no measured client size or
+  protocol-documented ceiling to anchor a fixed number on; the generous default can be raised
+  by an operator without a code change. Added to all seven shipped configs.
+- Scope, precisely: this bounds the body of **one request**, not aggregate memory under
+  concurrency — N concurrent `RecvFS` requests near the cap can still sum to N × the cap.
+- Added `TestPutCommitBoundsBodySize`, `TestPackFSBoundsBodySize`,
+  `TestPackFSBoundsChunkedBody`, `TestCheckFSBoundsBodySize`, `TestRecvFSBoundsBodySize` to
+  `internal/api/sync_body_limits_test.go`, pinning the rejection boundary (`cap+1` → 413) for
+  all four; deliberately not pinning any "positive path" body shape for `PackFS`/`RecvFS` that
+  would depend on incidental parser behavior rather than the size gate itself.
+
+---
+
 ## 2026-08-12 - `sesamefs_auth` cookie is httpOnly (ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01)
 
 - All four writers of `sesamefs_auth` (login and logout, in both `internal/api/server.go` and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,36 @@ Session-by-session development history for SesameFS.
 
 ---
 
+## 2026-08-12 - Three sync findings opened while auditing the X9 caps (no code change)
+
+Auditing the caps above surfaced three defects on the same handlers. All three are
+**pre-existing** — none is introduced or worsened by the X9 work, which in each case
+narrowed the surface — so they are documented here and left for their own changes
+rather than folded into this branch.
+
+- `ISSUE-RECVFS-DECOMPRESSION-AMPLIFICATION-01` (**HIGH**) — `recv_fs_max_bytes` bounds the
+  *compressed* body; `RecvFS` then inflates each packed object with an unbounded
+  `io.ReadAll(zlibReader)`. Measured `compress/zlib` at `BestCompression` over a run of
+  identical bytes: 1005:1 at 1 MiB, 1028:1 at 16 MiB, 1029:1 at 128 MiB. So a 128 KiB request
+  inflates to ~128 MiB and one at the body cap to ~126 GiB. The buffered body is not this
+  handler's dominant allocation.
+- `ISSUE-SYNC-FSID-WORK-AMPLIFICATION-01` (**HIGH**) — the derived id caps
+  (`maxPackFSIDs`/`maxCheckFSIDs`, 409,200) were derived against one axis, *never reject a
+  well-formed body*, and are silent on what an accepted list costs. Nothing deduplicates it,
+  so ~409k repeats of one valid id is a well-formed request: `PackFS` issues a sequential
+  Cassandra read per id and materializes every record in one `bytes.Buffer` before writing,
+  on `PermissionR` alone. `CheckFS` shares the per-id read (its map only translates ids) but
+  not the buffer. For contrast `check-blocks` caps ids at 100,000, picked as a work bound
+  when X11 closed, and bounds its lookup fan-out; these two allow 4x that with neither.
+- `ISSUE-RECVFS-FSID-UNVERIFIED-01` (**unrated, open question**) — `RecvFS` stores the
+  client-supplied `fs_id` without checking it hashes the content, while the download path is
+  integration-tested to require exactly that. Filed as a question rather than a defect
+  because SesameFS deliberately maintains a stored-vs-computed id mapping, so a naive
+  `fs_id == SHA-1(body)` check would reject writes the design intends to accept. The contract
+  has to be settled before anyone adds the check.
+
+---
+
 ## 2026-08-12 - Legacy batch move returns 501 instead of a false success (ISSUE-BATCH-MOVE-FALSE-SUCCESS-01)
 
 - `FileHandler.moveBatchFiles` in `internal/api/v2/files.go` (reached when the legacy
@@ -63,9 +93,16 @@ Session-by-session development history for SesameFS.
   all four; deliberately not pinning any "positive path" body shape for `PackFS`/`RecvFS` that
   would depend on incidental parser behavior rather than the size gate itself. Plus
   `TestFSIDCapsCannotCutWellFormedBodies` (the derivation invariant, asserted arithmetically)
-  and `TestFSIDCountCapsCutAmplification` (the degenerate body is refused at 50.6 MB against
-  the same 96 MB ceiling the `check-blocks` canary uses), and `TestEnvOverrideRecvFSMaxBytes`
-  in `internal/config/config_test.go` for the config contract.
+  and `TestFSIDCountCapsCutAmplification` (the degenerate body is refused, and the parse costs
+  16.0 MB — just its `string(body)` — against the same 96 MB ceiling the `check-blocks` canary
+  uses), and `TestEnvOverrideRecvFSMaxBytes` in `internal/config/config_test.go` for the config
+  contract.
+- That canary measures the **parser**, not a round trip, and the 413 is asserted separately
+  through the handler with no allocation measurement. The first version wrapped
+  `r.ServeHTTP` and reused the 96 MB ceiling anyway, which silently included
+  `readLimitedRequestBody`'s own 16 MiB read (~32 MiB cumulative as `io.ReadAll` doubles) —
+  a cost the ceiling was never derived for. It fit on go1.26/windows at 50.6 MB and failed
+  in the `gotest` container on go1.25/linux at 113.9 MB. Two claims, two windows.
 - `TestRecvFSBoundsBodySize` no longer pushes a 128 MiB body through HTTP to prove the default
   cap. That cost ~404 MB of allocation (~128 MiB body + ~269 MB of `io.ReadAll` growth), four
   times the 96 MB ceiling this same file treats as a failure condition elsewhere, and proved

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,23 @@ Session-by-session development history for SesameFS.
 
 ---
 
+## 2026-08-12 - Legacy batch move returns 501 instead of a false success (ISSUE-BATCH-MOVE-FALSE-SUCCESS-01)
+
+- `FileHandler.moveBatchFiles` in `internal/api/v2/files.go` (reached when the legacy
+  `POST /file/move` endpoint gets more than one `src` path in the same repo) previously
+  returned `{"success": true, "moved": N}` without ever touching the FS tree — a fabricated
+  success on a still-reachable handler. It now returns `501 Not Implemented`, pointing callers
+  at `POST /api/v2.1/repos/sync-batch-move-item/`, the real batch-move endpoint the UI already
+  uses (`seafileAPI.moveDirWithPolicy` → `SyncBatchMove`/`AsyncBatchMove` →
+  `processSingleItem`, integration-tested, unaffected by this change).
+- This is a bug fix, not new functionality: legacy same-repo batch move via this endpoint is
+  still unimplemented, it just no longer lies about having succeeded. Cross-repo batch move was
+  already correctly 501 and is unchanged.
+- Updated `TestBatchMoveFiles_FilenameArray` in `internal/api/v2/files_batch_test.go` (the
+  same-repo case now expects 501, not 200).
+
+---
+
 ## 2026-08-12 - Bound the four remaining unbounded sync request bodies (ISSUE-SYNC-UNBOUNDED-BODIES-01)
 
 - `PutCommit`, `PackFS`, `RecvFS`, `CheckFS` in `internal/api/sync.go` now read through the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,22 +38,51 @@ Session-by-session development history for SesameFS.
   (`recv_fs_max_bytes` in YAML, `SEAFHTTP_RECV_FS_MAX_BYTES` env override, default 128 MiB) —
   because it carries a real batch of packed FS objects with no measured client size or
   protocol-documented ceiling to anchor a fixed number on; the generous default can be raised
-  by an operator without a code change. Added to all seven shipped configs.
-- Scope, precisely: this bounds the body of **one request**, not aggregate memory under
-  concurrency — N concurrent `RecvFS` requests near the cap can still sum to N × the cap.
+  by an operator without a code change. Added to all seven shipped configs. `Validate()`
+  rejects zero and negative values (an unbounded body is the defect the cap closes, so no
+  configuration may restore it), and a malformed `SEAFHTTP_RECV_FS_MAX_BYTES` is reported via
+  `addEnvOverrideError` rather than silently dropped back to the default — matching its
+  neighbour `SEAFHTTP_SYNC_BLOCK_MAX_BYTES`. There is deliberately **no** ceiling: unlike the
+  block cap, no measured client batch size makes a large value self-evidently a mistake.
+- **A byte cap alone was not enough on `pack-fs`/`check-fs`.** Both parsed their id list with
+  `strings.Split`/`json.Unmarshal` over the whole body, so a body *under* the 16 MiB cap still
+  expanded ~17x — 16 MiB of bare newlines becomes ~16.7M string headers (~268 MB). That is the
+  cardinality half of the same defect, already solved for `check-blocks`. `parseCheckBlockIDs`
+  is generalized to `parseBoundedIDList` (+ per-route `idListSpec`, which preserves
+  `check-blocks`' existing client-visible 413 body verbatim) and both routes now use it, with
+  id caps **derived** from their byte caps (`byte cap / minFSIDWireBytes`). The derivation is
+  the point: the densest well-formed body the byte cap admits carries exactly the id cap, so
+  the cap is unreachable for real traffic and fires only on degenerate input — it is not a new
+  limit on large libraries.
+- Scope, precisely: this bounds **one request**, not aggregate memory under concurrency — N
+  concurrent `RecvFS` requests near the cap can still sum to N × the cap. That half is now
+  tracked as `ISSUE-SYNC-METADATA-CONCURRENCY-01` instead of being left as a remark.
 - Added `TestPutCommitBoundsBodySize`, `TestPackFSBoundsBodySize`,
   `TestPackFSBoundsChunkedBody`, `TestCheckFSBoundsBodySize`, `TestRecvFSBoundsBodySize` to
   `internal/api/sync_body_limits_test.go`, pinning the rejection boundary (`cap+1` → 413) for
   all four; deliberately not pinning any "positive path" body shape for `PackFS`/`RecvFS` that
-  would depend on incidental parser behavior rather than the size gate itself.
+  would depend on incidental parser behavior rather than the size gate itself. Plus
+  `TestFSIDCapsCannotCutWellFormedBodies` (the derivation invariant, asserted arithmetically)
+  and `TestFSIDCountCapsCutAmplification` (the degenerate body is refused at 50.6 MB against
+  the same 96 MB ceiling the `check-blocks` canary uses), and `TestEnvOverrideRecvFSMaxBytes`
+  in `internal/config/config_test.go` for the config contract.
+- `TestRecvFSBoundsBodySize` no longer pushes a 128 MiB body through HTTP to prove the default
+  cap. That cost ~404 MB of allocation (~128 MiB body + ~269 MB of `io.ReadAll` growth), four
+  times the 96 MB ceiling this same file treats as a failure condition elsewhere, and proved
+  nothing the small configured cap does not. The two properties are now pinned separately: the
+  resolver returns the default under a nil config, and the handler enforces whatever the
+  resolver returns (including the chunked, no-declared-length shape).
 
 ---
 
 ## 2026-08-12 - `sesamefs_auth` cookie is httpOnly (ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01)
 
-- All four writers of `sesamefs_auth` (login and logout, in both `internal/api/server.go` and
-  `internal/api/v2/auth.go`) now set `httpOnly=true`, funneled through one `setAuthCookie`
-  helper per package so the flag can't drift between login and logout again. Previously the
+- All four previously non-`HttpOnly` writers of `sesamefs_auth` (login and logout, in both
+  `internal/api/server.go` and `internal/api/v2/auth.go`) now set `httpOnly=true`, funneled
+  through one `setAuthCookie` helper per package so the flag can't drift between login and
+  logout again. (`handleAutoLogin` is a fifth writer of this cookie; it already set
+  `httpOnly=true` and is left alone here because it hardcodes `Secure=false`, which is the
+  separate `ISSUE-AUTOLOGIN-COOKIE-INSECURE-01`.) Previously the
   cookie was JS-readable, and the auth middleware accepts it as a live, replayable session
   bearer with a TTL up to 180 days for sync clients — any XSS on the origin could walk away
   with a long-lived credential.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,29 @@ Session-by-session development history for SesameFS.
 
 ---
 
+## 2026-08-12 - `sesamefs_auth` cookie is httpOnly (ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01)
+
+- All four writers of `sesamefs_auth` (login and logout, in both `internal/api/server.go` and
+  `internal/api/v2/auth.go`) now set `httpOnly=true`, funneled through one `setAuthCookie`
+  helper per package so the flag can't drift between login and logout again. Previously the
+  cookie was JS-readable, and the auth middleware accepts it as a live, replayable session
+  bearer with a TTL up to 180 days for sync clients — any XSS on the origin could walk away
+  with a long-lived credential.
+- Verified before closing: a repository-wide search (including `mobile-frontend/`) found no JS
+  code reading this cookie's value anywhere in this repository; the desktop-client SSO flow
+  gets its token via `clientSSOStore` polling, not by reading the cookie, contradicting the
+  stale "embedded WebView" comment that used to justify `httpOnly=false`. Confirmed with the
+  project owner that no client outside this repository depends on reading it either.
+- `Secure` is unchanged (still derived from `c.Request.TLS`) — that's the separate, still-open
+  `ISSUE-AUTOLOGIN-COOKIE-INSECURE-01`.
+- Added `TestServerSetAuthCookie` and `TestAuthHandlerSetAuthCookie`, testing each helper
+  directly so both login and logout are pinned without mocking a real OIDC exchange; extended
+  `TestLogout` to assert `HttpOnly` on the real end-to-end clear response.
+- Updated `docs/OIDC.md` and `docs/diagrams/auth-layer.md` to match; the stale "embedded
+  WebView" justification is gone.
+
+---
+
 ## 2026-07-16 - GC physical deletion is org-scoped end to end (P10 PR-3)
 
 - Normal block deletion and S3 orphan recovery now resolve `BlockStore` by

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,10 +10,12 @@ Session-by-session development history for SesameFS.
 
 ## 2026-08-12 - Three sync findings opened while auditing the X9 caps (no code change)
 
-Auditing the caps above surfaced three defects on the same handlers. All three are
-**pre-existing** — none is introduced or worsened by the X9 work, which in each case
-narrowed the surface — so they are documented here and left for their own changes
-rather than folded into this branch.
+Auditing the caps above surfaced three follow-up findings on the same handlers: **two
+confirmed defects and one protocol-contract question**. All three are **pre-existing**
+— the X9 work did not introduce any of them, and for the two memory defects it
+narrowed the surface rather than widening it — so they are documented here and left
+for their own changes rather than folded into this branch. (The third is a semantic
+question about the write path; a body cap neither helps nor hurts it.)
 
 - `ISSUE-RECVFS-DECOMPRESSION-AMPLIFICATION-01` (**HIGH**) — `recv_fs_max_bytes` bounds the
   *compressed* body; `RecvFS` then inflates each packed object with an unbounded
@@ -24,11 +26,14 @@ rather than folded into this branch.
 - `ISSUE-SYNC-FSID-WORK-AMPLIFICATION-01` (**HIGH**) — the derived id caps
   (`maxPackFSIDs`/`maxCheckFSIDs`, 409,200) were derived against one axis, *never reject a
   well-formed body*, and are silent on what an accepted list costs. Nothing deduplicates it,
-  so ~409k repeats of one valid id is a well-formed request: `PackFS` issues a sequential
-  Cassandra read per id and materializes every record in one `bytes.Buffer` before writing,
-  on `PermissionR` alone. `CheckFS` shares the per-id read (its map only translates ids) but
-  not the buffer. For contrast `check-blocks` caps ids at 100,000, picked as a work bound
-  when X11 closed, and bounds its lookup fan-out; these two allow 4x that with neither.
+  so ~409k repeats of one valid id is a well-formed request: `PackFS` issues a sequential,
+  context-less Cassandra read per id and materializes every record in one `bytes.Buffer`
+  before writing, on `PermissionR` alone. `CheckFS` shares the per-id read (its map only
+  translates ids) but not the buffer. X11 met this exact shape on `check-blocks` — "one id
+  repeated, then abandoned" — and closed it by deduplicating before lookup, resolving through
+  a context-carrying call at a configured fan-out, and taking its own admission capacity;
+  notably **not** by lowering the id cap, which it kept deliberately. That resolution is the
+  template.
 - `ISSUE-RECVFS-FSID-UNVERIFIED-01` (**unrated, open question**) — `RecvFS` stores the
   client-supplied `fs_id` without checking it hashes the content, while the download path is
   integration-tested to require exactly that. Filed as a question rather than a defect

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -6554,18 +6554,86 @@ derived from its own payload profile rather than one shared constant:
   ceiling to anchor a fixed number on (`docs/SEAFILE-SYNC-PROTOCOL-RFC.md` does
   not specify one) — the default is deliberately generous, and an operator can
   raise it via `SEAFHTTP_RECV_FS_MAX_BYTES` or `recv_fs_max_bytes` without a code
-  change if a real large commit needs more headroom.
+  change if a real large commit needs more headroom. Zero and negative values are
+  rejected at boot, and a malformed env value is reported rather than silently
+  dropped back to the default: an unbounded body is the defect the cap closes, so
+  no configuration may restore it.
 
-**Scope of the fix, precisely:** this closes the **unbounded body per request**.
-It does not bound aggregate memory under concurrency — N concurrent `RecvFS`
-requests near the cap can still sum to N × the cap. That is a distinct
-admission/concurrency problem (conceptually adjacent to the download-side D0-D6
-admission work, which has no write-side equivalent yet) and is not reopened here.
+**A byte cap alone was not enough on the two id-list routes.** `pack-fs` and
+`check-fs` parsed their id list the naive way — `strings.Split` on the whole body,
+or `json.Unmarshal` into a `[]string` — so a body *under* the 16 MiB cap still
+expanded ~17x: 16 MiB of bare newlines becomes ~16.7M string headers (~268 MB).
+That is the cardinality half of the same defect, already solved for `check-blocks`
+by a parser that refuses during the parse instead of after the list is
+materialized. Both routes now share it (`parseBoundedIDList`, generalized from
+`parseCheckBlockIDs`), with id caps **derived from their byte caps**
+(`maxPackFSIDs`, `maxCheckFSIDs` = byte cap / `minFSIDWireBytes`). Deriving them
+matters: the densest well-formed body the byte cap admits carries exactly the cap
+in ids, so the id cap is unreachable for real traffic and can only fire on
+degenerate input — it is not a new limit on large libraries.
+`TestFSIDCapsCannotCutWellFormedBodies` pins that invariant arithmetically;
+`TestFSIDCountCapsCutAmplification` measures the rejected path at 50.6 MB
+against a 96 MB ceiling.
+
+**Scope of the fix, precisely:** this closes the **unbounded body per request**
+and the id-list amplification within it. It does not bound aggregate memory under
+concurrency — N concurrent `RecvFS` requests near the 128 MiB cap can still sum to
+N × the cap. That is a distinct admission/concurrency problem, now tracked
+separately as `ISSUE-SYNC-METADATA-CONCURRENCY-01` rather than left implicit here.
 
 #### Related Docs
 
 - `docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md` (X9, and X10/X11 for what a cap is not)
 - `docs/GC-UPLOAD-FENCE-PR-PLAN.md` (PR-10 scope)
+- `ISSUE-SYNC-METADATA-CONCURRENCY-01` (the aggregate bound this fix does not provide)
+
+---
+
+### ISSUE-SYNC-METADATA-CONCURRENCY-01: The sync metadata routes have no aggregate memory bound
+
+**Status**: 🟡 Open — successor to X9's per-request cap
+**Severity**: Medium — authenticated memory-pressure DoS, aggregate rather than per-request
+**Affected**: `RecvFS`, `PackFS`, `CheckFS`, `PutCommit` in `internal/api/sync.go`
+**Source of record**: opened 2026-08-12 when `ISSUE-SYNC-UNBOUNDED-BODIES-01` closed
+
+#### Problem
+
+`ISSUE-SYNC-UNBOUNDED-BODIES-01` bounds **one** request on each of these routes.
+It does not bound N of them. `RecvFS` is the one that matters: its default cap is
+128 MiB and its body is fully buffered before parsing, so 8 concurrent uploads
+cost ~1 GiB of body buffers, 16 cost ~2 GiB, before anything else the process is
+doing. The route group carries only `syncAuthMiddleware` — no concurrency gate, no
+rate limit, no memory budget.
+
+This is the same shape as **X10** on the block routes, and X10 is the reason this
+entry exists as its own issue: X10 was closed by work scoped explicitly to
+`PutBlock` (`sync_block_max_inflight_per_node`, `sync_block_memory_budget_bytes`,
+the admission limiter and its 503 + `Retry-After` semantics). None of that machinery
+covers the metadata routes, so closing X9 without opening this would have retired
+the narrow finding and lost the layer underneath it.
+
+#### Fix Direction
+
+The block-route admission work is the template, not a new design: a bound on
+in-flight metadata readers acquired **before** the buffering read, answering
+**503 + `Retry-After`** after a bounded wait — never 429, which the official client
+does not classify as retryable. Two details differ from the block path and should be
+settled first:
+
+- `RecvFS`'s 128 MiB default is generous precisely because no client batch size was
+  ever measured. Measuring what the official client actually sends per `recv-fs`
+  (upstream batches packed objects rather than sending a whole commit at once) would
+  likely allow a far smaller cap, which is cheaper than an admission gate and should
+  be evaluated before building one.
+- The metadata routes should not draw from the block routes' capacity: one storming
+  must not spend the other's slots, the same separation X10's dated note records.
+
+#### Related Docs
+
+- `docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md` (X10 — the closed block-route equivalent,
+  and its dated note on capacity separation)
+- `ISSUE-SYNC-UNBOUNDED-BODIES-01` (the per-request cap this sits on top of)
+- `ISSUE-RATE-LIMIT-UPLOAD-DOWNLOAD-01` (the umbrella X10 was subcontract B of)
 
 ---
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -6571,26 +6571,27 @@ admission work, which has no write-side equivalent yet) and is not reopened here
 
 ### ISSUE-BATCH-MOVE-FALSE-SUCCESS-01: Legacy `moveBatchFiles` returns success without moving
 
-**Status**: 🟡 Open — API footgun; primary UI path is safe
+**Status**: ✅ Fixed 2026-08-12 — false success fixed; legacy same-repo batch move via
+`POST /file/move` remains unsupported and now returns 501 instead of a fabricated 200
 **Severity**: Medium — false-success on a still-reachable handler
 **Affected**: `FileHandler.moveBatchFiles` in `internal/api/v2/files.go` (reached when `MoveFile` gets `len(srcPaths) > 1`)
 **Source of record**: PENDING-ISSUES-AUDIT-2026-05-14 item 4; code-verified 2026-07-25
 
-#### Problem
+#### What Is True Today
 
-`moveBatchFiles` still contains `// TODO: Implement actual batch move logic`
-and returns `{"success": true, "moved": N}` for same-repo multi-file moves
-without updating the FS tree. Cross-repo batch move correctly returns 501.
+`moveBatchFiles` previously contained `// TODO: Implement actual batch move logic`
+and returned `{"success": true, "moved": N}` for same-repo multi-file moves
+without updating the FS tree; cross-repo batch move already correctly returned 501.
+It now returns `501 Not Implemented` for the same-repo case too, with an error
+pointing at the real endpoint. This is a bug fix, not new functionality: legacy
+same-repo batch move via this endpoint is still not implemented, it just no
+longer lies about having succeeded.
 
-The **UI** path does not use this: `seafileAPI.moveDirWithPolicy` goes through
-`SyncBatchMove` / `AsyncBatchMove` → `processSingleItem` in
-`batch_operations.go` (integration-tested). The defect is an API client that
-posts multiple `src` paths to the legacy `MoveFile` endpoint.
-
-#### Fix Direction
-
-Return `501 Not Implemented` (or wire to `processSingleItem`) until the batch
-path is real. Do not leave a success response on a no-op.
+The **UI** path never used this and is unaffected: `seafileAPI.moveDirWithPolicy`
+goes through `POST /api/v2.1/repos/sync-batch-move-item/` /
+`async-batch-move-item/` → `SyncBatchMove`/`AsyncBatchMove` → `processSingleItem`
+in `batch_operations.go` (integration-tested). The defect was reachable only by an
+API client posting multiple `src` paths to the legacy `MoveFile` endpoint.
 
 #### Related Docs
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -6590,7 +6590,7 @@ which varies enough by platform to make a shared threshold meaningless (50.6 MB 
 go1.26/windows, 113.9 MB on go1.25/linux, same code).
 
 **Scope of the fix, precisely:** this closes the **unbounded body per request**
-and the id-list amplification within it. Two things it does **not** do, both now
+and the id-list amplification within it. Three things it does **not** do, all now
 tracked rather than left implicit:
 
 - It does not bound aggregate memory under concurrency — N concurrent `RecvFS`
@@ -6754,8 +6754,12 @@ the memory that work allocates.
 
 When it is implemented, `io.LimitReader(zlibReader, max)` alone is not the fix:
 reading `max` and accepting what came back silently truncates. Read `max+1` (or
-check for a trailing byte) and **reject the object**, because a truncated fs object
-would be stored under an `fs_id` its stored body no longer corresponds to.
+check for a trailing byte) and **reject the object** — a partial decompressed object
+must not be parsed or persisted as if the complete packed object had arrived. Note
+that the reason is *not* "the stored body would no longer hash to its `fs_id`":
+whether that equality holds at all is exactly what
+`ISSUE-RECVFS-FSID-UNVERIFIED-01` leaves open, so this fix must not be justified by
+an invariant this repository has not established.
 
 #### Related Docs
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -6328,35 +6328,37 @@ than hardened.
 
 ### ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01: `sesamefs_auth` is a replayable bearer token in a JS-readable cookie
 
-**Status**: 🟡 Open — "by design" (seahub compatibility), flagged for reassessment
+**Status**: ✅ Fixed 2026-08-12
 **Severity**: High — an XSS yields full session-token theft, not merely a read surface
-**Affected**: `internal/api/server.go` — the OIDC callback cookie write and the auth resolution order
-**Source of record**: SEC-3 / NF-3 in `docs/PROD-SECURITY-READINESS-20260724.md`
+**Affected**: `internal/api/server.go`, `internal/api/v2/auth.go` — the OIDC callback cookie
+write and the auth resolution order
 
-#### Problem
+#### What Is True Today
 
-The OIDC callback sets `sesamefs_auth` with `httpOnly=false` to match the seahub
-convention. That cookie's value is not a display artifact: the auth middleware
-accepts it as a credential (it sits in the resolution order between dev tokens
-and the `Authorization` header), so it is a live, replayable session/API bearer.
-Sync-client sessions can carry a TTL up to 180 days.
+All four writers of `sesamefs_auth` (login and logout, in both `internal/api/server.go` and
+`internal/api/v2/auth.go`) now set `httpOnly=true`, funneled through one `setAuthCookie`
+helper per package so the flag can't drift between login and logout again. `Secure` is
+unchanged (still derived from `c.Request.TLS`; the separate `ISSUE-AUTOLOGIN-COOKIE-INSECURE-01`
+covers the one site — `handleAutoLogin` — that hardcodes it, and the broader TLS-terminating-
+proxy gap tracked in `TECHNICAL-DEBT.md` #21).
 
-Consequence: any XSS anywhere on the origin reads `document.cookie` and walks
-away with a long-lived credential. The original SEC-3 rating of Medium
-understated this by treating the cookie as an information leak rather than as
-the credential it is.
-
-#### Fix Direction
-
-Either stop accepting the cookie as a credential (make it a non-authoritative
-hint and require the `Authorization` header), or set `httpOnly=true` and give
-the frontend whatever non-secret signal it actually needs. Establish first what
-reads it client-side — if nothing does, this is a one-line change.
+What was verified before closing: a repository-wide search (including `mobile-frontend/`)
+found no JS code anywhere in this repository that reads this cookie's value — the only
+`document.cookie` touching it was a best-effort clear in `frontend/src/utils/auth-state.js`,
+and the server already clears it authoritatively on logout regardless. The desktop-client SSO
+flow gets its token via `clientSSOStore` polling (`docs/OIDC.md`), not by reading this cookie
+from an embedded WebView, contradicting the comment that used to justify `httpOnly=false`. The
+project owner confirmed no client outside this repository depends on reading it either.
+`internal/api/server_test.go` (`TestServerSetAuthCookie`) and `internal/api/v2/auth_test.go`
+(`TestAuthHandlerSetAuthCookie`, and the extended `TestLogout`) pin `HttpOnly` on both helpers,
+covering login and logout without needing to mock a real OIDC exchange.
 
 #### Related Docs
 
-- `docs/PROD-SECURITY-READINESS-20260724.md` (SEC-3, NF-3, checklist item 6)
-- `ISSUE-AUTOLOGIN-COOKIE-INSECURE-01` (the same cookie, set inconsistently elsewhere)
+- `docs/PROD-SECURITY-READINESS-20260724.md` (SEC-3, NF-3, checklist item 6) — dated snapshot,
+  not retro-edited; this entry is the live status.
+- `docs/OIDC.md`, `docs/diagrams/auth-layer.md` — updated to match.
+- `ISSUE-AUTOLOGIN-COOKIE-INSECURE-01` (the same cookie's `Secure` flag, still open, separate fix)
 
 ---
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -6533,30 +6533,34 @@ reuse the sysadmin retention messaging helpers on the org-admin frontend shell
 
 ### ISSUE-SYNC-UNBOUNDED-BODIES-01: Four sync handlers still read the request body unbounded
 
-**Status**: 🟡 Open — PR-10 closed the two block routes, not the class
+**Status**: ✅ Fixed 2026-08-12
 **Severity**: Medium — authenticated memory-pressure DoS
 **Affected**: `PutCommit`, `PackFS`, `RecvFS`, `CheckFS` in `internal/api/sync.go`
 **Source of record**: **X9** in `docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md`
 
-#### Problem
+#### What Is True Today
 
-PR-10 (#146) bounded `PutBlock` and `check-blocks` behind the shared
-`readLimitedRequestBody` helper, closing F12. Four sibling handlers on the same
-`SyncHandler` keep the identical unbounded `io.ReadAll(c.Request.Body)` — verified
-present 2026-07-25. F12 was scoped to the two block routes, so an authenticated
-client can drive the same memory-pressure DoS through any of the four.
+All four handlers now read through the shared `readLimitedRequestBody` helper (the
+same one PR-10 wired into `PutBlock`/`check-blocks` for F12), each with a cap
+derived from its own payload profile rather than one shared constant:
 
-This entry exists because X9 previously named an issue ID that had never been
-created, leaving the registry with a dangling reference.
+- `PutCommit`, `PackFS`, `CheckFS` — plain consts (`maxPutCommitBodyBytes` = 1 MiB;
+  `maxPackFSBodyBytes`, `maxCheckFSBodyBytes` = 16 MiB, matching `check-blocks`'s
+  existing const, since both carry the same small id-list shape).
+- `RecvFS` — **configuration**, not a const (`config.SeafHTTP.RecvFSMaxBytes`,
+  default 128 MiB via `config.DefaultRecvFSMaxBytes`, resolved by
+  `syncRecvFSMaxBytes()`). Unlike the other three, RecvFS carries a real batch of
+  packed FS objects with no measured client batch size or protocol-documented
+  ceiling to anchor a fixed number on (`docs/SEAFILE-SYNC-PROTOCOL-RFC.md` does
+  not specify one) — the default is deliberately generous, and an operator can
+  raise it via `SEAFHTTP_RECV_FS_MAX_BYTES` or `recv_fs_max_bytes` without a code
+  change if a real large commit needs more headroom.
 
-#### Fix Direction
-
-Each handler needs a cap derived from its own payload profile — a commit object,
-a packed FS batch, a received FS batch and an FS existence query have nothing in
-common, so a single shared constant would be wrong. Once each cap is chosen the
-change is one line per handler through `readLimitedRequestBody`. Note the same
-caveat as X10/X11: a per-request cap bounds one request, not the aggregate, and
-does not bound the work an accepted request triggers downstream.
+**Scope of the fix, precisely:** this closes the **unbounded body per request**.
+It does not bound aggregate memory under concurrency — N concurrent `RecvFS`
+requests near the cap can still sum to N × the cap. That is a distinct
+admission/concurrency problem (conceptually adjacent to the download-side D0-D6
+admission work, which has no write-side equivalent yet) and is not reopened here.
 
 #### Related Docs
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -6335,12 +6335,21 @@ write and the auth resolution order
 
 #### What Is True Today
 
-All four writers of `sesamefs_auth` (login and logout, in both `internal/api/server.go` and
-`internal/api/v2/auth.go`) now set `httpOnly=true`, funneled through one `setAuthCookie`
-helper per package so the flag can't drift between login and logout again. `Secure` is
+All four previously non-`HttpOnly` writers of `sesamefs_auth` — the OIDC login and logout
+pair in each of `internal/api/server.go` and `internal/api/v2/auth.go` — now set
+`httpOnly=true`, funneled through one `setAuthCookie` helper per package so the flag can't
+drift between login and logout again. `handleAutoLogin` is a fifth writer of this cookie and
+is untouched: it already set `httpOnly=true`, so it was never part of this defect. `Secure` is
 unchanged (still derived from `c.Request.TLS`; the separate `ISSUE-AUTOLOGIN-COOKIE-INSECURE-01`
 covers the one site — `handleAutoLogin` — that hardcodes it, and the broader TLS-terminating-
 proxy gap tracked in `TECHNICAL-DEBT.md` #21).
+
+One knock-on, dev-only: seeding the session from the browser console
+(`document.cookie = "sesamefs_auth=..."`, the SSO-less dev login in `README.md`) is now
+ignored by the browser whenever a real `HttpOnly` cookie of that name already exists — per
+RFC 6265 a script may not overwrite one. It still works from a clean profile, and the README
+records the caveat. Playwright's `context.addCookies` is unaffected because it writes to the
+browser's cookie jar directly, not through JS, so `mobile-frontend/e2e-sesamefs/` keeps working.
 
 What was verified before closing: a repository-wide search (including `mobile-frontend/`)
 found no JS code anywhere in this repository that reads this cookie's value — the only
@@ -6576,16 +6585,78 @@ degenerate input — it is not a new limit on large libraries.
 against a 96 MB ceiling.
 
 **Scope of the fix, precisely:** this closes the **unbounded body per request**
-and the id-list amplification within it. It does not bound aggregate memory under
-concurrency — N concurrent `RecvFS` requests near the 128 MiB cap can still sum to
-N × the cap. That is a distinct admission/concurrency problem, now tracked
-separately as `ISSUE-SYNC-METADATA-CONCURRENCY-01` rather than left implicit here.
+and the id-list amplification within it. Two things it does **not** do, both now
+tracked rather than left implicit:
+
+- It does not bound aggregate memory under concurrency — N concurrent `RecvFS`
+  requests near the 128 MiB cap can still sum to N × the cap
+  (`ISSUE-SYNC-METADATA-CONCURRENCY-01`).
+- **It does not make `RecvFS` a bounded-memory handler.** The body cap bounds the
+  *compressed* bytes; `RecvFS` then inflates each packed object with an unbounded
+  `io.ReadAll(zlibReader)`, and DEFLATE's best case is ~1029:1 (measured), so a
+  128 MiB body can inflate to ~126 GiB. The buffered body is not this handler's
+  largest allocation, and reading this entry as "recv-fs memory is now bounded"
+  would be wrong (`ISSUE-RECVFS-DECOMPRESSION-AMPLIFICATION-01`).
 
 #### Related Docs
 
 - `docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md` (X9, and X10/X11 for what a cap is not)
 - `docs/GC-UPLOAD-FENCE-PR-PLAN.md` (PR-10 scope)
 - `ISSUE-SYNC-METADATA-CONCURRENCY-01` (the aggregate bound this fix does not provide)
+
+---
+
+### ISSUE-RECVFS-DECOMPRESSION-AMPLIFICATION-01: `recv-fs` inflates each packed object unbounded
+
+**Status**: 🟡 Open — found 2026-08-12 while auditing the X9 caps
+**Severity**: High — one authenticated request can exhaust process memory; the body cap does not bound it
+**Affected**: `RecvFS` in `internal/api/sync.go` (the `io.ReadAll(zlibReader)` inside the per-object loop)
+**Source of record**: opened 2026-08-12; pre-existing, **not** introduced by `ISSUE-SYNC-UNBOUNDED-BODIES-01`
+
+#### Problem
+
+`recv-fs` carries packed objects as `40-byte id + 4-byte size + zlib-compressed JSON`.
+The X9 cap (`seafhttp.recv_fs_max_bytes`, default 128 MiB) bounds the **compressed**
+body. The handler then decompresses each object with an unbounded `io.ReadAll` over
+a `zlib.Reader`, so the largest allocation the handler makes is not the one that was
+capped.
+
+Measured, not estimated — `compress/zlib` at `BestCompression` over a run of
+identical bytes:
+
+| plaintext | compressed | ratio |
+|---|---|---|
+| 1 MiB | 1,043 B | 1005:1 |
+| 16 MiB | 16,320 B | 1028:1 |
+| 128 MiB | 130,466 B | 1029:1 |
+
+So a **128 KiB** request inflates to ~128 MiB, and a request at the 128 MiB body cap
+inflates to ~126 GiB. The `objSize` header is attacker-controlled and only checked
+against the remaining body length, so a single object may span the whole body.
+
+This is why closing X9 must not be read as "recv-fs memory is bounded": it bounds the
+buffered body, which is not the dominant term.
+
+#### Fix Direction
+
+Bound the decompressed side, not just the compressed one — `io.LimitReader` around
+the `zlib.Reader` (plus a total across the batch, since the loop runs per object),
+rejecting rather than truncating, because a truncated fs object would be silently
+stored with a body that no longer hashes to its `fs_id`.
+
+The cap value should **not** be guessed the way `recv_fs_max_bytes` had to be. Here
+there is something to measure: an fs object is either a directory's `dirents` or a
+file's `block_ids`, and both have computable worst cases from this deployment's own
+data (largest directory entry count; largest file ÷ block size). Measure those, then
+set a per-object cap with real headroom. Until then, note that the compressed body
+cap does bound *how much work* an attacker gets per request — it just does not bound
+the memory that work allocates.
+
+#### Related Docs
+
+- `ISSUE-SYNC-UNBOUNDED-BODIES-01` (the body cap this sits behind)
+- `ISSUE-SYNC-METADATA-CONCURRENCY-01` (the aggregate term; N concurrent inflates)
+- `docs/SEAFILE-SYNC-PROTOCOL-RFC.md` §5.6.1 (the packed-object wire format)
 
 ---
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -6581,8 +6581,13 @@ matters: the densest well-formed body the byte cap admits carries exactly the ca
 in ids, so the id cap is unreachable for real traffic and can only fire on
 degenerate input — it is not a new limit on large libraries.
 `TestFSIDCapsCannotCutWellFormedBodies` pins that invariant arithmetically;
-`TestFSIDCountCapsCutAmplification` measures the rejected path at 50.6 MB
-against a 96 MB ceiling.
+`TestFSIDCountCapsCutAmplification` asserts the 413 through the handler and,
+separately, measures the parse at 16.0 MB — just its `string(body)` — against the
+same 96 MB ceiling the `check-blocks` canary uses. The two are separate on purpose:
+an allocation canary wrapped around a whole round trip also measures
+`readLimitedRequestBody`'s 16 MiB read, which the ceiling was never derived for and
+which varies enough by platform to make a shared threshold meaningless (50.6 MB on
+go1.26/windows, 113.9 MB on go1.25/linux, same code).
 
 **Scope of the fix, precisely:** this closes the **unbounded body per request**
 and the id-list amplification within it. Two things it does **not** do, both now
@@ -6597,12 +6602,81 @@ tracked rather than left implicit:
   128 MiB body can inflate to ~126 GiB. The buffered body is not this handler's
   largest allocation, and reading this entry as "recv-fs memory is now bounded"
   would be wrong (`ISSUE-RECVFS-DECOMPRESSION-AMPLIFICATION-01`).
+- **The derived id caps are not a work bound.** They were derived against one axis
+  only — never reject a well-formed body — and are silent on what an accepted list
+  costs. Nothing deduplicates it, so ~409,000 repeats of one valid id are a
+  well-formed request; `pack-fs` materializes the whole response for it. For
+  contrast, `check-blocks` caps ids at 100,000, chosen as a work bound. Tracked as
+  `ISSUE-SYNC-FSID-WORK-AMPLIFICATION-01`.
 
 #### Related Docs
 
 - `docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md` (X9, and X10/X11 for what a cap is not)
 - `docs/GC-UPLOAD-FENCE-PR-PLAN.md` (PR-10 scope)
 - `ISSUE-SYNC-METADATA-CONCURRENCY-01` (the aggregate bound this fix does not provide)
+
+---
+
+### ISSUE-SYNC-FSID-WORK-AMPLIFICATION-01: `pack-fs`/`check-fs` bound the parse, not the work it triggers
+
+**Status**: 🟡 Open — found 2026-08-12 auditing the X9 caps
+**Severity**: High for `pack-fs` (one request can materialize a multi-GiB response), Medium for `check-fs`
+**Affected**: `PackFS`, `CheckFS` in `internal/api/sync.go`
+**Source of record**: opened 2026-08-12; the fs-id equivalent of `ISSUE-CHECKBLOCKS-WORK-AMPLIFICATION-01` (X11)
+
+#### Problem
+
+`maxPackFSIDs`/`maxCheckFSIDs` (409,200) are derived from the 16 MiB byte caps so
+they can never cut a well-formed body — see `ISSUE-SYNC-UNBOUNDED-BODIES-01`. That
+derivation was chosen against exactly one axis, *do not reject real traffic*, and is
+silent on a second: **the work an accepted list triggers**. Nothing deduplicates the
+list, so a well-formed request may repeat one valid fs id ~409,000 times.
+
+`PackFS` is the severe half. Per requested id it issues one sequential Cassandra
+point read, marshals and zlib-compresses the object, and appends it to a single
+`bytes.Buffer`, which is only handed to `c.Data` once the whole loop finishes — so
+the entire response is materialized in memory. With a repeated id, response size is
+`409,200 × (that object's compressed size)`: ~80 MiB for a small file object, and
+multiple GiB if the repeat target is a large directory. It requires only
+`PermissionR`.
+
+`CheckFS` shares the fan-out but not the buffer: the per-id check is a Cassandra
+query, **not** a lookup in the `computedToStored` map (the map only translates the
+id), so an accepted list is ~409,000 sequential point reads holding the handler.
+`buildFSIDMapping` is per-request, not per-id, so it is not the amplifying term.
+
+The comparison that makes this concrete: `check-blocks` caps ids at **100,000**
+(`DefaultCheckBlocksMaxIDs`), a number picked as a work bound when X11 closed, and
+also bounds its lookup concurrency (`checkBlocksLookupFanout`). These two routes
+allow **4x** that with no fan-out bound at all.
+
+None of this is new in the X9 fix — before it, both routes had no body cap and
+therefore no id bound whatsoever, so the current state is strictly better. It is
+filed because the X9 caps should not be mistaken for a work bound.
+
+#### Fix Direction
+
+Three things, in increasing order of how much they need measuring first:
+
+1. **Deduplicate** the requested list. Cheap and the largest single win against the
+   repeated-id shape. Confirm first that returning one entry for a duplicated id
+   does not break the official client's pack-fs framing — the response is a stream
+   of `(id, size, data)` records and a client indexing by id will not care, but that
+   should be verified, not assumed.
+2. **Bound the response**, by size rather than only by id count, and prefer
+   streaming each record to `c.Writer` over accumulating `buf`. A cap on the
+   materialized response is the only thing that bounds the large-directory case.
+3. **Re-derive the id caps against work**, the way `check-blocks` was, rather than
+   against "the densest body the byte cap admits". That likely means a lower cap
+   plus a fan-out bound, and it needs the same measurement
+   `ISSUE-SYNC-METADATA-CONCURRENCY-01` calls for: what the official client
+   actually requests per pack-fs/check-fs.
+
+#### Related Docs
+
+- `ISSUE-CHECKBLOCKS-WORK-AMPLIFICATION-01` / registry X11 (the same defect on the block route, closed — its resolution is the template)
+- `ISSUE-SYNC-UNBOUNDED-BODIES-01` (where the 409,200 caps come from, and why they are derived that way)
+- `ISSUE-SYNC-METADATA-CONCURRENCY-01` (the aggregate term; this issue is per-request)
 
 ---
 
@@ -6652,11 +6726,70 @@ set a per-object cap with real headroom. Until then, note that the compressed bo
 cap does bound *how much work* an attacker gets per request — it just does not bound
 the memory that work allocates.
 
+When it is implemented, `io.LimitReader(zlibReader, max)` alone is not the fix:
+reading `max` and accepting what came back silently truncates. Read `max+1` (or
+check for a trailing byte) and **reject the object**, because a truncated fs object
+would be stored under an `fs_id` its stored body no longer corresponds to.
+
 #### Related Docs
 
 - `ISSUE-SYNC-UNBOUNDED-BODIES-01` (the body cap this sits behind)
 - `ISSUE-SYNC-METADATA-CONCURRENCY-01` (the aggregate term; N concurrent inflates)
+- `ISSUE-RECVFS-FSID-UNVERIFIED-01` (the same handler trusts the id it stores)
 - `docs/SEAFILE-SYNC-PROTOCOL-RFC.md` §5.6.1 (the packed-object wire format)
+
+---
+
+### ISSUE-RECVFS-FSID-UNVERIFIED-01: `recv-fs` stores the client's fs_id without checking it addresses the content
+
+**Status**: 🟡 Open — **question, not a diagnosed defect**; establish the Seafile contract before anyone "fixes" it
+**Severity**: Unrated pending that answer — either content-addressing integrity, or by design
+**Affected**: `RecvFS` in `internal/api/sync.go`
+**Source of record**: opened 2026-08-12 during the X9 audit
+
+#### Problem
+
+`RecvFS` takes the 40 bytes the client supplies, decompresses the object body, and
+inserts `fs_objects(library_id=repoID, fs_id=<client-supplied>, …)`. It never
+recomputes `SHA-1(jsonData)` to confirm the id addresses the content it is filed
+under. The handler's own comment asserts the invariant it does not check: *"the
+fs_id is the SHA1 hash of the exact JSON content"*. The only `sha1.Sum` calls in
+this package are on the web-upload path in `seafhttp.go`, not here.
+
+On the read side the id *is* treated as content-addressed:
+`internal/integration/sync_protocol_regression_test.go` records that the served JSON
+"must re-hash to the requested fs_id (otherwise the desktop client rejects the
+object)". Nothing enforces the same on the write side.
+
+#### Fix Direction
+
+Not "add a hash check". The obvious fix — recompute and reject on mismatch — is very
+likely **wrong here**, and that is the point of filing this as a question.
+
+SesameFS deliberately maintains a *stored* fs id that differs from the *computed*
+one. `CheckFS` says so directly ("Client sends COMPUTED fs_ids (SHA-1 of corrected
+JSON), but we store objects with their ORIGINAL (stored) fs_ids"), and
+`buildFSIDMapping`/`collectCorrectedObjects` exist to translate between them. A
+strict `fs_id == SHA-1(body)` check in `RecvFS` would reject writes this design
+intends to accept.
+
+So the real question is which of these is true, and the answer decides everything:
+
+- the id is genuinely content-addressed and the mapping layer compensates for a
+  historical divergence — in which case verification belongs here, and its absence
+  means a client can file arbitrary content under an id another client will later
+  fetch by hash; or
+- the id is a client-chosen key that this deployment never treated as a hash — in
+  which case the comments asserting otherwise are the bug, and they should be
+  corrected before someone adds a check that breaks sync.
+
+Answer that from the Seafile protocol contract and the mapping layer's history
+first. Do not add a hash check on the strength of this entry alone.
+
+#### Related Docs
+
+- `docs/SEAFILE-SYNC-PROTOCOL-RFC.md` §5.6.1 (the wire format and its id definition)
+- `ISSUE-RECVFS-DECOMPRESSION-AMPLIFICATION-01` (same handler, unrelated cause)
 
 ---
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -6605,9 +6605,10 @@ tracked rather than left implicit:
 - **The derived id caps are not a work bound.** They were derived against one axis
   only — never reject a well-formed body — and are silent on what an accepted list
   costs. Nothing deduplicates it, so ~409,000 repeats of one valid id are a
-  well-formed request; `pack-fs` materializes the whole response for it. For
-  contrast, `check-blocks` caps ids at 100,000, chosen as a work bound. Tracked as
-  `ISSUE-SYNC-FSID-WORK-AMPLIFICATION-01`.
+  well-formed request; `pack-fs` materializes the whole response for it. No id cap
+  is a work bound on its own — `check-blocks`' 100,000 is a parse bound too, and
+  what closed X11 there was dedup, context, fan-out and admission, not the number.
+  Tracked as `ISSUE-SYNC-FSID-WORK-AMPLIFICATION-01`.
 
 #### Related Docs
 
@@ -6645,10 +6646,21 @@ query, **not** a lookup in the `computedToStored` map (the map only translates t
 id), so an accepted list is ~409,000 sequential point reads holding the handler.
 `buildFSIDMapping` is per-request, not per-id, so it is not the amplifying term.
 
-The comparison that makes this concrete: `check-blocks` caps ids at **100,000**
-(`DefaultCheckBlocksMaxIDs`), a number picked as a work bound when X11 closed, and
-also bounds its lookup concurrency (`checkBlocksLookupFanout`). These two routes
-allow **4x** that with no fan-out bound at all.
+**X11 already met this exact shape on `check-blocks`, and its dated note describes
+it almost word for word:** "identical ids were resolved once per occurrence rather
+than once. So the cheapest possible request — one id repeated, then abandoned — was
+also among the most expensive to serve." It also names a second term this entry
+would otherwise miss: that route's mapping read "took no `context` at all, so a
+client disconnect could not stop the loop". `PackFS` and `CheckFS` have the same
+gap — both call `h.db.Session().Query(...)` with no context, so abandoning the
+request does not stop the work it started.
+
+Note what the 100,000 cap on `check-blocks` is and is not. The registry is explicit
+that it "was chosen as a safe parse bound rather than validated against Cassandra,
+the S3 pool, response size or client cancellation" — it is **not** a work bound and
+is not what closed X11. So "these routes allow 4x check-blocks' cap" is the wrong
+comparison to draw; the right one is that `check-blocks` grew the controls below and
+these two routes have none of them.
 
 None of this is new in the X9 fix — before it, both routes had no body cap and
 therefore no id bound whatsoever, so the current state is strictly better. It is
@@ -6656,25 +6668,39 @@ filed because the X9 caps should not be mistaken for a work bound.
 
 #### Fix Direction
 
-Three things, in increasing order of how much they need measuring first:
+X11's resolution is the template, and it is worth following closely because it
+already answered the question this entry would otherwise re-litigate. On
+`check-blocks` the route now deduplicates ids **before any lookup**, resolves them
+through a context-carrying DB call at a configured fan-out, and takes an admission
+from its **own** limiter instance — separate capacity, so one route storming cannot
+spend the other's slots. The same four moves apply here.
 
-1. **Deduplicate** the requested list. Cheap and the largest single win against the
-   repeated-id shape. Confirm first that returning one entry for a duplicated id
-   does not break the official client's pack-fs framing — the response is a stream
-   of `(id, size, data)` records and a client indexing by id will not care, but that
-   should be verified, not assumed.
-2. **Bound the response**, by size rather than only by id count, and prefer
-   streaming each record to `c.Writer` over accumulating `buf`. A cap on the
-   materialized response is the only thing that bounds the large-directory case.
-3. **Re-derive the id caps against work**, the way `check-blocks` was, rather than
-   against "the densest body the byte cap admits". That likely means a lower cap
-   plus a fan-out bound, and it needs the same measurement
-   `ISSUE-SYNC-METADATA-CONCURRENCY-01` calls for: what the official client
-   actually requests per pack-fs/check-fs.
+Two route-specific additions:
+
+- `PackFS` also needs its **response** bounded, not just its lookups: dedup fixes
+  the DB fan-out but a repeated id still emits one record per occurrence into a
+  single `bytes.Buffer`. Prefer streaming records to `c.Writer` over accumulating
+  them. Whoever does this must decide what happens when a cap is reached *after*
+  headers are on the wire — at that point a clean 413 is no longer available, which
+  is the same late-failure class as `ISSUE-ZIP-STREAM-LATEFAIL-01`.
+- Confirm the client contract before deduplicating the **response** (as opposed to
+  the work): the response is a stream of `(id, size, data)` records and a client
+  indexing by id should not care, but that must be verified, not assumed. Resolving
+  each distinct id once while still emitting one record per requested id needs no
+  such confirmation and is the safe half.
+
+**Do not lower the id caps as part of this.** X11 considered exactly that and
+deliberately declined: it kept 100k as the default and turned it into a validation
+ceiling, on the grounds that "lowering it on a guess would trade a bounded
+amplification for an unbounded risk of 413-ing a legitimate initial sync." It added
+`sync_check_blocks_ids_per_request` as the evidence a future reduction would need.
+The equivalent metric for these two routes is the prerequisite here too — the caps
+are derived to be unreachable by well-formed bodies precisely so they never do the
+413-ing X11 warns about.
 
 #### Related Docs
 
-- `ISSUE-CHECKBLOCKS-WORK-AMPLIFICATION-01` / registry X11 (the same defect on the block route, closed — its resolution is the template)
+- `ISSUE-CHECKBLOCKS-WORK-AMPLIFICATION-01` / registry X11 and its 2026-07-31 dated note (the same defect on the block route; closed by dedup-before-lookup, a context-carrying resolve at a configured fan-out, and its own admission capacity — **not** by lowering the id cap, which it deliberately kept)
 - `ISSUE-SYNC-UNBOUNDED-BODIES-01` (where the 409,200 caps come from, and why they are derived that way)
 - `ISSUE-SYNC-METADATA-CONCURRENCY-01` (the aggregate term; this issue is per-request)
 
@@ -6753,13 +6779,15 @@ would be stored under an `fs_id` its stored body no longer corresponds to.
 inserts `fs_objects(library_id=repoID, fs_id=<client-supplied>, …)`. It never
 recomputes `SHA-1(jsonData)` to confirm the id addresses the content it is filed
 under. The handler's own comment asserts the invariant it does not check: *"the
-fs_id is the SHA1 hash of the exact JSON content"*. The only `sha1.Sum` calls in
-this package are on the web-upload path in `seafhttp.go`, not here.
+fs_id is the SHA1 hash of the exact JSON content"*.
 
-On the read side the id *is* treated as content-addressed:
+Not for want of the machinery. `computeCorrectedObject` in this same file hashes an
+object's JSON to derive its `ComputedFSID`, which is how the computed↔stored mapping
+is built at all — so the write path declines a check the read path depends on. And
+on the read side the id *is* treated as content-addressed:
 `internal/integration/sync_protocol_regression_test.go` records that the served JSON
 "must re-hash to the requested fs_id (otherwise the desktop client rejects the
-object)". Nothing enforces the same on the write side.
+object)".
 
 #### Fix Direction
 
@@ -6769,9 +6797,12 @@ likely **wrong here**, and that is the point of filing this as a question.
 SesameFS deliberately maintains a *stored* fs id that differs from the *computed*
 one. `CheckFS` says so directly ("Client sends COMPUTED fs_ids (SHA-1 of corrected
 JSON), but we store objects with their ORIGINAL (stored) fs_ids"), and
-`buildFSIDMapping`/`collectCorrectedObjects` exist to translate between them. A
-strict `fs_id == SHA-1(body)` check in `RecvFS` would reject writes this design
-intends to accept.
+`buildFSIDMapping`/`collectCorrectedObjects` — built on the `computeCorrectedObject`
+hashing above — exist precisely to translate between them. A strict
+`fs_id == SHA-1(body)` check in `RecvFS` would reject writes this design intends to
+accept. The existence of that mapping layer is the whole reason this is a question:
+the divergence is known and compensated for, so what is undetermined is whether the
+write path is *allowed* to introduce a new one.
 
 So the real question is which of these is true, and the answer decides everything:
 

--- a/docs/OIDC.md
+++ b/docs/OIDC.md
@@ -623,7 +623,7 @@ mechanism (matches seahub's `ClientSSOToken` design). The server advertises supp
 9.  Server (handleOAuthCallback):
     - Exchanges code for tokens, creates session (API_TOKEN)
     - Extracts pending token T from state, marks it as success with API_TOKEN
-    - Sets sesamefs_auth cookie = "email@API_TOKEN" (7 days, httpOnly=false)
+    - Sets sesamefs_auth cookie = "email@API_TOKEN" (7 days, httpOnly=true)
     - Redirects browser to / (home page, matches seahub behavior)
 10. Client polling GET /api2/client-sso-link/T/ receives:
     {"status": "success", "username": "user@example.com", "apiToken": "API_TOKEN"}
@@ -640,7 +640,7 @@ mechanism (matches seahub's `ClientSSOToken` design). The server advertises supp
 **Security notes:**
 - The pending token is 160-bit random (crypto/rand) — not guessable
 - It expires after 15 minutes regardless of authentication outcome
-- The `sesamefs_auth` cookie is set with `httpOnly=false` intentionally (embedded WebView needs JS access)
+- The `sesamefs_auth` cookie is `httpOnly=true` (`ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01`, fixed). The desktop client never reads this cookie — it gets its token via the polling flow above (step 10), same as any other client. An older comment here claimed an "embedded WebView" needed JS access to it; no such reader was ever found in this repository.
 - In a **multi-instance** deployment behind a load balancer, the in-memory `ssoStore` is not shared across instances — a request to the polling endpoint may reach a different instance than the one that processed the callback, causing the client to never receive the token. For multi-instance deployments, the pending token store should be moved to the shared database (Cassandra sessions table).
 
 ### Integration Tests

--- a/docs/OPEN-WORK-INDEX.md
+++ b/docs/OPEN-WORK-INDEX.md
@@ -86,8 +86,9 @@ stays in [KNOWN_ISSUES.md](./KNOWN_ISSUES.md).
 - `ISSUE-SYNC-UNBOUNDED-BODIES-01` — **Fixed 2026-08-12** (registry X9). All four
   remaining sync handlers read through `readLimitedRequestBody`; `pack-fs` and
   `check-fs` also gained the id-count cap that stops a body under the byte cap from
-  expanding ~17x. Bounds one request, not N — the aggregate half is now
-  `ISSUE-SYNC-METADATA-CONCURRENCY-01` above.
+  expanding ~17x. It bounds one **compressed** body, and nothing more: the aggregate
+  term is `ISSUE-SYNC-METADATA-CONCURRENCY-01` and the inflate is
+  `ISSUE-RECVFS-DECOMPRESSION-AMPLIFICATION-01`, both above.
 - `ISSUE-BATCH-MOVE-FALSE-SUCCESS-01` — **Fixed 2026-08-12.** Legacy same-repo batch
   move via `POST /file/move` returned `{"success":true,"moved":N}` without touching
   the FS tree; it now returns 501 pointing at `sync-batch-move-item/`. Still
@@ -136,6 +137,7 @@ on every replica in every DC until both close.
 
 | Issue | Sev | One line | Detail |
 |---|---|---|---|
+| `ISSUE-RECVFS-DECOMPRESSION-AMPLIFICATION-01` | HIGH | `recv-fs` inflates each object unbounded; 128 MiB body → ~126 GiB at DEFLATE's measured 1029:1 | Found auditing X9; the body cap does not bound this |
 | `ISSUE-ZIP-STREAM-LATEFAIL-01` | HIGH | ZIP download can truncate after `200 OK` | Readiness DL-2 |
 | `ISSUE-BLOCK-CROSS-LIBRARY-READ-01` | MEDIUM | Cross-library block read (BOLA), gated only by knowing the 256-bit hash | Readiness B2/SEC-1 |
 | `ISSUE-SHARELINK-DOWNLOAD-CAP-RACE-01` | MEDIUM | Download cap and `single_use` are race-bypassable | Readiness NF-2 / SH-5 |

--- a/docs/OPEN-WORK-INDEX.md
+++ b/docs/OPEN-WORK-INDEX.md
@@ -86,9 +86,10 @@ stays in [KNOWN_ISSUES.md](./KNOWN_ISSUES.md).
 - `ISSUE-SYNC-UNBOUNDED-BODIES-01` — **Fixed 2026-08-12** (registry X9). All four
   remaining sync handlers read through `readLimitedRequestBody`; `pack-fs` and
   `check-fs` also gained the id-count cap that stops a body under the byte cap from
-  expanding ~17x. It bounds one **compressed** body, and nothing more: the aggregate
-  term is `ISSUE-SYNC-METADATA-CONCURRENCY-01` and the inflate is
-  `ISSUE-RECVFS-DECOMPRESSION-AMPLIFICATION-01`, both above.
+  expanding ~17x. It bounds one **compressed** body, and nothing more — the three
+  residuals are all above: the aggregate term is `ISSUE-SYNC-METADATA-CONCURRENCY-01`,
+  the inflate is `ISSUE-RECVFS-DECOMPRESSION-AMPLIFICATION-01`, and the work an
+  accepted id list triggers is `ISSUE-SYNC-FSID-WORK-AMPLIFICATION-01`.
 - `ISSUE-BATCH-MOVE-FALSE-SUCCESS-01` — **Fixed 2026-08-12.** Legacy same-repo batch
   move via `POST /file/move` returned `{"success":true,"moved":N}` without touching
   the FS tree; it now returns 501 pointing at `sync-batch-move-item/`. Still

--- a/docs/OPEN-WORK-INDEX.md
+++ b/docs/OPEN-WORK-INDEX.md
@@ -86,8 +86,9 @@ stays in [KNOWN_ISSUES.md](./KNOWN_ISSUES.md).
 - `ISSUE-SYNC-UNBOUNDED-BODIES-01` — **Fixed 2026-08-12** (registry X9). All four
   remaining sync handlers read through `readLimitedRequestBody`; `pack-fs` and
   `check-fs` also gained the id-count cap that stops a body under the byte cap from
-  expanding ~17x. It bounds one **compressed** body, and nothing more — the three
-  residuals are all above: the aggregate term is `ISSUE-SYNC-METADATA-CONCURRENCY-01`,
+  expanding ~17x. It bounds one request body at a time and nothing more — and for
+  `RecvFS`, only the **compressed** body at that. The three residuals are all above:
+  the aggregate term is `ISSUE-SYNC-METADATA-CONCURRENCY-01`,
   the inflate is `ISSUE-RECVFS-DECOMPRESSION-AMPLIFICATION-01`, and the work an
   accepted id list triggers is `ISSUE-SYNC-FSID-WORK-AMPLIFICATION-01`.
 - `ISSUE-BATCH-MOVE-FALSE-SUCCESS-01` — **Fixed 2026-08-12.** Legacy same-repo batch

--- a/docs/OPEN-WORK-INDEX.md
+++ b/docs/OPEN-WORK-INDEX.md
@@ -129,7 +129,6 @@ on every replica in every DC until both close.
 | `ISSUE-UPLOAD-PUT-BEFORE-INTENT-01` | MEDIUM | S3 PUT precedes durable intent; a crash leaves an undiscoverable object | Registry X3 |
 | `ISSUE-QUOTA-RESERVATION-01` | MEDIUM | TOCTOU between quota pre-check and publish | Readiness UP-3 |
 | `ISSUE-DOWNLOAD-NO-404-01` | MEDIUM | Deleted file answers 503 forever; layers disagree | Registry X8 — **accepted cost of PR-6** |
-| `ISSUE-BATCH-MOVE-FALSE-SUCCESS-01` | MEDIUM | Legacy `moveBatchFiles` returns `success:true` without moving | API footgun; UI uses `SyncBatchMove` |
 | `ISSUE-ACCOUNTS-M2M-PATH-01` | MEDIUM | Admin API key channel works; M2M lacks `source=accounts` + idempotency | Code-verified 2026-07-25 |
 | `ISSUE-MID-OPERATION-REVOCATION-01` | MEDIUM | Revoke mid chunked-upload / mid-stream / ZIP does not abort in flight | UP-5 / DL-5 / RB-4 |
 | `ISSUE-SHARELINK-NO-ORG-SCOPE-01` | MEDIUM | No org-internal share-link scope (token-only, anonymous) | SH-2 — product / BY DESIGN option |

--- a/docs/OPEN-WORK-INDEX.md
+++ b/docs/OPEN-WORK-INDEX.md
@@ -138,6 +138,8 @@ on every replica in every DC until both close.
 | Issue | Sev | One line | Detail |
 |---|---|---|---|
 | `ISSUE-RECVFS-DECOMPRESSION-AMPLIFICATION-01` | HIGH | `recv-fs` inflates each object unbounded; 128 MiB body → ~126 GiB at DEFLATE's measured 1029:1 | Found auditing X9; the body cap does not bound this |
+| `ISSUE-SYNC-FSID-WORK-AMPLIFICATION-01` | HIGH | `pack-fs` materializes the whole response: ~409k repeats of one valid id, `PermissionR` only. `check-fs` shares the fan-out | Found auditing X9; the fs-id equivalent of the closed X11 |
+| `ISSUE-RECVFS-FSID-UNVERIFIED-01` | ? | `recv-fs` never checks the client's fs_id hashes the content it stores — but the stored-vs-computed mapping may make that by design | Open **question**; settle the contract before "fixing" |
 | `ISSUE-ZIP-STREAM-LATEFAIL-01` | HIGH | ZIP download can truncate after `200 OK` | Readiness DL-2 |
 | `ISSUE-BLOCK-CROSS-LIBRARY-READ-01` | MEDIUM | Cross-library block read (BOLA), gated only by knowing the 256-bit hash | Readiness B2/SEC-1 |
 | `ISSUE-SHARELINK-DOWNLOAD-CAP-RACE-01` | MEDIUM | Download cap and `single_use` are race-bypassable | Readiness NF-2 / SH-5 |

--- a/docs/OPEN-WORK-INDEX.md
+++ b/docs/OPEN-WORK-INDEX.md
@@ -125,7 +125,6 @@ on every replica in every DC until both close.
 | `ISSUE-ZIP-STREAM-LATEFAIL-01` | HIGH | ZIP download can truncate after `200 OK` | Readiness DL-2 |
 | `ISSUE-BLOCK-CROSS-LIBRARY-READ-01` | MEDIUM | Cross-library block read (BOLA), gated only by knowing the 256-bit hash | Readiness B2/SEC-1 |
 | `ISSUE-SHARELINK-DOWNLOAD-CAP-RACE-01` | MEDIUM | Download cap and `single_use` are race-bypassable | Readiness NF-2 / SH-5 |
-| `ISSUE-SYNC-UNBOUNDED-BODIES-01` | MEDIUM | Four sync handlers still read the body unbounded | Registry X9 |
 | `ISSUE-AUDIT-TRAIL-INCOMPLETE-01` | MEDIUM | `audit_log` records deletions but never grants | Readiness NF-6 / RB-3 |
 | `ISSUE-UPLOAD-PUT-BEFORE-INTENT-01` | MEDIUM | S3 PUT precedes durable intent; a crash leaves an undiscoverable object | Registry X3 |
 | `ISSUE-QUOTA-RESERVATION-01` | MEDIUM | TOCTOU between quota pre-check and publish | Readiness UP-3 |

--- a/docs/OPEN-WORK-INDEX.md
+++ b/docs/OPEN-WORK-INDEX.md
@@ -78,6 +78,20 @@ Kept briefly so a reader who arrives with the old blocker list can see it moved
 rather than vanished. Drop rows once they stop being recent; status of record
 stays in [KNOWN_ISSUES.md](./KNOWN_ISSUES.md).
 
+- `ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01` — **Fixed 2026-08-12** (readiness SEC-3 /
+  NF-3). The `sesamefs_auth` cookie is `httpOnly=true` on every OIDC login and
+  logout writer, funneled through one `setAuthCookie` helper per package. Verified
+  first that nothing in this repository reads it from JS. `Secure` is untouched —
+  that is `ISSUE-AUTOLOGIN-COOKIE-INSECURE-01`, still open.
+- `ISSUE-SYNC-UNBOUNDED-BODIES-01` — **Fixed 2026-08-12** (registry X9). All four
+  remaining sync handlers read through `readLimitedRequestBody`; `pack-fs` and
+  `check-fs` also gained the id-count cap that stops a body under the byte cap from
+  expanding ~17x. Bounds one request, not N — the aggregate half is now
+  `ISSUE-SYNC-METADATA-CONCURRENCY-01` above.
+- `ISSUE-BATCH-MOVE-FALSE-SUCCESS-01` — **Fixed 2026-08-12.** Legacy same-repo batch
+  move via `POST /file/move` returned `{"success":true,"moved":N}` without touching
+  the FS tree; it now returns 501 pointing at `sync-batch-move-item/`. Still
+  unimplemented, no longer lying about it. The UI never used this path.
 - `ISSUE-SHARELINK-PASSWORD-BYPASS-01` — **Fixed 2026-07-25** (readiness NF-1 /
   SH-6). Gate runs before the inline read and the OnlyOffice token mint; the
   bundle builder drops protected content; the OnlyOffice helper fails closed.
@@ -125,6 +139,7 @@ on every replica in every DC until both close.
 | `ISSUE-ZIP-STREAM-LATEFAIL-01` | HIGH | ZIP download can truncate after `200 OK` | Readiness DL-2 |
 | `ISSUE-BLOCK-CROSS-LIBRARY-READ-01` | MEDIUM | Cross-library block read (BOLA), gated only by knowing the 256-bit hash | Readiness B2/SEC-1 |
 | `ISSUE-SHARELINK-DOWNLOAD-CAP-RACE-01` | MEDIUM | Download cap and `single_use` are race-bypassable | Readiness NF-2 / SH-5 |
+| `ISSUE-SYNC-METADATA-CONCURRENCY-01` | MEDIUM | Sync metadata routes bound one body, not N — 16 concurrent `recv-fs` ≈ 2 GiB | Successor to X9; X10's equivalent for the block routes is closed |
 | `ISSUE-AUDIT-TRAIL-INCOMPLETE-01` | MEDIUM | `audit_log` records deletions but never grants | Readiness NF-6 / RB-3 |
 | `ISSUE-UPLOAD-PUT-BEFORE-INTENT-01` | MEDIUM | S3 PUT precedes durable intent; a crash leaves an undiscoverable object | Registry X3 |
 | `ISSUE-QUOTA-RESERVATION-01` | MEDIUM | TOCTOU between quota pre-check and publish | Readiness UP-3 |

--- a/docs/OPEN-WORK-INDEX.md
+++ b/docs/OPEN-WORK-INDEX.md
@@ -122,7 +122,6 @@ on every replica in every DC until both close.
 
 | Issue | Sev | One line | Detail |
 |---|---|---|---|
-| `ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01` | HIGH | `sesamefs_auth` is a replayable bearer in a JS-readable cookie → XSS = token theft | Readiness SEC-3 / NF-3 |
 | `ISSUE-ZIP-STREAM-LATEFAIL-01` | HIGH | ZIP download can truncate after `200 OK` | Readiness DL-2 |
 | `ISSUE-BLOCK-CROSS-LIBRARY-READ-01` | MEDIUM | Cross-library block read (BOLA), gated only by knowing the 256-bit hash | Readiness B2/SEC-1 |
 | `ISSUE-SHARELINK-DOWNLOAD-CAP-RACE-01` | MEDIUM | Download cap and `single_use` are race-bypassable | Readiness NF-2 / SH-5 |

--- a/docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md
+++ b/docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md
@@ -150,7 +150,15 @@ X11's sibling fix had already removed from `check-blocks`. Both now share that
 parser (`parseBoundedIDList`), with id caps derived from their byte caps so they
 are unreachable for well-formed input and fire only on degenerate bodies.
 
-What X9 does **not** close is the aggregate: a per-request cap bounds one request,
+Choosing the `recv-fs` cap also surfaced something the row does not contemplate at
+all: the cap bounds the **compressed** body, and `RecvFS` then inflates each packed
+object with an unbounded `io.ReadAll` over a `zlib.Reader`. DEFLATE's measured best
+case here is 1029:1, so 128 MiB of body inflates to ~126 GiB — the buffered body is
+not this handler's dominant allocation. Pre-existing, not caused by X9's fix, and
+filed as `ISSUE-RECVFS-DECOMPRESSION-AMPLIFICATION-01`. X9 stays closed on its own
+terms (unbounded body reads), but no one should read it as "recv-fs is bounded".
+
+What X9 also does **not** close is the aggregate: a per-request cap bounds one request,
 and `RecvFS` at 128 MiB × N concurrent is the same shape X10 described for the
 block routes. X10's fix is scoped to `PutBlock` and does not cover these routes, so
 that layer is now `ISSUE-SYNC-METADATA-CONCURRENCY-01` rather than an unowned

--- a/docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md
+++ b/docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md
@@ -146,9 +146,16 @@ fixed number on.
 Choosing the caps surfaced a second half the row does not describe. `pack-fs` and
 `check-fs` parsed their id list with `strings.Split`/`json.Unmarshal` over the
 whole body, so a body *under* the byte cap still expanded ~17x — the amplification
-X11's sibling fix had already removed from `check-blocks`. Both now share that
-parser (`parseBoundedIDList`), with id caps derived from their byte caps so they
-are unreachable for well-formed input and fire only on degenerate bodies.
+PR-10 had already removed from `check-blocks` when it closed F12 by rejecting an
+oversized id list *during* the parse. Both now share that parser
+(`parseBoundedIDList`), with id caps derived from their byte caps so they are
+unreachable for well-formed input and fire only on degenerate bodies.
+
+Deriving those caps that way bounds what a body can expand into and nothing else.
+It says nothing about what an accepted list costs — X11's territory, not F12's —
+and these two routes have none of the controls X11 grew: no dedup before lookup,
+no context on the per-id read, no fan-out bound, no admission capacity. Filed as
+`ISSUE-SYNC-FSID-WORK-AMPLIFICATION-01`.
 
 Choosing the `recv-fs` cap also surfaced something the row does not contemplate at
 all: the cap bounds the **compressed** body, and `RecvFS` then inflates each packed

--- a/docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md
+++ b/docs/UPLOAD-FENCE-FINDINGS-REGISTRY.md
@@ -134,6 +134,29 @@ below the table.
 | X11 | Medium | **`maxCheckBlockIDs` (100k) bounds the parser, not the work an accepted request triggers.** PR-10's cap is a memory bound on parsing and is correct as such. Downstream, an accepted list still drives one `GetBlockIDMapping` Cassandra point read **per legacy SHA-1 id, sequentially** in the `CheckBlocks` loop, then `CheckBlocksExist` at fan-out 10 — so a single accepted 100k-id request can issue ~100k serial reads while holding the handler. That is a request-amplification and latency concern, not a memory one, and the 100k figure was chosen as a safe parse bound rather than validated against Cassandra, the S3 pool, response size or client cancellation. Related to X5, which flags the same unvalidated fan-out on the canonical read path. | `ISSUE-CHECKBLOCKS-WORK-AMPLIFICATION-01`; also subcontract C of `ISSUE-RATE-LIMIT-UPLOAD-DOWNLOAD-01` |
 | X6 | Medium | **Read-after-write across DCs.** Canonical lookups retry a missing row 3×25 ms, which covers local lag but not cross-DC. Safe (fails closed) but an availability dependency: transient 404/503 after a remote upload, `check-blocks` reporting a block missing, needless re-uploads. | `ISSUE-READ-AFTER-WRITE-CROSS-DC-01` (related to X2) |
 
+### Dated note — X9, 2026-08-12
+
+X9 is **closed**. All four handlers read through `readLimitedRequestBody`:
+`PutCommit` at 1 MiB, `PackFS`/`CheckFS` at 16 MiB (plain consts — the same
+id-list shape as `check-blocks`), `RecvFS` at a configurable 128 MiB default
+(`seafhttp.recv_fs_max_bytes`, no ceiling on purpose, zero rejected at boot),
+since it carries a real object batch with no measured client size to anchor a
+fixed number on.
+
+Choosing the caps surfaced a second half the row does not describe. `pack-fs` and
+`check-fs` parsed their id list with `strings.Split`/`json.Unmarshal` over the
+whole body, so a body *under* the byte cap still expanded ~17x — the amplification
+X11's sibling fix had already removed from `check-blocks`. Both now share that
+parser (`parseBoundedIDList`), with id caps derived from their byte caps so they
+are unreachable for well-formed input and fire only on degenerate bodies.
+
+What X9 does **not** close is the aggregate: a per-request cap bounds one request,
+and `RecvFS` at 128 MiB × N concurrent is the same shape X10 described for the
+block routes. X10's fix is scoped to `PutBlock` and does not cover these routes, so
+that layer is now `ISSUE-SYNC-METADATA-CONCURRENCY-01` rather than an unowned
+caveat. Its first step should be measuring what the official client actually sends
+per `recv-fs`: a measured cap may be cheaper than an admission gate.
+
 ### Dated note — X10, 2026-07-30
 
 The aggregate bound and its post-implementation hardening are complete; X10 is

--- a/docs/diagrams/auth-layer.md
+++ b/docs/diagrams/auth-layer.md
@@ -14,7 +14,10 @@
 
 ## Token Creation
 
-**Key issue:** The `sesamefs_auth` cookie is set with `httpOnly=false`, meaning JavaScript (and any XSS) can read it.
+**Fixed (`ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01`):** The `sesamefs_auth` cookie is now set with
+`httpOnly=true`, so JavaScript (and any XSS) can no longer read it. No code in this repository
+was found reading its value from JS; the desktop-client SSO flow gets its token via polling,
+not by reading this cookie.
 
 ```mermaid
 flowchart TD
@@ -22,10 +25,10 @@ flowchart TD
     Login --> GenToken["Generate crypto/rand token"]
     GenToken --> HashToken["SHA-256 hash"]
     HashToken --> StoreDB["Store hash in Cassandra<br/>user_id, org_id, expiry"]
-    StoreDB --> SetCookie["Set cookie<br/>sesamefs_auth = email@token<br/>httpOnly = false"]
+    StoreDB --> SetCookie["Set cookie<br/>sesamefs_auth = email@token<br/>httpOnly = true"]
     SetCookie --> Done["Return token to client"]
 
-    style SetCookie fill:#ffc107,color:#000
+    style SetCookie fill:#28a745,color:#fff
 ```
 
 ---

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2319,15 +2319,21 @@ func (s *Server) handleLogout(c *gin.Context) {
 	c.Redirect(http.StatusFound, "/")
 }
 
-// setAuthCookie is the single writer for the sesamefs_auth session cookie in this
-// package, used by both the OIDC callback (login) and handleLogout (clear).
+// setAuthCookie is the shared writer for sesamefs_auth issuance and clearing on
+// the OIDC path in this package, used by both handleOAuthCallback (login) and
+// handleLogout (clear) so the flags cannot drift between the two.
+//
 // httpOnly is always true: ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01 found no code in
 // this repository — including mobile-frontend — that reads this cookie's value
 // from JS; the desktop-client SSO flow already gets its token via clientSSOStore
 // polling, not by reading this cookie from an embedded WebView as an older
 // comment here used to claim. Secure is still derived per-request from
-// c.Request.TLS, matching every other writer of this cookie (the separate
-// ISSUE-AUTOLOGIN-COOKIE-INSECURE-01 covers the one site that hardcodes it).
+// c.Request.TLS.
+//
+// Not every writer in the package: handleAutoLogin writes this cookie directly
+// because it hardcodes Secure=false, which is the separate, still-open
+// ISSUE-AUTOLOGIN-COOKIE-INSECURE-01. It already sets httpOnly=true, so it is
+// consistent on this flag; folding it in here is that issue's work, not this one's.
 func (s *Server) setAuthCookie(c *gin.Context, value string, maxAge int) {
 	isSecure := c.Request.TLS != nil
 	c.SetCookie("sesamefs_auth", value, maxAge, "/", "", isSecure, true)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2277,12 +2277,10 @@ func (s *Server) handleOAuthCallback(c *gin.Context) {
 	}
 
 	// Set sesamefs_auth cookie (email@token) — matches seahub convention.
-	// httpOnly=false is intentional: the embedded WebView needs to read this via JS.
 	// Cookie TTL matches session TTL so both expire at the same time.
 	seahubAuth := result.Email + "@" + result.SessionToken
-	isSecure := c.Request.TLS != nil
 	cookieMaxAge := int(s.config.Auth.OIDC.SessionTTL.Seconds())
-	c.SetCookie("sesamefs_auth", seahubAuth, cookieMaxAge, "/", "", isSecure, false)
+	s.setAuthCookie(c, seahubAuth, cookieMaxAge)
 
 	// If this was a desktop client SSO login (returnURL starts with seafile://),
 	// show a confirmation page instead of redirecting to the web app home page.
@@ -2315,11 +2313,24 @@ func (s *Server) handleLogout(c *gin.Context) {
 	}
 
 	// Clear the auth cookie server-side (maxAge=-1 expires immediately)
-	isSecure := c.Request.TLS != nil
-	c.SetCookie("sesamefs_auth", "", -1, "/", "", isSecure, false)
+	s.setAuthCookie(c, "", -1)
 
 	// Redirect to home — the SPA will detect the missing session and show the login page
 	c.Redirect(http.StatusFound, "/")
+}
+
+// setAuthCookie is the single writer for the sesamefs_auth session cookie in this
+// package, used by both the OIDC callback (login) and handleLogout (clear).
+// httpOnly is always true: ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01 found no code in
+// this repository — including mobile-frontend — that reads this cookie's value
+// from JS; the desktop-client SSO flow already gets its token via clientSSOStore
+// polling, not by reading this cookie from an embedded WebView as an older
+// comment here used to claim. Secure is still derived per-request from
+// c.Request.TLS, matching every other writer of this cookie (the separate
+// ISSUE-AUTOLOGIN-COOKIE-INSECURE-01 covers the one site that hardcodes it).
+func (s *Server) setAuthCookie(c *gin.Context, value string, maxAge int) {
+	isSecure := c.Request.TLS != nil
+	c.SetCookie("sesamefs_auth", value, maxAge, "/", "", isSecure, true)
 }
 
 // handleCreateRepoTag returns a stub response for tag creation

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	stdgzip "compress/gzip"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"io"
@@ -1118,6 +1119,70 @@ func TestAuthTokenErrorFormat(t *testing.T) {
 	if _, ok := response["non_field_errors"]; !ok {
 		t.Error("auth error should have 'non_field_errors' field for Seafile compatibility")
 	}
+}
+
+// TestServerSetAuthCookie pins ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01 at the single
+// writer both handleSSOCallback (login) and handleLogout (clear) share, rather than
+// at a full HTTP round trip through either — HandleOIDCCallback's success path
+// requires a real OIDC code exchange this test suite does not mock, so testing the
+// helper directly is what actually reaches the login-side write.
+func TestServerSetAuthCookie(t *testing.T) {
+	t.Run("always sets HttpOnly", func(t *testing.T) {
+		s := &Server{}
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+		s.setAuthCookie(c, "user@example.com@sometoken", 3600)
+
+		setCookie := w.Header().Get("Set-Cookie")
+		if !strings.Contains(setCookie, "HttpOnly") {
+			t.Fatalf("Set-Cookie = %q, want it to contain HttpOnly", setCookie)
+		}
+		// gin URL-encodes the cookie value, so "@" becomes "%40" — the actual
+		// production value has the same shape (email@token).
+		if !strings.Contains(setCookie, "sesamefs_auth=user%40example.com%40sometoken") {
+			t.Fatalf("Set-Cookie = %q, want it to carry the given value", setCookie)
+		}
+		if strings.Contains(setCookie, "Secure") {
+			t.Fatalf("Set-Cookie = %q, want no Secure over a plain-HTTP request", setCookie)
+		}
+	})
+
+	t.Run("derives Secure from the request's TLS state", func(t *testing.T) {
+		s := &Server{}
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+		c.Request.TLS = &tls.ConnectionState{}
+
+		s.setAuthCookie(c, "user@example.com@sometoken", 3600)
+
+		setCookie := w.Header().Get("Set-Cookie")
+		if !strings.Contains(setCookie, "Secure") {
+			t.Fatalf("Set-Cookie = %q, want Secure over a TLS request", setCookie)
+		}
+		if !strings.Contains(setCookie, "HttpOnly") {
+			t.Fatalf("Set-Cookie = %q, want it to still contain HttpOnly", setCookie)
+		}
+	})
+
+	t.Run("clearing uses maxAge=-1 and still sets HttpOnly", func(t *testing.T) {
+		s := &Server{}
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+		s.setAuthCookie(c, "", -1)
+
+		setCookie := w.Header().Get("Set-Cookie")
+		if !strings.Contains(setCookie, "HttpOnly") {
+			t.Fatalf("Set-Cookie = %q, want it to contain HttpOnly on clear too", setCookie)
+		}
+		if !strings.Contains(setCookie, "Max-Age=0") {
+			t.Fatalf("Set-Cookie = %q, want an expiring Max-Age=0 (net/http's encoding of maxAge=-1)", setCookie)
+		}
+	})
 }
 
 // TestAccountInfoTotalSpace tests account info total_space field

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1121,9 +1121,9 @@ func TestAuthTokenErrorFormat(t *testing.T) {
 	}
 }
 
-// TestServerSetAuthCookie pins ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01 at the single
-// writer both handleSSOCallback (login) and handleLogout (clear) share, rather than
-// at a full HTTP round trip through either — HandleOIDCCallback's success path
+// TestServerSetAuthCookie pins ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01 at the shared
+// writer both handleOAuthCallback (login) and handleLogout (clear) use, rather than
+// at a full HTTP round trip through either — the callback's success path
 // requires a real OIDC code exchange this test suite does not mock, so testing the
 // helper directly is what actually reaches the login-side write.
 func TestServerSetAuthCookie(t *testing.T) {

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -1465,6 +1465,19 @@ const (
 	maxPutCommitBodyBytes = 1 * 1024 * 1024  // 1 MiB
 	maxPackFSBodyBytes    = 16 * 1024 * 1024 // 16 MiB, same shape as check-blocks
 	maxCheckFSBodyBytes   = 16 * 1024 * 1024 // 16 MiB, same shape as check-blocks
+
+	// minFSIDWireBytes is the smallest on-the-wire cost of one well-formed 40-hex
+	// fs id: the 40 characters plus a single delimiter (a newline, or the "," in a
+	// JSON array). Deriving the id caps below from the byte caps above makes them
+	// unreachable for any well-formed body — 16 MiB cannot carry more ids than
+	// this — so they only ever fire on degenerate input, which is precisely the
+	// amplification they exist to stop and not a new limit on real clients.
+	//
+	// Without them, a body *under* the byte cap still expands ~17x: 16 MiB of bare
+	// newlines becomes ~16.7M string headers (~268 MB). See parseBoundedIDList.
+	minFSIDWireBytes = 41
+	maxPackFSIDs     = maxPackFSBodyBytes / minFSIDWireBytes
+	maxCheckFSIDs    = maxCheckFSBodyBytes / minFSIDWireBytes
 )
 
 // checkBlocksMaxIDs resolves the accepted id-count cap.
@@ -2065,23 +2078,59 @@ type CheckBlocksRequest struct {
 	BlockIDs []string `json:"block_ids"`
 }
 
-// parseCheckBlockIDs parses a check-blocks body into block ids, bounding the id
-// count *before* the list is materialized. Checking the count after the parse
-// would allocate exactly what the cap exists to bound: within the 16 MiB body cap
-// a caller can still reach ~16.7M ids via one-byte entries ("a\n\n\n…\na", which
-// TrimSpace cannot collapse because both ends are non-space), and strings.Split
-// pre-sizes the slice in a single make — ~272 MB of string headers. The JSON path
-// is the same class (~5.6M empty strings, ~198 MB) because json.Unmarshal grows
-// the slice to completion first.
+// idListSpec describes one route's id-list parse: how many ids it accepts and how
+// it names them when it refuses. The naming is per-route rather than generic
+// because check-blocks' 413 body — {"error":"too many block ids","max_block_ids":N}
+// — is an existing client-visible shape, and generalizing this parser must not
+// silently change it.
+type idListSpec struct {
+	route      string // log prefix on a malformed body, e.g. "check-blocks"
+	maxIDs     int
+	tooManyMsg string // 413 "error" text, e.g. "too many block ids"
+	maxField   string // 413 field carrying the cap, e.g. "max_block_ids"
+}
+
+// checkBlocksIDListSpec preserves check-blocks' pre-existing 413 body verbatim
+// ({"error":"too many block ids","max_block_ids":N}); the cap stays configuration.
+func checkBlocksIDListSpec(maxIDs int) idListSpec {
+	return idListSpec{route: "check-blocks", maxIDs: maxIDs, tooManyMsg: "too many block ids", maxField: "max_block_ids"}
+}
+
+// packFSIDListSpec and checkFSIDListSpec name the id-list parse for the two fs
+// routes. Their 413 shape is new (neither route bounded id count before), so it is
+// named for fs ids rather than borrowing check-blocks' block-id wording, and their
+// caps are derived consts rather than configuration — see minFSIDWireBytes.
+func packFSIDListSpec() idListSpec {
+	return idListSpec{route: "pack-fs", maxIDs: maxPackFSIDs, tooManyMsg: "too many fs ids", maxField: "max_fs_ids"}
+}
+
+func checkFSIDListSpec() idListSpec {
+	return idListSpec{route: "check-fs", maxIDs: maxCheckFSIDs, tooManyMsg: "too many fs ids", maxField: "max_fs_ids"}
+}
+
+// parseBoundedIDList parses a newline-separated or JSON-array id body into ids,
+// bounding the id count *before* the list is materialized. Checking the count
+// after the parse would allocate exactly what the cap exists to bound: within a
+// 16 MiB body cap a caller can still reach ~16.7M ids via one-byte entries
+// ("a\n\n\n…\na", which TrimSpace cannot collapse because both ends are
+// non-space), and strings.Split pre-sizes the slice in a single make — ~272 MB of
+// string headers. The JSON path is the same class (~5.6M empty strings, ~198 MB)
+// because json.Unmarshal grows the slice to completion first.
+//
+// A byte cap alone does not close this: readLimitedRequestBody bounds the body,
+// this bounds what the body can expand into. check-fs and pack-fs carry the same
+// 40-hex id shape as check-blocks and reached this parser late (their byte caps
+// landed first, in ISSUE-SYNC-UNBOUNDED-BODIES-01 / X9), which is why the parser
+// is shared rather than reimplemented per route.
 //
 // Returns ok=false after writing the response; the caller must return immediately.
-func parseCheckBlockIDs(c *gin.Context, body []byte, maxCheckBlockIDs int) ([]string, bool) {
+func parseBoundedIDList(c *gin.Context, body []byte, spec idListSpec) ([]string, bool) {
 	tooMany := func() ([]string, bool) {
-		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "too many block ids", "max_block_ids": maxCheckBlockIDs})
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": spec.tooManyMsg, spec.maxField: spec.maxIDs})
 		return nil, false
 	}
 	invalid := func(err error) ([]string, bool) {
-		log.Printf("check-blocks: failed to parse JSON array: %v", err)
+		log.Printf("%s: failed to parse JSON array: %v", spec.route, err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid JSON array"})
 		return nil, false
 	}
@@ -2091,7 +2140,7 @@ func parseCheckBlockIDs(c *gin.Context, body []byte, maxCheckBlockIDs int) ([]st
 	// Newline-separated format: count the delimiters first, since strings.Split
 	// allocates one slice entry per id up front.
 	if !strings.HasPrefix(bodyStr, "[") {
-		if strings.Count(bodyStr, "\n")+1 > maxCheckBlockIDs {
+		if strings.Count(bodyStr, "\n")+1 > spec.maxIDs {
 			return tooMany()
 		}
 		return strings.Split(bodyStr, "\n"), true
@@ -2105,7 +2154,7 @@ func parseCheckBlockIDs(c *gin.Context, body []byte, maxCheckBlockIDs int) ([]st
 	}
 	externalIDs := make([]string, 0, 64)
 	for dec.More() {
-		if len(externalIDs) >= maxCheckBlockIDs {
+		if len(externalIDs) >= spec.maxIDs {
 			return tooMany()
 		}
 		var id string
@@ -2295,7 +2344,7 @@ func (h *SyncHandler) CheckBlocks(c *gin.Context) {
 		return
 	}
 	// Parse the body - can be JSON array or newline-separated
-	externalIDs, ok := parseCheckBlockIDs(c, body, h.checkBlocksMaxIDs())
+	externalIDs, ok := parseBoundedIDList(c, body, checkBlocksIDListSpec(h.checkBlocksMaxIDs()))
 	if !ok {
 		return
 	}
@@ -2669,18 +2718,9 @@ func (h *SyncHandler) PackFS(c *gin.Context) {
 	}
 
 	// Parse the body - can be JSON array or newline-separated
-	var requestedFSIDs []string
-	bodyStr := strings.TrimSpace(string(body))
-	if strings.HasPrefix(bodyStr, "[") {
-		// JSON array format
-		if err := json.Unmarshal(body, &requestedFSIDs); err != nil {
-			log.Printf("pack-fs: failed to parse JSON array: %v", err)
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid JSON array"})
-			return
-		}
-	} else {
-		// Newline-separated format
-		requestedFSIDs = strings.Split(bodyStr, "\n")
+	requestedFSIDs, ok := parseBoundedIDList(c, body, packFSIDListSpec())
+	if !ok {
+		return
 	}
 
 	// Build binary response
@@ -2919,18 +2959,9 @@ func (h *SyncHandler) CheckFS(c *gin.Context) {
 	}
 
 	// Parse the body - can be JSON array or newline-separated
-	var fsIDs []string
-	bodyStr := strings.TrimSpace(string(body))
-	if strings.HasPrefix(bodyStr, "[") {
-		// JSON array format
-		if err := json.Unmarshal(body, &fsIDs); err != nil {
-			log.Printf("check-fs: failed to parse JSON array: %v", err)
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid JSON array"})
-			return
-		}
-	} else {
-		// Newline-separated format
-		fsIDs = strings.Split(bodyStr, "\n")
+	fsIDs, ok := parseBoundedIDList(c, body, checkFSIDListSpec())
+	if !ok {
+		return
 	}
 
 	// CRITICAL: Client sends COMPUTED fs_ids (SHA-1 of corrected JSON),

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -1467,11 +1467,14 @@ const (
 	maxCheckFSBodyBytes   = 16 * 1024 * 1024 // 16 MiB, same shape as check-blocks
 
 	// minFSIDWireBytes is the smallest on-the-wire cost of one well-formed 40-hex
-	// fs id: the 40 characters plus a single delimiter (a newline, or the "," in a
-	// JSON array). Deriving the id caps below from the byte caps above makes them
-	// unreachable for any well-formed body — 16 MiB cannot carry more ids than
-	// this — so they only ever fire on degenerate input, which is precisely the
-	// amplification they exist to stop and not a new limit on real clients.
+	// fs id, which the newline format sets: 40 characters plus one delimiter. JSON
+	// is strictly less dense — each id is also quoted, so ~43 bytes — and therefore
+	// cannot bind first; TestFSIDCapsCannotCutWellFormedBodies asserts both.
+	//
+	// Deriving the id caps below from the byte caps above makes them unreachable for
+	// any well-formed body — 16 MiB cannot carry more ids than this — so they only
+	// ever fire on degenerate input, which is precisely the amplification they exist
+	// to stop and not a new limit on real clients.
 	//
 	// Without them, a body *under* the byte cap still expands ~17x: 16 MiB of bare
 	// newlines becomes ~16.7M string headers (~268 MB). See parseBoundedIDList.

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -1174,9 +1174,8 @@ func (h *SyncHandler) PutCommit(c *gin.Context) {
 	}
 
 	// Read commit data from body
-	body, err := io.ReadAll(c.Request.Body)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read body"})
+	body, ok := readLimitedRequestBody(c, maxPutCommitBodyBytes)
+	if !ok {
 		return
 	}
 
@@ -1194,7 +1193,7 @@ func (h *SyncHandler) PutCommit(c *gin.Context) {
 
 	// Store commit in database
 	now := time.Now()
-	err = h.db.Session().Query(`
+	err := h.db.Session().Query(`
 		INSERT INTO commits (library_id, commit_id, parent_id, root_fs_id, creator_id, description, created_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?)
 	`, repoID, commitID, commit.ParentID, commit.RootID, userID, commit.Description, now).Exec()
@@ -1456,6 +1455,16 @@ func syncBlockDownloadStreamCause(err error) downloadadmission.ReleaseCause {
 // from it; the block cap is now configuration, see syncBlockMaxBytes below.
 const (
 	maxCheckBlocksBodyBytes = 16 * 1024 * 1024 // 16 MiB
+
+	// PutCommit, PackFS and CheckFS were the other three handlers still reading
+	// an unbounded body (ISSUE-SYNC-UNBOUNDED-BODIES-01 / X9) — the same defect
+	// F12 fixed for PutBlock/CheckBlocks. Plain consts, not configuration: a
+	// commit object and an id list (PackFS/CheckFS request the same 40-char hex
+	// fs-id shape check-blocks does) are small, protocol-shaped payloads, not a
+	// variable-sized bulk payload like recv-fs below.
+	maxPutCommitBodyBytes = 1 * 1024 * 1024  // 1 MiB
+	maxPackFSBodyBytes    = 16 * 1024 * 1024 // 16 MiB, same shape as check-blocks
+	maxCheckFSBodyBytes   = 16 * 1024 * 1024 // 16 MiB, same shape as check-blocks
 )
 
 // checkBlocksMaxIDs resolves the accepted id-count cap.
@@ -1498,6 +1507,26 @@ func (h *SyncHandler) syncBlockMaxBytes() int64 {
 		return config.DefaultSyncBlockMaxBytes
 	}
 	return h.config.SeafHTTP.SyncBlockMaxBytes
+}
+
+// syncRecvFSMaxBytes resolves the per-request body cap for RecvFS.
+//
+// Unlike maxPutCommitBodyBytes/maxPackFSBodyBytes/maxCheckFSBodyBytes above,
+// this is configuration rather than a const: recv-fs carries a real batch of
+// packed FS objects, not a small id list, and there is no measured client
+// batch size or protocol-documented ceiling to anchor a fixed number on. The
+// default is deliberately generous so it is unlikely to cut a legitimate large
+// commit; an operator can raise it further without a code change.
+//
+// The nil-config fallback is the package default rather than something
+// permissive, for the same reason as syncBlockMaxBytes: a handler without
+// config is a wiring bug, and failing open here would restore the unbounded
+// read this cap exists to prevent.
+func (h *SyncHandler) syncRecvFSMaxBytes() int64 {
+	if h == nil || h.config == nil || h.config.SeafHTTP.RecvFSMaxBytes <= 0 {
+		return config.DefaultRecvFSMaxBytes
+	}
+	return h.config.SeafHTTP.RecvFSMaxBytes
 }
 
 func (h *SyncHandler) syncBlockAdmittedLifetime() time.Duration {
@@ -2634,9 +2663,8 @@ func (h *SyncHandler) PackFS(c *gin.Context) {
 	}
 
 	// Read FS IDs from body
-	body, err := io.ReadAll(c.Request.Body)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read body"})
+	body, ok := readLimitedRequestBody(c, maxPackFSBodyBytes)
+	if !ok {
 		return
 	}
 
@@ -2750,9 +2778,8 @@ func (h *SyncHandler) RecvFS(c *gin.Context) {
 	}
 
 	// Read FS objects from body
-	body, err := io.ReadAll(c.Request.Body)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read body"})
+	body, ok := readLimitedRequestBody(c, h.syncRecvFSMaxBytes())
+	if !ok {
 		return
 	}
 
@@ -2886,9 +2913,8 @@ func (h *SyncHandler) CheckFS(c *gin.Context) {
 	}
 
 	// Read FS IDs from body
-	body, err := io.ReadAll(c.Request.Body)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read body"})
+	body, ok := readLimitedRequestBody(c, maxCheckFSBodyBytes)
+	if !ok {
 		return
 	}
 
@@ -2913,7 +2939,7 @@ func (h *SyncHandler) CheckFS(c *gin.Context) {
 
 	// Get HEAD commit's root_fs_id to build the mapping
 	var headCommitID string
-	err = h.db.Session().Query(`
+	err := h.db.Session().Query(`
 		SELECT head_commit_id FROM libraries WHERE org_id = ? AND library_id = ?
 	`, orgID, repoID).Scan(&headCommitID)
 	if err != nil {

--- a/internal/api/sync_body_limits_test.go
+++ b/internal/api/sync_body_limits_test.go
@@ -310,10 +310,14 @@ func TestParseCheckBlockIDsRejectsBeforeMaterializing(t *testing.T) {
 	}
 }
 
-// TestIDListSpec413BodiesAreStable pins the client-visible 413 payloads across the
-// generalization of parseCheckBlockIDs into parseBoundedIDList. check-blocks' body
-// predates that refactor and must survive it byte for byte; the two fs routes name
-// fs ids because their 413 is new, and naming them "block ids" would be a lie a
+// TestIDListSpec413BodiesAreStable pins the client-visible 413 *schema* across the
+// generalization of parseCheckBlockIDs into parseBoundedIDList — the error text, the
+// cap field's name, and the cap's value. Not byte equality: key order in a gin.H is
+// not a contract anyone should depend on, and pinning it would fail on an unrelated
+// field being added rather than on the shape actually changing.
+//
+// check-blocks' schema predates the refactor and must survive it. The two fs routes
+// name fs ids because their 413 is new; calling them "block ids" would be a lie a
 // future reader would have to debug.
 func TestIDListSpec413BodiesAreStable(t *testing.T) {
 	for _, tc := range []struct {
@@ -346,8 +350,11 @@ func TestIDListSpec413BodiesAreStable(t *testing.T) {
 			if got["error"] != tc.wantError {
 				t.Errorf("error = %v, want %q", got["error"], tc.wantError)
 			}
-			if _, ok := got[tc.wantField]; !ok {
-				t.Errorf("413 body = %v, want it to carry %q", got, tc.wantField)
+			// The field must carry the cap that actually fired, not merely exist:
+			// a 413 that reports the wrong number is worse than one that reports
+			// none, since an operator would tune against it.
+			if got[tc.wantField] != float64(tc.spec.maxIDs) {
+				t.Errorf("413 body[%q] = %v, want the cap %d that fired (body=%v)", tc.wantField, got[tc.wantField], tc.spec.maxIDs, got)
 			}
 		})
 	}

--- a/internal/api/sync_body_limits_test.go
+++ b/internal/api/sync_body_limits_test.go
@@ -352,3 +352,142 @@ func TestCheckBlocksBoundsChunkedBody(t *testing.T) {
 		t.Fatalf("chunked oversized body = %d, want 413; body=%s", w.Code, w.Body.String())
 	}
 }
+
+// TestPutCommitBoundsBodySize covers ISSUE-SYNC-UNBOUNDED-BODIES-01 / X9 for
+// PutCommit, the first of the four sibling handlers PR-10 left on unbounded
+// io.ReadAll. Only the rejection boundary is pinned (cap+1 -> 413); the positive
+// case below asserts the size gate is passed (not 413) using an invalid body
+// that fails cleanly at JSON parsing (400) rather than reaching h.db, which is
+// nil in this handler and would panic on the unconditional DB write PutCommit
+// performs after a valid commit — that write is out of scope for this cap.
+func TestPutCommitBoundsBodySize(t *testing.T) {
+	postPutCommit := func(t *testing.T, body string, declaredLen int64) int {
+		t.Helper()
+		r := setupSyncTestRouter()
+		h := &SyncHandler{}
+		r.PUT("/seafhttp/repo/:repo_id/commit/:commit_id", h.PutCommit)
+		req := httptest.NewRequest(http.MethodPut, "/seafhttp/repo/repo/commit/somecommitid", strings.NewReader(body))
+		req.ContentLength = declaredLen
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if code := postPutCommit(t, strings.Repeat("a", maxPutCommitBodyBytes+1), int64(maxPutCommitBodyBytes+1)); code != http.StatusRequestEntityTooLarge {
+		t.Errorf("PutCommit body over cap = %d, want 413", code)
+	}
+	// Not valid JSON, so it fails at "invalid commit format" (400) rather than
+	// reaching the database — this proves the size gate let it through, not a
+	// parser accident, since a malformed body is a stable, intentional 400.
+	invalidJSON := strings.Repeat("a", maxPutCommitBodyBytes)
+	if code := postPutCommit(t, invalidJSON, int64(maxPutCommitBodyBytes)); code == http.StatusRequestEntityTooLarge {
+		t.Errorf("PutCommit body at cap was rejected 413, want it through the size gate")
+	} else if code != http.StatusBadRequest {
+		t.Errorf("PutCommit body at cap (invalid JSON) = %d, want 400", code)
+	}
+}
+
+// TestPackFSBoundsBodySize covers ISSUE-SYNC-UNBOUNDED-BODIES-01 / X9 for
+// PackFS. Only the rejection boundary is pinned: what PackFS does with a body
+// under the cap depends on parser/DB behavior that is not this cap's contract.
+func TestPackFSBoundsBodySize(t *testing.T) {
+	r := setupSyncTestRouter()
+	h := &SyncHandler{}
+	r.POST("/seafhttp/repo/:repo_id/pack-fs", h.PackFS)
+
+	body := strings.Repeat("a", maxPackFSBodyBytes+1)
+	req := httptest.NewRequest(http.MethodPost, "/seafhttp/repo/repo/pack-fs", strings.NewReader(body))
+	req.ContentLength = int64(len(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("PackFS body over cap = %d, want 413", w.Code)
+	}
+}
+
+// TestPackFSBoundsChunkedBody mirrors TestCheckBlocksBoundsChunkedBody for
+// PackFS: a client that declares no Content-Length must still be cut by
+// MaxBytesReader, not merely by the declared-length fast path — precisely the
+// shape io.ReadAll without a limit could not bound before this fix.
+func TestPackFSBoundsChunkedBody(t *testing.T) {
+	r := setupSyncTestRouter()
+	h := &SyncHandler{}
+	r.POST("/seafhttp/repo/:repo_id/pack-fs", h.PackFS)
+
+	body := strings.NewReader(strings.Repeat("a", maxPackFSBodyBytes+1))
+	req := httptest.NewRequest(http.MethodPost, "/seafhttp/repo/repo/pack-fs", body)
+	req.ContentLength = -1
+	req.TransferEncoding = []string{"chunked"}
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("chunked oversized PackFS body = %d, want 413; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestCheckFSBoundsBodySize covers ISSUE-SYNC-UNBOUNDED-BODIES-01 / X9 for
+// CheckFS. Only the rejection boundary is pinned: unlike PackFS/RecvFS, CheckFS
+// touches h.db unconditionally right after parsing (even for an empty id list),
+// so there is no body shape that reaches a positive result without a live DB.
+func TestCheckFSBoundsBodySize(t *testing.T) {
+	r := setupSyncTestRouter()
+	h := &SyncHandler{}
+	r.POST("/seafhttp/repo/:repo_id/check-fs", h.CheckFS)
+
+	body := strings.Repeat("a", maxCheckFSBodyBytes+1)
+	req := httptest.NewRequest(http.MethodPost, "/seafhttp/repo/repo/check-fs", strings.NewReader(body))
+	req.ContentLength = int64(len(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("CheckFS body over cap = %d, want 413", w.Code)
+	}
+}
+
+// TestRecvFSBoundsBodySize covers ISSUE-SYNC-UNBOUNDED-BODIES-01 / X9 for
+// RecvFS, the one handler of the four where the cap is configuration
+// (config.SeafHTTP.RecvFSMaxBytes) rather than a const, because unlike the
+// other three it carries a real batch payload with no measured client size to
+// anchor a fixed number on. Both the nil-config default and an explicit
+// configured cap are exercised, mirroring TestPutBlockBoundsBodySize's
+// "nil config uses the default cap" / "configured cap overrides the default".
+func TestRecvFSBoundsBodySize(t *testing.T) {
+	postRecvFS := func(t *testing.T, h *SyncHandler, bodyLen int) int {
+		t.Helper()
+		r := setupSyncTestRouter()
+		r.POST("/seafhttp/repo/:repo_id/recv-fs", h.RecvFS)
+		body := strings.Repeat("a", bodyLen)
+		req := httptest.NewRequest(http.MethodPost, "/seafhttp/repo/repo/recv-fs", strings.NewReader(body))
+		req.ContentLength = int64(bodyLen)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	t.Run("nil config uses the default cap", func(t *testing.T) {
+		h := &SyncHandler{}
+		if got := h.syncRecvFSMaxBytes(); got != config.DefaultRecvFSMaxBytes {
+			t.Fatalf("cap = %d, want the %d default", got, config.DefaultRecvFSMaxBytes)
+		}
+		if code := postRecvFS(t, h, int(config.DefaultRecvFSMaxBytes)+1); code != http.StatusRequestEntityTooLarge {
+			t.Errorf("RecvFS body over the default cap = %d, want 413", code)
+		}
+	})
+
+	t.Run("configured cap overrides the default", func(t *testing.T) {
+		const configured = 64 * 1024
+		h := &SyncHandler{config: &config.Config{}}
+		h.config.SeafHTTP.RecvFSMaxBytes = configured
+
+		if got := h.syncRecvFSMaxBytes(); got != configured {
+			t.Fatalf("cap = %d, want the configured %d", got, configured)
+		}
+		if code := postRecvFS(t, h, configured+1); code != http.StatusRequestEntityTooLarge {
+			t.Errorf("RecvFS body over the configured cap = %d, want 413", code)
+		}
+	})
+}

--- a/internal/api/sync_body_limits_test.go
+++ b/internal/api/sync_body_limits_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -215,7 +216,7 @@ func parseCheckBlockIDsForTest(body string) ([]string, bool, int) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
-	ids, ok := parseCheckBlockIDs(c, []byte(body), config.DefaultCheckBlocksMaxIDs)
+	ids, ok := parseBoundedIDList(c, []byte(body), checkBlocksIDListSpec(config.DefaultCheckBlocksMaxIDs))
 	return ids, ok, w.Code
 }
 
@@ -303,6 +304,140 @@ func TestParseCheckBlockIDsRejectsBeforeMaterializing(t *testing.T) {
 			t.Logf("body=%d bytes, allocated %.1f MB", len(tc.body), float64(allocated)/(1024*1024))
 			if allocated > maxAllocBytes {
 				t.Fatalf("allocated %.1f MB parsing a rejected body, want < %d MB: the id cap is being applied after the list is materialized",
+					float64(allocated)/(1024*1024), maxAllocBytes/(1024*1024))
+			}
+		})
+	}
+}
+
+// TestIDListSpec413BodiesAreStable pins the client-visible 413 payloads across the
+// generalization of parseCheckBlockIDs into parseBoundedIDList. check-blocks' body
+// predates that refactor and must survive it byte for byte; the two fs routes name
+// fs ids because their 413 is new, and naming them "block ids" would be a lie a
+// future reader would have to debug.
+func TestIDListSpec413BodiesAreStable(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		spec      idListSpec
+		wantError string
+		wantField string
+	}{
+		{"check-blocks", checkBlocksIDListSpec(7), "too many block ids", "max_block_ids"},
+		{"pack-fs", packFSIDListSpec(), "too many fs ids", "max_fs_ids"},
+		{"check-fs", checkFSIDListSpec(), "too many fs ids", "max_fs_ids"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+			// One id past the cap on the cheap newline path.
+			body := strings.Repeat("a\n", tc.spec.maxIDs) + "a"
+			if _, ok := parseBoundedIDList(c, []byte(body), tc.spec); ok {
+				t.Fatal("oversized list accepted")
+			}
+			if w.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("code = %d, want 413", w.Code)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("413 body %q is not JSON: %v", w.Body.String(), err)
+			}
+			if got["error"] != tc.wantError {
+				t.Errorf("error = %v, want %q", got["error"], tc.wantError)
+			}
+			if _, ok := got[tc.wantField]; !ok {
+				t.Errorf("413 body = %v, want it to carry %q", got, tc.wantField)
+			}
+		})
+	}
+}
+
+// TestFSIDCapsCannotCutWellFormedBodies is the non-regression contract for the
+// pack-fs/check-fs id caps: they must be unreachable for any body the byte cap
+// already admits, so they can only ever fire on degenerate input.
+//
+// The densest well-formed body is the newline format — N ids of 40 hex chars with
+// N-1 separators, so 41N-1 bytes. If that N ever exceeds the id cap, the cap has
+// started cutting legitimate traffic (a very large library's fs-id list) rather
+// than only amplification, which is the one failure mode this defense must not
+// have. Asserted arithmetically rather than by sending 16 MiB.
+func TestFSIDCapsCannotCutWellFormedBodies(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		byteCap  int
+		idCap    int
+		jsonCost int
+	}{
+		{"pack-fs", maxPackFSBodyBytes, maxPackFSIDs, 43},
+		{"check-fs", maxCheckFSBodyBytes, maxCheckFSIDs, 43},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// 41N-1 <= byteCap  =>  N <= (byteCap+1)/41
+			densestNewline := (tc.byteCap + 1) / minFSIDWireBytes
+			if densestNewline > tc.idCap {
+				t.Fatalf("a well-formed newline body within the %d-byte cap carries up to %d ids, above the %d id cap: the cap would reject real traffic, not just amplification",
+					tc.byteCap, densestNewline, tc.idCap)
+			}
+			// JSON is strictly less dense (2 + 42N + (N-1) bytes), so it cannot
+			// bind either; asserted so a future format change is caught here.
+			densestJSON := (tc.byteCap - 1) / tc.jsonCost
+			if densestJSON > tc.idCap {
+				t.Fatalf("a well-formed JSON body within the %d-byte cap carries up to %d ids, above the %d id cap", tc.byteCap, densestJSON, tc.idCap)
+			}
+		})
+	}
+}
+
+// TestFSIDCountCapsCutAmplification is the regression for the gap the byte caps
+// alone left open on pack-fs and check-fs: a body *under* the byte cap that
+// explodes into ~17x its size in string headers (16 MiB of bare newlines ->
+// ~16.7M ids, ~268 MB). Both routes now share check-blocks' bounded parser, so
+// the list is refused during the parse instead of after it is materialized.
+//
+// Same allocation-canary caveats as TestParseCheckBlockIDsRejectsBeforeMaterializing:
+// TotalAlloc is process-global, so this must never be made parallel, and a failure
+// under a new Go version should be read as "re-measure the headroom" first.
+func TestFSIDCountCapsCutAmplification(t *testing.T) {
+	// A body at the byte cap made of bare newlines: ~1 byte per id, the worst
+	// case, and one TrimSpace cannot collapse because both ends are non-space.
+	degenerate := func(n int) string { return "a" + strings.Repeat("\n", n-2) + "a" }
+
+	for _, tc := range []struct {
+		name    string
+		route   string
+		handler func(*SyncHandler) gin.HandlerFunc
+		byteCap int
+	}{
+		{"pack-fs", "/seafhttp/repo/:repo_id/pack-fs", func(h *SyncHandler) gin.HandlerFunc { return h.PackFS }, maxPackFSBodyBytes},
+		{"check-fs", "/seafhttp/repo/:repo_id/check-fs", func(h *SyncHandler) gin.HandlerFunc { return h.CheckFS }, maxCheckFSBodyBytes},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := setupSyncTestRouter()
+			h := &SyncHandler{}
+			r.POST(tc.route, tc.handler(h))
+
+			body := degenerate(tc.byteCap)
+			req := httptest.NewRequest(http.MethodPost, strings.Replace(tc.route, ":repo_id", "repo", 1), strings.NewReader(body))
+			req.ContentLength = int64(len(body))
+			w := httptest.NewRecorder()
+
+			var m1, m2 runtime.MemStats
+			runtime.ReadMemStats(&m1)
+			r.ServeHTTP(w, req)
+			runtime.ReadMemStats(&m2)
+
+			if w.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("degenerate body under the byte cap = %d, want 413; body=%s", w.Code, w.Body.String())
+			}
+			// Same 96 MB threshold the check-blocks canary uses: comfortably above
+			// the unavoidable cost (the body plus its string conversion, ~16 MiB
+			// each) and far below the ~268 MB a materializing parse would spend.
+			const maxAllocBytes = 96 * 1024 * 1024
+			allocated := m2.TotalAlloc - m1.TotalAlloc
+			t.Logf("body=%d bytes, allocated %.1f MB", len(body), float64(allocated)/(1024*1024))
+			if allocated > maxAllocBytes {
+				t.Fatalf("allocated %.1f MB on a rejected body, want < %d MB: the id cap is being applied after the list is materialized",
 					float64(allocated)/(1024*1024), maxAllocBytes/(1024*1024))
 			}
 		})
@@ -452,33 +587,26 @@ func TestCheckFSBoundsBodySize(t *testing.T) {
 // RecvFS, the one handler of the four where the cap is configuration
 // (config.SeafHTTP.RecvFSMaxBytes) rather than a const, because unlike the
 // other three it carries a real batch payload with no measured client size to
-// anchor a fixed number on. Both the nil-config default and an explicit
-// configured cap are exercised, mirroring TestPutBlockBoundsBodySize's
-// "nil config uses the default cap" / "configured cap overrides the default".
+// anchor a fixed number on.
+//
+// The two properties are pinned separately and deliberately: the resolver returns
+// the default under a nil config, and the handler enforces whatever the resolver
+// returns. Driving a body over the 128 MiB *default* through HTTP would prove
+// nothing the small configured cap does not already prove, while costing ~404 MB
+// of allocation (~128 MiB for the body plus ~269 MB of io.ReadAll buffer growth) —
+// four times the 96 MB ceiling this same file treats as a failure condition in
+// TestParseCheckBlockIDsRejectsBeforeMaterializing.
 func TestRecvFSBoundsBodySize(t *testing.T) {
-	postRecvFS := func(t *testing.T, h *SyncHandler, bodyLen int) int {
-		t.Helper()
-		r := setupSyncTestRouter()
-		r.POST("/seafhttp/repo/:repo_id/recv-fs", h.RecvFS)
-		body := strings.Repeat("a", bodyLen)
-		req := httptest.NewRequest(http.MethodPost, "/seafhttp/repo/repo/recv-fs", strings.NewReader(body))
-		req.ContentLength = int64(bodyLen)
-		w := httptest.NewRecorder()
-		r.ServeHTTP(w, req)
-		return w.Code
-	}
-
-	t.Run("nil config uses the default cap", func(t *testing.T) {
+	t.Run("nil config resolves the default cap", func(t *testing.T) {
 		h := &SyncHandler{}
 		if got := h.syncRecvFSMaxBytes(); got != config.DefaultRecvFSMaxBytes {
 			t.Fatalf("cap = %d, want the %d default", got, config.DefaultRecvFSMaxBytes)
 		}
-		if code := postRecvFS(t, h, int(config.DefaultRecvFSMaxBytes)+1); code != http.StatusRequestEntityTooLarge {
-			t.Errorf("RecvFS body over the default cap = %d, want 413", code)
-		}
 	})
 
-	t.Run("configured cap overrides the default", func(t *testing.T) {
+	// A small configured cap keeps this cheap while exercising the same code: the
+	// point is that RecvFS reads through syncRecvFSMaxBytes(), not the byte count.
+	t.Run("the handler enforces the resolved cap", func(t *testing.T) {
 		const configured = 64 * 1024
 		h := &SyncHandler{config: &config.Config{}}
 		h.config.SeafHTTP.RecvFSMaxBytes = configured
@@ -486,8 +614,33 @@ func TestRecvFSBoundsBodySize(t *testing.T) {
 		if got := h.syncRecvFSMaxBytes(); got != configured {
 			t.Fatalf("cap = %d, want the configured %d", got, configured)
 		}
-		if code := postRecvFS(t, h, configured+1); code != http.StatusRequestEntityTooLarge {
+
+		postRecvFS := func(bodyLen int, declaredLen int64) int {
+			r := setupSyncTestRouter()
+			r.POST("/seafhttp/repo/:repo_id/recv-fs", h.RecvFS)
+			req := httptest.NewRequest(http.MethodPost, "/seafhttp/repo/repo/recv-fs", strings.NewReader(strings.Repeat("a", bodyLen)))
+			req.ContentLength = declaredLen
+			if declaredLen < 0 {
+				req.TransferEncoding = []string{"chunked"}
+			}
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			return w.Code
+		}
+
+		if code := postRecvFS(configured+1, int64(configured+1)); code != http.StatusRequestEntityTooLarge {
 			t.Errorf("RecvFS body over the configured cap = %d, want 413", code)
+		}
+		// A client that declares no length must still be cut — the shape an
+		// unbounded io.ReadAll could not bound, and the one a declared-length
+		// check alone would miss.
+		if code := postRecvFS(configured+1, -1); code != http.StatusRequestEntityTooLarge {
+			t.Errorf("chunked RecvFS body over the configured cap = %d, want 413", code)
+		}
+		// The same shape under the cap: proves the two cases above are the cap
+		// firing, not RecvFS rejecting these requests for some other reason.
+		if code := postRecvFS(configured, -1); code == http.StatusRequestEntityTooLarge {
+			t.Error("chunked RecvFS body exactly at the configured cap was rejected 413")
 		}
 	})
 }

--- a/internal/api/sync_body_limits_test.go
+++ b/internal/api/sync_body_limits_test.go
@@ -402,9 +402,23 @@ func TestFSIDCapsCannotCutWellFormedBodies(t *testing.T) {
 // ~16.7M ids, ~268 MB). Both routes now share check-blocks' bounded parser, so
 // the list is refused during the parse instead of after it is materialized.
 //
-// Same allocation-canary caveats as TestParseCheckBlockIDsRejectsBeforeMaterializing:
-// TotalAlloc is process-global, so this must never be made parallel, and a failure
-// under a new Go version should be read as "re-measure the headroom" first.
+// Two claims, deliberately measured separately, because they need different
+// windows and conflating them is how the first version of this test broke:
+//
+//   - the *handler* answers 413 on a body the byte cap already admits. Asserted
+//     through a real round trip, with no allocation measurement — the round trip's
+//     cost is dominated by readLimitedRequestBody's own 16 MiB read (~32 MiB
+//     cumulative as io.ReadAll doubles) plus the parser's string(body), none of
+//     which is what this test is about, and all of which varies enough by Go
+//     version and platform to make a shared threshold meaningless. Measured at
+//     50.6 MB on go1.26/windows and 113.9 MB on go1.25/linux for the same code.
+//   - the *parser* refuses without materializing the list. Asserted on
+//     parseBoundedIDList directly, which is the same window — and therefore the
+//     same 96 MB threshold — as TestParseCheckBlockIDsRejectsBeforeMaterializing.
+//
+// Same allocation-canary caveats as that test: TotalAlloc is process-global, so
+// this must never be made parallel, and a failure under a new Go version should be
+// read as "re-measure the headroom" before "the cap regressed".
 func TestFSIDCountCapsCutAmplification(t *testing.T) {
 	// A body at the byte cap made of bare newlines: ~1 byte per id, the worst
 	// case, and one TrimSpace cannot collapse because both ends are non-space.
@@ -414,12 +428,13 @@ func TestFSIDCountCapsCutAmplification(t *testing.T) {
 		name    string
 		route   string
 		handler func(*SyncHandler) gin.HandlerFunc
+		spec    idListSpec
 		byteCap int
 	}{
-		{"pack-fs", "/seafhttp/repo/:repo_id/pack-fs", func(h *SyncHandler) gin.HandlerFunc { return h.PackFS }, maxPackFSBodyBytes},
-		{"check-fs", "/seafhttp/repo/:repo_id/check-fs", func(h *SyncHandler) gin.HandlerFunc { return h.CheckFS }, maxCheckFSBodyBytes},
+		{"pack-fs", "/seafhttp/repo/:repo_id/pack-fs", func(h *SyncHandler) gin.HandlerFunc { return h.PackFS }, packFSIDListSpec(), maxPackFSBodyBytes},
+		{"check-fs", "/seafhttp/repo/:repo_id/check-fs", func(h *SyncHandler) gin.HandlerFunc { return h.CheckFS }, checkFSIDListSpec(), maxCheckFSBodyBytes},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name+" handler answers 413", func(t *testing.T) {
 			r := setupSyncTestRouter()
 			h := &SyncHandler{}
 			r.POST(tc.route, tc.handler(h))
@@ -428,23 +443,36 @@ func TestFSIDCountCapsCutAmplification(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, strings.Replace(tc.route, ":repo_id", "repo", 1), strings.NewReader(body))
 			req.ContentLength = int64(len(body))
 			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("degenerate body at the byte cap = %d, want 413; body=%s", w.Code, w.Body.String())
+			}
+		})
+
+		t.Run(tc.name+" parse does not materialize", func(t *testing.T) {
+			// Built outside the window on purpose: strings.Repeat plus the
+			// concatenation is ~32 MiB that has nothing to do with the parser.
+			body := []byte(degenerate(tc.byteCap))
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
 
 			var m1, m2 runtime.MemStats
 			runtime.ReadMemStats(&m1)
-			r.ServeHTTP(w, req)
+			_, ok := parseBoundedIDList(c, body, tc.spec)
 			runtime.ReadMemStats(&m2)
 
-			if w.Code != http.StatusRequestEntityTooLarge {
-				t.Fatalf("degenerate body under the byte cap = %d, want 413; body=%s", w.Code, w.Body.String())
+			if ok || w.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("ok=%v code=%d, want rejected 413", ok, w.Code)
 			}
-			// Same 96 MB threshold the check-blocks canary uses: comfortably above
-			// the unavoidable cost (the body plus its string conversion, ~16 MiB
-			// each) and far below the ~268 MB a materializing parse would spend.
+			// Generous headroom over the unavoidable cost (string(body), ~16 MiB)
+			// while still far below the ~268 MB a materializing parse would spend.
 			const maxAllocBytes = 96 * 1024 * 1024
 			allocated := m2.TotalAlloc - m1.TotalAlloc
 			t.Logf("body=%d bytes, allocated %.1f MB", len(body), float64(allocated)/(1024*1024))
 			if allocated > maxAllocBytes {
-				t.Fatalf("allocated %.1f MB on a rejected body, want < %d MB: the id cap is being applied after the list is materialized",
+				t.Fatalf("allocated %.1f MB parsing a rejected body, want < %d MB: the id cap is being applied after the list is materialized",
 					float64(allocated)/(1024*1024), maxAllocBytes/(1024*1024))
 			}
 		})

--- a/internal/api/v2/auth.go
+++ b/internal/api/v2/auth.go
@@ -175,12 +175,10 @@ func (h *AuthHandler) HandleOIDCCallback(c *gin.Context) {
 
 	// Set sesamefs_auth cookie so the browser can identify the user when
 	// serving org admin HTML pages (resolveOrgForPanel reads this cookie).
-	// httpOnly=false is required: the frontend JS reads this as a fallback.
 	// Cookie TTL matches session TTL so both expire at the same time.
 	seahubAuth := result.Email + "@" + result.SessionToken
-	isSecure := c.Request.TLS != nil
 	cookieMaxAge := int(h.config.Auth.OIDC.SessionTTL.Seconds())
-	c.SetCookie("sesamefs_auth", seahubAuth, cookieMaxAge, "/", "", isSecure, false)
+	h.setAuthCookie(c, seahubAuth, cookieMaxAge)
 
 	// Return the session token
 	c.JSON(http.StatusOK, gin.H{
@@ -336,11 +334,24 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 		return
 	}
 
-	// Clear the sesamefs_auth session cookie (match flags from login: path="/", httpOnly=false)
-	isSecure := c.Request.TLS != nil
-	c.SetCookie("sesamefs_auth", "", -1, "/", "", isSecure, false)
+	// Clear the sesamefs_auth session cookie (match flags from login).
+	h.setAuthCookie(c, "", -1)
 
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 	})
+}
+
+// setAuthCookie is the single writer for the sesamefs_auth session cookie in this
+// package, used by both HandleOIDCCallback (login) and Logout (clear). httpOnly is
+// always true: ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01 found no code in this
+// repository — including mobile-frontend — that reads this cookie's value from JS;
+// the desktop-client SSO flow gets its token via clientSSOStore polling, not by
+// reading this cookie as an older comment here used to claim. Secure is still
+// derived per-request from c.Request.TLS, matching every other writer of this
+// cookie (the separate ISSUE-AUTOLOGIN-COOKIE-INSECURE-01 covers the one site
+// that hardcodes it).
+func (h *AuthHandler) setAuthCookie(c *gin.Context, value string, maxAge int) {
+	isSecure := c.Request.TLS != nil
+	c.SetCookie("sesamefs_auth", value, maxAge, "/", "", isSecure, true)
 }

--- a/internal/api/v2/auth.go
+++ b/internal/api/v2/auth.go
@@ -342,15 +342,17 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 	})
 }
 
-// setAuthCookie is the single writer for the sesamefs_auth session cookie in this
-// package, used by both HandleOIDCCallback (login) and Logout (clear). httpOnly is
-// always true: ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01 found no code in this
-// repository — including mobile-frontend — that reads this cookie's value from JS;
-// the desktop-client SSO flow gets its token via clientSSOStore polling, not by
+// setAuthCookie is the shared writer for sesamefs_auth issuance and clearing in
+// this package, used by both HandleOIDCCallback (login) and Logout (clear) so the
+// flags cannot drift between the two.
+//
+// httpOnly is always true: ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01 found no code in
+// this repository — including mobile-frontend — that reads this cookie's value from
+// JS; the desktop-client SSO flow gets its token via clientSSOStore polling, not by
 // reading this cookie as an older comment here used to claim. Secure is still
-// derived per-request from c.Request.TLS, matching every other writer of this
-// cookie (the separate ISSUE-AUTOLOGIN-COOKIE-INSECURE-01 covers the one site
-// that hardcodes it).
+// derived per-request from c.Request.TLS; the one site that hardcodes it lives in
+// package api (handleAutoLogin) and is the separate, still-open
+// ISSUE-AUTOLOGIN-COOKIE-INSECURE-01.
 func (h *AuthHandler) setAuthCookie(c *gin.Context, value string, maxAge int) {
 	isSecure := c.Request.TLS != nil
 	c.SetCookie("sesamefs_auth", value, maxAge, "/", "", isSecure, true)

--- a/internal/api/v2/auth_test.go
+++ b/internal/api/v2/auth_test.go
@@ -2,10 +2,12 @@ package v2
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -361,6 +363,13 @@ func TestLogout(t *testing.T) {
 		if _, err := handler.sessions.ValidateSession(session.Token); !errors.Is(err, auth.ErrSessionNotFound) {
 			t.Fatalf("ValidateSession() error = %v, want %v", err, auth.ErrSessionNotFound)
 		}
+
+		// ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01: the clear on logout must not
+		// reopen the JS-readable window the fix closes on login.
+		setCookie := w.Header().Get("Set-Cookie")
+		if !strings.Contains(setCookie, "HttpOnly") {
+			t.Fatalf("Set-Cookie = %q, want it to contain HttpOnly", setCookie)
+		}
 	})
 
 	t.Run("rejects invalid token", func(t *testing.T) {
@@ -448,4 +457,65 @@ func TestNewAuthHandler(t *testing.T) {
 	if handler.sessions == nil {
 		t.Error("Session manager should be created")
 	}
+}
+
+// TestAuthHandlerSetAuthCookie pins ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01 at the
+// single writer HandleOIDCCallback (login) and Logout (clear) share, rather than
+// at a full HTTP round trip through HandleOIDCCallback — its success path requires
+// a real OIDC code exchange this test suite does not mock, so testing the helper
+// directly is what actually reaches the login-side write.
+func TestAuthHandlerSetAuthCookie(t *testing.T) {
+	t.Run("always sets HttpOnly", func(t *testing.T) {
+		h := &AuthHandler{}
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+		h.setAuthCookie(c, "user@example.com@sometoken", 3600)
+
+		setCookie := w.Header().Get("Set-Cookie")
+		if !strings.Contains(setCookie, "HttpOnly") {
+			t.Fatalf("Set-Cookie = %q, want it to contain HttpOnly", setCookie)
+		}
+		// gin URL-encodes the cookie value, so "@" becomes "%40" — the actual
+		// production value has the same shape (email@token).
+		if !strings.Contains(setCookie, "sesamefs_auth=user%40example.com%40sometoken") {
+			t.Fatalf("Set-Cookie = %q, want it to carry the given value", setCookie)
+		}
+	})
+
+	t.Run("derives Secure from the request's TLS state", func(t *testing.T) {
+		h := &AuthHandler{}
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+		c.Request.TLS = &tls.ConnectionState{}
+
+		h.setAuthCookie(c, "user@example.com@sometoken", 3600)
+
+		setCookie := w.Header().Get("Set-Cookie")
+		if !strings.Contains(setCookie, "Secure") {
+			t.Fatalf("Set-Cookie = %q, want Secure over a TLS request", setCookie)
+		}
+		if !strings.Contains(setCookie, "HttpOnly") {
+			t.Fatalf("Set-Cookie = %q, want it to still contain HttpOnly", setCookie)
+		}
+	})
+
+	t.Run("clearing uses maxAge=-1 and still sets HttpOnly", func(t *testing.T) {
+		h := &AuthHandler{}
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+		h.setAuthCookie(c, "", -1)
+
+		setCookie := w.Header().Get("Set-Cookie")
+		if !strings.Contains(setCookie, "HttpOnly") {
+			t.Fatalf("Set-Cookie = %q, want it to contain HttpOnly on clear too", setCookie)
+		}
+		if !strings.Contains(setCookie, "Max-Age=0") {
+			t.Fatalf("Set-Cookie = %q, want an expiring Max-Age=0 (net/http's encoding of maxAge=-1)", setCookie)
+		}
+	})
 }

--- a/internal/api/v2/auth_test.go
+++ b/internal/api/v2/auth_test.go
@@ -460,7 +460,7 @@ func TestNewAuthHandler(t *testing.T) {
 }
 
 // TestAuthHandlerSetAuthCookie pins ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01 at the
-// single writer HandleOIDCCallback (login) and Logout (clear) share, rather than
+// shared writer HandleOIDCCallback (login) and Logout (clear) use, rather than
 // at a full HTTP round trip through HandleOIDCCallback — its success path requires
 // a real OIDC code exchange this test suite does not mock, so testing the helper
 // directly is what actually reaches the login-side write.

--- a/internal/api/v2/files.go
+++ b/internal/api/v2/files.go
@@ -2846,25 +2846,13 @@ func (h *FileHandler) moveBatchFiles(c *gin.Context, srcPaths []string, srcRepoI
 		return
 	}
 
-	// For same-repo batch moves, move files sequentially
-	// In production, this should be done as a background job for large batches
-	var movedFiles []string
-	var failedFiles []map[string]string
-
-	for _, srcPath := range srcPaths {
-		fileName := path.Base(srcPath)
-		// Create a mock gin.Context for the single file move
-		// For now, return a simplified response
-		movedFiles = append(movedFiles, fileName)
-	}
-
-	// TODO: Implement actual batch move logic with FS tree updates
-	// For now, return success for same-repo moves
-	c.JSON(http.StatusOK, gin.H{
-		"success": true,
-		"moved":   len(movedFiles),
-		"failed":  len(failedFiles),
-	})
+	// Same-repo batch move via this legacy endpoint is not implemented: it used to
+	// report {"success":true,"moved":N} without touching the FS tree at all
+	// (ISSUE-BATCH-MOVE-FALSE-SUCCESS-01). Real batch moves go through
+	// seafileAPI.moveDirWithPolicy -> POST /api/v2.1/repos/sync-batch-move-item/
+	// (SyncBatchMove/AsyncBatchMove -> processSingleItem), which is
+	// integration-tested and correct.
+	c.JSON(http.StatusNotImplemented, gin.H{"error": "batch move via this legacy endpoint is not implemented; use POST /api/v2.1/repos/sync-batch-move-item/"})
 }
 
 // CopyFileRequest represents the request for copying a file

--- a/internal/api/v2/files_batch_test.go
+++ b/internal/api/v2/files_batch_test.go
@@ -432,7 +432,9 @@ func TestBatchMoveFiles_FilenameArray(t *testing.T) {
 				"dst_dir":  "/destination",
 				"filename": []string{"file1.txt", "file2.txt", "file3.txt"},
 			},
-			wantStatus: http.StatusOK, // Batch handler returns OK with summary
+			// Legacy same-repo batch move is unimplemented (ISSUE-BATCH-MOVE-FALSE-SUCCESS-01):
+			// it used to fabricate {"success":true} without touching the FS tree.
+			wantStatus: http.StatusNotImplemented,
 		},
 		{
 			name: "batch move with array - cross repo not implemented",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1935,12 +1935,18 @@ func (c *Config) applyEnvOverrides() {
 			c.SeafHTTP.ZipMaxBytes = i
 		}
 	}
+	// Reported rather than silently dropped, for the same reason as the sync
+	// block cap below: falling back to the default would leave an operator who
+	// deliberately raised the recv-fs cap running the lower one with no signal.
 	if v := os.Getenv("SEAFHTTP_RECV_FS_MAX_BYTES"); v != "" {
-		if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+		i, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			c.addEnvOverrideError("SEAFHTTP_RECV_FS_MAX_BYTES is invalid: %v", err)
+		} else {
 			c.SeafHTTP.RecvFSMaxBytes = i
 		}
 	}
-	// Unlike the neighbours above, a malformed value is reported rather than
+	// Unlike the zip neighbours above, a malformed value is reported rather than
 	// silently dropped: falling back to the default would leave an operator who
 	// deliberately raised the cap running the lower one with no signal.
 	if v := os.Getenv("SEAFHTTP_SYNC_BLOCK_MAX_BYTES"); v != "" {
@@ -3243,6 +3249,13 @@ func (c *Config) Validate() error {
 	if c.SeafHTTP.SyncBlockMaxBytes > MaxSyncBlockMaxBytes {
 		return fmt.Errorf("seafhttp.sync_block_max_bytes is %d, above the %d ceiling; the official client CDC maximum is 4 MiB and SesameFS's related server-side split is 8 MiB, so a larger value is likely derived from the unrelated web uploader ceiling",
 			c.SeafHTTP.SyncBlockMaxBytes, MaxSyncBlockMaxBytes)
+	}
+	// Same rule as sync_block_max_bytes, same reason: an unbounded recv-fs body is
+	// the defect this cap exists for. There is deliberately no ceiling to match —
+	// unlike the block cap, no measured client batch size makes a large value
+	// self-evidently a mistake, so raising it is an informed operator choice.
+	if c.SeafHTTP.RecvFSMaxBytes <= 0 {
+		return fmt.Errorf("seafhttp.recv_fs_max_bytes must be greater than zero (an unbounded recv-fs body is not a supported configuration)")
 	}
 	// The in-flight caps are what make sync_block_max_bytes an aggregate bound.
 	// Zero is accepted here — unlike the body cap — because disabling the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -596,6 +596,24 @@ type SeafHTTPConfig struct {
 	// route is the defect (F12), so there is no configuration that restores it.
 	SyncBlockMaxBytes int64 `yaml:"sync_block_max_bytes"`
 
+	// RecvFSMaxBytes bounds one POST /seafhttp/repo/:repo_id/recv-fs body: a
+	// batch of packed FS objects (40-byte id + 4-byte size + zlib-compressed
+	// JSON per entry) the desktop client uploads at the end of a commit.
+	// RecvFS buffers the whole body before parsing (ISSUE-SYNC-UNBOUNDED-BODIES-01
+	// / X9), so this is the per-request buffered-body bound.
+	//
+	// Unlike sync_block_max_bytes, there is no measured client batch size or
+	// protocol-documented ceiling to anchor this on: the RFC in
+	// docs/SEAFILE-SYNC-PROTOCOL-RFC.md does not specify one, and this route
+	// carries a genuinely variable-sized payload (a real object batch, not a
+	// small id list like check-fs/pack-fs). The default is therefore
+	// deliberately generous rather than measured, so an operator can raise it
+	// without a code change if a real large commit needs more headroom.
+	//
+	// Zero is rejected the same way as sync_block_max_bytes: an unbounded body
+	// on this route is the defect this field exists to close.
+	RecvFSMaxBytes int64 `yaml:"recv_fs_max_bytes"`
+
 	// SyncBlockMaxInflightPerNode caps concurrent block uploads that have been
 	// admitted past the gate on this process, and is therefore the term that
 	// turns SyncBlockMaxBytes into an actual memory bound:
@@ -786,6 +804,13 @@ type SeafHTTPConfig struct {
 const (
 	DefaultSyncBlockMaxBytes int64 = 16 * 1024 * 1024
 	MaxSyncBlockMaxBytes     int64 = 64 * 1024 * 1024
+
+	// RecvFS has no measured client batch size to anchor a default on (see the
+	// field doc on RecvFSMaxBytes), so this default is deliberately generous
+	// rather than tight, with no validation ceiling — an operator raising it is
+	// making an informed deployment choice, not restoring a mistake the way an
+	// oversized SyncBlockMaxBytes usually is.
+	DefaultRecvFSMaxBytes int64 = 128 * 1024 * 1024
 
 	// Download admission sizes are derived from the D6 measurements. Encrypted
 	// prefetch keeps the current and next block plus the encrypted source, so the
@@ -1510,6 +1535,7 @@ func DefaultConfig() *Config {
 			ZipMaxBytes:            10 * 1024 * 1024 * 1024,
 			ChunkedStagingMaxBytes: 0,
 			SyncBlockMaxBytes:      DefaultSyncBlockMaxBytes,
+			RecvFSMaxBytes:         DefaultRecvFSMaxBytes,
 
 			SyncBlockMaxInflightPerNode: DefaultSyncBlockMaxInflightPerNode,
 			SyncBlockMemoryBudgetBytes:  DefaultSyncBlockMemoryBudgetBytes,
@@ -1907,6 +1933,11 @@ func (c *Config) applyEnvOverrides() {
 	if v := os.Getenv("SEAFHTTP_ZIP_MAX_BYTES"); v != "" {
 		if i, err := strconv.ParseInt(v, 10, 64); err == nil {
 			c.SeafHTTP.ZipMaxBytes = i
+		}
+	}
+	if v := os.Getenv("SEAFHTTP_RECV_FS_MAX_BYTES"); v != "" {
+		if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+			c.SeafHTTP.RecvFSMaxBytes = i
 		}
 	}
 	// Unlike the neighbours above, a malformed value is reported rather than

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -40,6 +40,7 @@ func clearLoadEnvOverrides(t *testing.T) {
 		"WEB_UPLOADS_MAX_STAGED_BYTES_PER_SESSION_MB",
 		"SEAFHTTP_TOKEN_TTL", "SEAFHTTP_ZIP_MAX_ENTRIES",
 		"SEAFHTTP_ZIP_MAX_DEPTH", "SEAFHTTP_ZIP_MAX_BYTES",
+		"SEAFHTTP_RECV_FS_MAX_BYTES",
 		"SEAFHTTP_SYNC_BLOCK_MAX_BYTES", "SEAFHTTP_SYNC_BLOCK_MAX_INFLIGHT_PER_NODE",
 		"SEAFHTTP_SYNC_BLOCK_MAX_INFLIGHT_PER_USER", "SEAFHTTP_SYNC_BLOCK_ADMISSION_WAIT",
 		"SEAFHTTP_SYNC_BLOCK_MAX_WAITERS_PER_NODE", "SEAFHTTP_SYNC_BLOCK_MAX_WAITERS_PER_USER",
@@ -1071,6 +1072,94 @@ func TestEnvOverrideSyncBlockMaxBytes(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestEnvOverrideRecvFSMaxBytes mirrors TestEnvOverrideSyncBlockMaxBytes for the
+// recv-fs body cap. The two knobs differ in one respect only — recv-fs has no
+// validation ceiling, deliberately, because no measured client batch size makes a
+// large value self-evidently a mistake — so "above the ceiling" has no analogue
+// here. Everything else must behave identically: a malformed value is reported
+// rather than silently dropped back to the default, and zero is not "unlimited".
+func TestEnvOverrideRecvFSMaxBytes(t *testing.T) {
+	clearLoadEnvOverrides(t)
+
+	newCfg := func() *Config {
+		cfg := DefaultConfig()
+		cfg.Auth.DevMode = true
+		cfg.DownloadAdmission.Enabled = false
+		return cfg
+	}
+
+	t.Run("default is used when nothing overrides it", func(t *testing.T) {
+		cfg := newCfg()
+		cfg.applyEnvOverrides()
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("Validate() error = %v", err)
+		}
+		if cfg.SeafHTTP.RecvFSMaxBytes != DefaultRecvFSMaxBytes {
+			t.Fatalf("RecvFSMaxBytes = %d, want the %d default", cfg.SeafHTTP.RecvFSMaxBytes, DefaultRecvFSMaxBytes)
+		}
+	})
+
+	t.Run("valid value overrides the default", func(t *testing.T) {
+		cfg := newCfg()
+		t.Setenv("SEAFHTTP_RECV_FS_MAX_BYTES", "268435456")
+
+		cfg.applyEnvOverrides()
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("Validate() error = %v", err)
+		}
+		// Raising it well past the default must pass: there is no ceiling on this
+		// knob on purpose, and a test that only ever lowered it would not show that.
+		if cfg.SeafHTTP.RecvFSMaxBytes != 256*1024*1024 {
+			t.Fatalf("RecvFSMaxBytes = %d, want %d", cfg.SeafHTTP.RecvFSMaxBytes, 256*1024*1024)
+		}
+	})
+
+	t.Run("malformed value is reported, not dropped", func(t *testing.T) {
+		cfg := newCfg()
+		t.Setenv("SEAFHTTP_RECV_FS_MAX_BYTES", "128MiB")
+
+		cfg.applyEnvOverrides()
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("Validate() = nil; a malformed override must not fall back to the default silently")
+		}
+		if !strings.Contains(err.Error(), "SEAFHTTP_RECV_FS_MAX_BYTES") {
+			t.Fatalf("Validate() error = %v, want it to name SEAFHTTP_RECV_FS_MAX_BYTES", err)
+		}
+	})
+
+	// Zero is rejected rather than read as "unlimited": an unbounded recv-fs body
+	// is the defect the cap exists to close, so no configuration may restore it.
+	for _, tc := range []struct{ name, value string }{
+		{"zero", "0"},
+		{"negative", "-1"},
+	} {
+		t.Run("rejects "+tc.name, func(t *testing.T) {
+			cfg := newCfg()
+			t.Setenv("SEAFHTTP_RECV_FS_MAX_BYTES", tc.value)
+
+			cfg.applyEnvOverrides()
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("Validate() = nil for %s; the env lever must obey the same bounds as the YAML knob", tc.value)
+			}
+			if !strings.Contains(err.Error(), "seafhttp.recv_fs_max_bytes") {
+				t.Fatalf("Validate() error = %v, want it to name seafhttp.recv_fs_max_bytes", err)
+			}
+		})
+	}
+
+	// The YAML knob is the same field, so a config file that sets it to zero must
+	// fail for the same reason the env lever does.
+	t.Run("rejects zero from YAML", func(t *testing.T) {
+		cfg := newCfg()
+		cfg.SeafHTTP.RecvFSMaxBytes = 0
+		if err := cfg.Validate(); err == nil {
+			t.Fatal("Validate() = nil for recv_fs_max_bytes: 0, want it rejected")
+		}
+	})
 }
 
 // TestEnvOverrideUploadLinkWriteLimits pins the four operator levers for the


### PR DESCRIPTION
## Summary

Three independently-scoped, verified-against-code fixes for issues tracked in `docs/KNOWN_ISSUES.md` / `docs/OPEN-WORK-INDEX.md`. None touch GC, quotas, or the X1/X2 generation-fence work — each is its own commit and can be reviewed/reverted independently.

- **`fix(auth)`** — `sesamefs_auth` is a live, replayable session bearer (sync-client TTL up to 180 days) that all four writers set `httpOnly=false` on (`ISSUE-SESSION-COOKIE-NOT-HTTPONLY-01`, HIGH). A repo-wide search (including `mobile-frontend/`) found no code reading this cookie's value; the desktop-client SSO flow already gets its token via `clientSSOStore` polling, contradicting the stale "embedded WebView" comment that justified `httpOnly=false`. Confirmed with the project owner that no client outside this repository depends on it either. Centralized the write into one `setAuthCookie` helper per package (login + logout can no longer disagree on the flag) and made it directly testable without mocking an OIDC exchange.
- **`fix(sync)`** — `PutCommit`, `PackFS`, `RecvFS`, `CheckFS` in `internal/api/sync.go` still read the whole request body with an unbounded `io.ReadAll`, the same defect PR-10 fixed for `PutBlock`/`check-blocks` (`ISSUE-SYNC-UNBOUNDED-BODIES-01` / X9, MEDIUM — authenticated memory-pressure DoS). Wired all four through the existing `readLimitedRequestBody` helper with a cap sized to each payload's shape; `RecvFS` gets a **configuration** knob (`recv_fs_max_bytes` / `SEAFHTTP_RECV_FS_MAX_BYTES`, default 128 MiB) instead of a const, since it carries a real batch payload with no measured client size or protocol-documented ceiling to anchor a fixed number on.
- **`fix(files)`** — the legacy same-repo batch-move path (`FileHandler.moveBatchFiles`, reached via `POST /file/move` with >1 `src`) returned `{"success": true, "moved": N}` without ever touching the FS tree (`ISSUE-BATCH-MOVE-FALSE-SUCCESS-01`, MEDIUM). The UI never used this path (`SyncBatchMove`/`AsyncBatchMove` is real and integration-tested) but any API client hitting it got a fabricated success. Now returns 501, pointing at the real endpoint.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages pass, including new/updated tests:
  - `TestServerSetAuthCookie`, `TestAuthHandlerSetAuthCookie`, extended `TestLogout` (pins `HttpOnly` on both login and logout paths)
  - `TestPutCommitBoundsBodySize`, `TestPackFSBoundsBodySize`, `TestPackFSBoundsChunkedBody`, `TestCheckFSBoundsBodySize`, `TestRecvFSBoundsBodySize` (rejection boundary only — deliberately not pinning "positive path" body shapes that would depend on incidental parser behavior)
  - `TestBatchMoveFiles_FilenameArray` updated (same-repo case now expects 501)
- [x] All 7 shipped YAML configs re-validated for syntax after adding `recv_fs_max_bytes`
- [ ] Manual smoke test recommended before merge: real browser login in dev mode, confirm `Set-Cookie: sesamefs_auth=...; HttpOnly` and that the web session still works normally (not blocking — code path is covered by the direct helper tests above)

## Docs

`docs/KNOWN_ISSUES.md`, `docs/OPEN-WORK-INDEX.md`, and `docs/CHANGELOG.md` updated per-commit to close each issue with a calibrated "what was verified" note, per this repo's rule that live status lives only in `KNOWN_ISSUES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)