### PR TITLE
fix(gc): give sync publication a per-attempt identity and a real handshake (R25, R29)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -408,14 +408,73 @@ their evidence. All four are closed here; none of them reopened X2.
 
 ---
 
+## 2026-08-15 - R25 fixed structurally: the idempotent sync repair establishes the publication handshake
+
+`repairPublishedSyncCommitBlockDelta` previously built the block delta and went straight
+to `finalizeSyncCommitBlockDelta`, making it the one production path that wrote permanent
+`fs:` references without establishing this attempt's `pub:` rows. It now stages first with
+a fresh attempt ID, exactly like a first publish (`internal/api/sync.go`).
+
+- **Why it mattered.** R3 concluded that `RegisterFSObjectBlockReferences` needs no fence
+  check of its own because permanent references are written only inside
+  `PromotePublishAttemptReferences`, after a checked publication handshake. The promote
+  structure is real; the inference was false for this path, and it failed **silently** —
+  promote calls `registerPermanent()` and then deletes whatever attempt rows it finds,
+  never verifying that any exist (`internal/db/block_references.go — PromotePublishAttemptReferences`). Every publication safety
+  check X1 adds hangs off the handshake, so a path that skips it is a path those checks
+  cannot see.
+- **Repair failure semantics.** Both pre-CAS publication and post-publication repair use
+  `StagePublishAttemptReferences`. A fresh attempt ID means a partial rollback can remove
+  only the current call's rows; it cannot retract another publisher's liveness. A complete
+  stage followed by a lost process still leaves that attempt's `pub:` rows until TTL, which
+  is recorded as R30/R31 below. `TestPublishedSyncRepairPartialStageFailureDoesNotFinalize`
+  and the DB stage rollback tests pin this distinction.
+- **Reachability**, narrower than "any retry" and still ordinary: `finalizedBlockDeltas`
+  is a per-process two-generation memo with 4096 entries per generation (up to 8192
+  retained pairs), marked only after a successful finalize, so a warm same-instance retry
+  short-circuits. The repair is reached when the retry lands on another instance, when
+  the original finalize failed, after a restart, or after eviction.
+- **Cost.** One staged `pub:` reference per added block on a retry that already committed
+  to the full-tree reconciliation; today one statement each, since
+  `addPublishAttemptReferencesRows` loops rather than batching
+  (`block_references.go:460-473`). `TestRepairSkipsEverythingOnceThisProcessFinalized` pins
+  that the memo still absorbs the warm case, so this fix cannot quietly make every
+  idempotent retry pay for the walk.
+- **Evidence.** `TestRepairPublishedSyncCommitBlockDeltaEstablishesHandshakeBeforeFinalizing` was verified
+  **red** before the fix and is now **green**; reverting the helper to build-then-finalize
+  reproduces the original red result.
+- **Scope.** This closes **R25 structurally only**. R3's post-stage validation of the
+  canonical incarnation still does not exist on any path, so the publication TOCTOU is
+  open exactly as before: between `stage pub:` and `finalize`, GC can still claim
+  and authorize. **R25 fixed, R3 open, X1 open**, `GC_ENABLED=false` unchanged. A structural
+  fix is not evidence toward closing X1.
+- **R29 remains open as a separate ownership criterion.** Before this follow-up, sync used
+  the commit ID as the publication-attempt identity, so concurrent same-target requests
+  could retract each other's `pub:` rows. The implementation now gives each sync delta a
+  fresh attempt ID; that identity shape is unit-tested, while CAS/post-CAS retention and
+  concurrent Cassandra cleanup remain integration evidence.
+- **R30 is a per-attempt retention consequence.** A repair uses a fresh UUID and therefore
+  cannot retire the original crashed publisher's UUID ref; after successful `fs:` repair,
+  that old `pub:` row can remain a liveness pin until its 35-day TTL expires. A complete
+  repair stage followed by another crash/finalize failure can leave the same shape for the
+  repair UUID, and repeated failed repairs can extend aggregate retention. This is not data
+  loss, but it is not evidence that temporary publication state was fully retired.
+- **R31 is the publication-safety blocker.** A CAS that may have applied, or a successful
+  CAS whose block-reference finalize failed, can leave a visible HEAD protected only by a
+  TTL-bound `pub:` row. Sync has no durable background repair independent of a later client
+  request, so X1 cannot close until a durable reconciliation path exists.
+
+---
+
 ## 2026-08-14 - X1: r3 generational fence abandoned; closure options documented; prod `GC_ENABLED=false` pinned
 
-No production behaviour changed, and no X1 safety fix landed. `internal/api/sync.go`
+No X1 runtime safety protocol changed, and no X1 safety fix landed. `internal/api/sync.go`
 gained four test seams for the R25 executable reproduction — `stageSyncPublishAttempt-
 ReferencesFn`, `promoteSyncPublishAttemptReferencesFn`, `buildSyncCommitBlockDeltaFn`,
 `resolveSyncBlockIDsFn` — and the production targets of those seams are the existing
-functions, so the compiled call graph is equivalent. Documentation and deployment
-configuration also changed. X1 stays open, no design is accepted, and `GC_ENABLED=false`
+functions, so the compiled call graph is equivalent. Deployment safety configuration did
+change: `GC_ENABLED=false` was pinned in production configuration and Cassandra image
+settings were made explicit. X1 stays open, no design is accepted, and `GC_ENABLED=false`
 remains mandatory on every replica in every DC.
 
 **The r3 generational-fence ADR is abandoned.** PR #166 closed unmerged; the branch
@@ -492,32 +551,31 @@ new relative to the withdrawn document:
   `storage_class` and, because it never touches the projection, no `_by_day` row — a
   writer fence that recovery cannot enumerate. With the TTL removed as the TTL package
   proposes, it would never expire either.
-- **R25 — a promote path creates `fs:` without ever staging a checked `pub:`.** The
-  highest-severity item after R17, and the one that **invalidates a conclusion this
+- **R25 — a promote path created `fs:` without ever staging a checked `pub:`.** The
+  highest-severity item after R17, and the one that **invalidated a conclusion this
   document previously drew** rather than adding a requirement to it. R3 argued that
   `RegisterFSObjectBlockReferences` needs no check of its own because promotion only
   happens inside `PromotePublishAttemptReferences`, after a checked stage — "the gap is
-  one function, not two". The structure is real; the inference is not.
+  one function, not two". The structure was real; the inference was not.
   `PromotePublishAttemptReferences` never verifies a `pub:` row exists
-  (`block_references.go:519-544`), and sync has a fourth entry into finalize that skips
-  staging: an already-published HEAD goes `handleSyncHeadPromotion` →
-  `handleSyncHeadIdempotentSuccess` (`sync.go:4221-4224`) →
-  `repairPublishedSyncCommitBlockDelta`, which rebuilds the delta and calls
-  `finalizeSyncCommitBlockDelta` directly (`sync.go:4113`). Permanent references are
-  written with no handshake at any point. Reachability is narrower than "any retry" and
-  still ordinary: `finalizedBlockDeltas` is a per-process memo marked only after a
-  successful finalize, so a warm same-instance retry short-circuits, but a retry landing
-  on another instance, a retry after the original finalize failed — the case the repair
-  exists to heal — a process restart or an eviction all reach it. The other three promote
-  sites stage correctly. Fix shape: re-stage on repair, rather than making `fs:`
-  generation-aware. **Now executable:**
-  `TestRepairPublishedSyncCommitBlockDeltaStagesBeforeFinalizing`
-  (`internal/api/sync_publish_handshake_test.go`) drives the real helper and is red; the
-  candidate one-line fix turns it green, which is the mutation that makes the red mean
-  something. The companion tests pin the primitive's behaviour and the intended
-  `stage → finalize` shape — they are explicitly **not** control-flow coverage of the
-  normal and auto-merge branches, which need a DB session and belong to the integration
-  leg.
+  (`internal/db/block_references.go — PromotePublishAttemptReferences`), and before the R25 fix sync had a fourth entry into
+  finalize that skipped staging: an already-published HEAD went
+  `handleSyncHeadPromotion` → `handleSyncHeadIdempotentSuccess` →
+  `repairPublishedSyncCommitBlockDelta`, which rebuilt the delta and called
+  `finalizeSyncCommitBlockDelta` directly. Permanent references were written with no
+  handshake at that point. Reachability was narrower than "any retry" and still ordinary:
+  `finalizedBlockDeltas` was a per-process memo marked only after a successful finalize,
+  so a warm same-instance retry short-circuited, but a retry landing on another instance,
+  a retry after the original finalize failed, a process restart or an eviction reached it.
+  The other three promote sites already staged correctly. The fix establishes `pub:` on
+  repair with a fresh attempt ID, rather than making `fs:` generation-aware. **Now executable:**
+  `TestRepairPublishedSyncCommitBlockDeltaEstablishesHandshakeBeforeFinalizing` and
+  `TestPublishedSyncRepairPartialStageFailureDoesNotFinalize`
+  (`internal/api/sync_publish_handshake_test.go`) drive the real helper; the pre-fix
+  reproducer was verified red and the fixed path is green. The companion tests pin the
+  primitive's behaviour and the intended stage → finalize shape — they are
+  explicitly **not** control-flow coverage of the normal and auto-merge branches, which
+  need a DB session and belong to the integration leg.
 - **R26 — the discovery index needs binding in both directions.** R22 constrains how
   recovery *reads* `_by_day`; nothing constrained writes to it. `DeleteS3Orphan` deletes
   the projection by timestamp identity and resolves a zero `firstSeenAt` from whatever

--- a/docs/GC-X1-CLOSURE-OPTIONS.md
+++ b/docs/GC-X1-CLOSURE-OPTIONS.md
@@ -698,12 +698,13 @@ error/recovery signal rather than leaving a rejected publication live. The exist
 `RegisterFSObjectBlockReferences` never checks anything itself: it verifies the
 `fs_object` exists and resolves block ids (`fs_helpers.go:1037-1059`), then writes
 permanent `fs:` rows. It runs only inside `PromotePublishAttemptReferences` — all three
-promote sites (`seafhttp.go:3161`, `sync.go:4070`, `fs_helpers.go:1236`) sit inside a
+promote sites (`seafhttp.go:3161`, `sync.go — finalizeSyncCommitBlockDelta`, `fs_helpers.go:1236`) sit inside a
 stage/promote pair. **That structure is real, but the inference drawn from it is not:
 `PromotePublishAttemptReferences` never verifies that a `pub:` row exists**
-(`block_references.go:519-544` calls `registerPermanent()` and then deletes whatever
+(`internal/db/block_references.go — PromotePublishAttemptReferences` calls `registerPermanent()` and then deletes whatever
 `pub:` rows it finds), so "promote implies a checked stage" holds only for callers that
-actually staged. See **R25** — one production path does not.
+actually establish the handshake. See **R25**, which recorded the one production path that
+did not.
 
 Availability note: that post-check reads `blocks` at `LOCAL_QUORUM` while `K2` may have
 been installed by an LWT in another DC. It can miss it and retry. That costs latency, not
@@ -845,28 +846,37 @@ an active canonical incarnation preserve its key.
 | R22 | Recovery destroys bytes using data read from the discovery projection, without re-reading the canonical orphan row | The document says `_by_day` is "a discovery index and never a source of authorization", but the code does not honour that: `RecoverS3Orphans` takes its `S3OrphanInfo` straight from `ListS3OrphansByDay` and then uses those fields — `StorageClass` included — to resolve the backend and issue the delete (`worker.go:1376-1560`), never reloading `gc_s3_orphans`. So a stale or diverged projection row can select the wrong backend for a physical delete. **Required flow: `by_day` → load the canonical orphan → require an exact `P` match → only then destroy.** If the canonical row is missing, or `P_projection ≠ P_canonical`, the sweep may repair or drop the projection entry and must **never** issue a physical DELETE. |
 | R23 | `storage_class` is rebound to a different bucket, account or backend namespace | **`P` is only an eternal physical identity when its backend namespace identity is immutable.** `storage_class` is a logical label resolved through `m.backends[className]` (`internal/storage/storage.go:493`), and bucket/endpoint for a class come from configuration (`internal/config/config.go:3526,3532`). Rebind `hot-s3-na` from bucket A to bucket B and every persisted `P` silently renames the object it addresses — a months-old orphan would then issue an exact DELETE into a namespace it never verified. Define `B` as an immutable backend identity: a storage-class name may serve as `B` only when it is append-only and never rebound or reused for another namespace; otherwise persist an immutable `backend_id` and define `P = (backend_id, storage_key)`. Credentials and endpoints may change as long as they keep naming the same namespace. **Removing the orphan TTL makes this contract permanent rather than 90-day-bounded.** |
 | R24 | An ambiguous install outcome is reused or cleaned before its status is settled | **The same ABA as X1, produced by the writer's own cleanup instead of by GC.** R9 has the losing writer best-effort delete its key; R17 forbids a stale *repair* from installing. Neither covers a stale **install**: `W2` loses the CAS to `W1`, schedules cleanup of `P2`, and that DELETE is slow; later GC removes `P1` and `blocks(L)` goes absent; a lingering retry of `W2` re-runs `INSERT … IF NOT EXISTS` with `P2`, which now applies — and the old cleanup DELETE lands on live bytes. **Rule: a minted `P` is a single-use installation identity.** A failed install whose outcome is known lost makes `P` burned and cleanup-eligible; an ambiguous outcome makes `P` **install-uncertain**: it is non-retryable, cannot be reused for another install, and is not cleanup-authorized until serial settlement proves it is not canonical. Settlement proving applied moves `P` to canonical; settlement proving another locator won moves `P` to burned and permits exact-key cleanup. If settlement cannot be established, `P` stays install-uncertain and the safe result is a possible X3 leak, not deletion. |
-| R25 | A promote path creates permanent `fs:` references without ever having staged a checked `pub:` | **Highest-severity item after R17, and it breaks R3's argument as written.** R3 concludes that `fs:` inherits liveness from a `pub:` row that was itself post-checked, because promotion only happens inside `PromotePublishAttemptReferences`. The structure is real; the inference is not. `PromotePublishAttemptReferences` does **not** require a `pub:` row to exist (`block_references.go:519-544`): it calls `registerPermanent()` and then deletes whatever attempt rows it finds. And sync has a **fourth entry into finalize that skips staging**: `handleSyncHeadPromotion` answers an already-published HEAD with `handleSyncHeadIdempotentSuccess` (`sync.go:4221-4224`) → `repairPublishedSyncCommitBlockDelta`, which rebuilds the delta and calls `finalizeSyncCommitBlockDelta` **directly** (`sync.go:4113`), never `stageSyncCommitBlockDelta`. Finalize then promotes and registers `fs:` with no `pub:` handshake at any point, and `RegisterFSObjectBlockReferences` checks only that the `fs_object` exists. **Reachability, stated precisely rather than as "any retry":** `repairPublishedSyncCommitBlockDelta` first consults `finalizedBlockDeltas`, a per-process two-generation set of 4096 entries (`sync.go:141,158-194`) marked only *after* a finalize fully succeeds (`sync.go:4104`). A warm same-instance retry therefore short-circuits. The path runs when the retry lands on **another instance** — the memo is per process and production is multi-node — when **the original finalize failed**, which is the case the repair exists to heal and where the memo was never marked, after a process restart, or after eviction. Ordinary in production topology, not on a single warm node. The normal sync path, the auto-merge path (`sync.go:4156`), the SeafHTTP path (`seafhttp.go:3143,3161`) and the v2 path (`fs_helpers.go` stage/promote pair) all stage correctly. **Rule: every path that can promote permanent `fs:` references must first establish the same checked `pub:` handshake.** The small fix that matches this design is to re-stage on repair — rebuild, stage `pub:`, run R3's post-write check, then promote — rather than making `fs:` generation-aware. The alternative, requiring `PromotePublishAttemptReferences` to demand durable proof that this attempt's `pub:` rows were validated, adds state for the same property. |
+| R25 | A promote path creates permanent `fs:` references without ever having staged a checked `pub:` | **FIXED structurally** — the published-head repair now stages the `pub:` rows with a fresh attempt ID before finalizing, gated by `TestRepairPublishedSyncCommitBlockDeltaEstablishesHandshakeBeforeFinalizing` and `TestPublishedSyncRepairPartialStageFailureDoesNotFinalize`. Before this fix, `repairPublishedSyncCommitBlockDelta` rebuilt the delta and called `finalizeSyncCommitBlockDelta` directly, bypassing the handshake. The repair now uses the same `StagePublishAttemptReferences` operation as first publication; its rollback is scoped to the fresh repair ID, so a partial repair cannot retract another attempt's liveness. The *primitive* half remains unchanged: `PromotePublishAttemptReferences` does not require a staged row, so a future promote caller can reintroduce the bypass. **R25 was the highest-severity item after R17, and it broke R3's argument as written.** R3 itself remains open: the post-stage canonical-incarnation check does not exist yet. **Reachability, stated precisely rather than as "any retry":** `repairPublishedSyncCommitBlockDelta` first consults `finalizedBlockDeltas`, a per-process two-generation set with 4096 entries per generation (up to 8192 retained pairs) (`sync.go:138-194`), marked only *after* a finalize fully succeeds (`sync.go — finalizeSyncCommitBlockDelta`). A warm same-instance retry therefore short-circuits. The path runs when the retry lands on **another instance**, when **the original finalize failed**, after a process restart, or after eviction. The normal sync path, the auto-merge path, the SeafHTTP path and the v2 path already establish the handshake. **Rule: every known path that can promote permanent `fs:` references must execute Stage before Promote; preservation of the established handshake against concurrent cleanup remains R29/R3.** R3's eventual post-stage check must be added to Stage. |
 | R26 | A stale lifecycle's clear removes another lifecycle's discovery row | **Liveness, not data loss — but under a removed TTL it is permanent.** R22 makes recovery *read* the projection non-authoritatively; nothing yet constrains *writes* to it. `DeleteS3Orphan` clears the canonical row and then deletes the projection by timestamp identity — `first_seen_day`/`bucket`/`first_seen_at`/`org`/`block` (`store_cassandra.go:1783-1788`) — and when the caller passes a zero `firstSeenAt` it *resolves that timestamp from whatever canonical row is current* (`store_cassandra.go:1766-1772`), which may already belong to `P2`. Making only the canonical clear conditional on `P` (B.1) therefore leaves the projection half unbound: a delayed `P1` cleanup can still erase `P2`'s discoverability while `P2`'s canonical orphan correctly keeps fencing the writer. The result is a fence recovery cannot enumerate — R19's failure mode reached by a different route. **Rule: every repair or delete of `_by_day` is scoped to the expected `P`, or `P` becomes part of the projection's identity. Prefer the second.** A conditional `DELETE … IF P = P1` buys a Paxos round on a structure that is explicitly *liveness, never authorization* — the wrong place to spend consensus. Fold `P` into the discovery row's identity instead and the problem disappears by construction: a stale `P1` clear simply cannot name `P2`'s row. That is the same reasoning that makes A+ attractive in the first place — an identity that is never reused beats a check that has to be remembered. `_by_day` is never authorization, but stale lifecycle work must never remove another lifecycle's recovery discoverability. |
 | R27 | R18(a) says "re-project and retry", but the current projection cannot schedule a retry into the future | **R18(a) is the recommended resolution and is not yet implementable.** `gc_s3_orphans_by_day` is partitioned by `(first_seen_day, bucket)` and clustered on `first_seen_at`, and `upsertS3OrphanProjection` always derives the day from the *original* `firstSeenAt` (`store_cassandra.go:1561-1565`). Re-projecting a deferred orphan therefore rewrites it into the same past day the cursor already passed, and the next sweep starts only `gcScanOverlapDays = 2` days back (`store_cassandra.go:205`). "Re-project and retry until the attempt TTLs expire" has no mechanism behind it. **Separate the two facts the code currently conflates:** `first_seen_at` is an immutable lifecycle fact, and retry scheduling needs a mutable `next_retry_at`. **The separation only works if the partition key derives from the mutable fact.** Adding `next_retry_at` as another clustering column under an immutable `first_seen_day` partition does nothing: the row still lives physically in the August partition, and a scanner working September never reads it. What is required is a discovery structure partitioned on `(next_retry_day, bucket)` and clustered on `(next_retry_at, org_id, block_id, …P)`, or a separate durable retry queue queried by retry time — which is arguably cleaner, since it stops overloading a first-seen index with scheduling. Holding the cursor instead is correct but lets one row block a whole day/partition. Until this exists, A+'s availability bound under R18(a) is not merely long — it is **unbounded**, because nothing automatically returns the orphan to the working set after the `pub:` TTL expires. |
 | R28 | A partial orphan appears with no upsert-after-clear, purely from per-value TTL expiry | **R19's failure mode has a second cause, and it explains why the TTL package is indivisible.** Cassandra applies `default_time_to_live` per written value, and an `UPDATE` rewrites only the values it touches, with a fresh expiry. `UpdateS3OrphanAttempt` writes `last_attempt_at`/`retry_count`/`last_error` and leaves `storage_class`, `first_seen_at` and `recovery_phase` untouched. A retry on day 89 therefore pushes the diagnostic values to day 179 while the identity values still expire on day 90, and the `_by_day` projection — never rewritten — expires with them. Between those dates the row has a live primary key, no `storage_class`, no `first_seen_at` and no discovery entry. Both fence reads select only `block_id` (`block_references.go:851`, `1138`), which a partially expired row still returns, so the writer stays fenced while `GetBlockS3OrphanInfo` reads nulls. **Consequence for the wording elsewhere in this document: the 90-day TTL is not a ceiling on the row.** It bounds each value independently, and retries extend the diagnostic ones. **Consequence for R19:** partial orphan state arises both from an unconditional upsert after a clear *and* from per-value TTL skew, so making non-creating mutations conditional and removing the TTL are both required — neither alone closes it. |
+| R29 | A concurrent publisher can retract another publisher's `pub:` handshake | Sync previously used `targetCommitID` as the publication attempt ID, so concurrent requests for the same target shared `pub:<targetCommitID>`. A loser could delete the winner's row during CAS-conflict cleanup, and a partial `StagePublishAttemptReferences` rollback could do the same before CAS. The fix uses a fresh `publishAttemptID` per sync publication delta and retains refs for ambiguous CAS or post-CAS outcomes. **Required outcome:** cleanup may address only the current request's unique attempt; an uncertain CAS result retains its refs for retry, and a confirmed same-target winner enters idempotent repair. R25 remains structurally fixed, but preservation of an established handshake is an open X1/R3 criterion until this identity/outcome contract is evidenced in the integration leg. |
+| R30 | Superseded or abandoned publication attempts retain `pub:` rows until TTL | **Liveness/retention, not data loss.** After a publisher wins HEAD and crashes, a later repair creates `pub:<repair-uuid>` because the original attempt ID is not persisted. Promote removes the repair ref, but cannot identify the crashed publisher's `pub:<original-uuid>`. A complete repair stage followed by another crash/finalize failure leaves the same shape for the repair UUID; partial stages now roll back their own fresh ID. Each row is bounded by the 35-day TTL, but repeated failed repairs can create successive retained attempts and extend aggregate retention. **Required decision:** accept this per-attempt bounded retention as the cost of non-shared identity, or persist publication-attempt lineage so successful repair can retire superseded refs. This is separate from R29's safety fix and must not be described as X1 closure. |
+| R31 | A possibly successful published HEAD has no durable repair path after its `pub:` TTL expires | **Blocker for X1 safety closure.** A CAS timeout or a post-CAS block-reference failure can leave `HEAD = T` while only `pub:<attempt>` protects the blocks. Sync repair currently runs from a later idempotent client request; it is not a durable worker or queue. If no request arrives before the 35-day TTL, the temporary liveness can expire while `fs:` refs are still absent, allowing GC to see zero refs. **Required outcome:** settle the CAS serially and finalize when published, or persist a durable pending-publication/reconciliation record that a background worker can process independently of client retries. |
 
 R8, R13 and R15 decide whether Option B is viable. R16, R17, R19, R20, R22, R23, R24, R25,
-R26, R28, R3, R9, R10, R11 and R12 are common closure criteria — R16 and R20 become newly
+R26, R28, R29, R31, R3, R9, R10, R11 and R12 are common safety-closure criteria — R16 and R20 become newly
 load-bearing when claim IDs move from candidate identity to per-attempt UUIDs, and R17 is one
 of the direct same-physical-identity paths that reopens X1; R24 is the corresponding
-stale-install form. **R25 is the one that invalidates a conclusion this document previously
+stale-install form. **R25 was the one that invalidated a conclusion this document previously
 drew** rather than adding a new requirement to it: R3's "the gap is one function, not two"
-was wrong, because one production path promotes without ever staging.
+was wrong, because one production path promoted without ever staging. It is now fixed and
+gated; R3 itself remains open, and the structural fix is not evidence toward it.
 **R18 is A+-specific and is the one open question A+ does not inherit from X2 for free;
 R27 is what makes its recommended resolution implementable at all.**
 R21 gates B and any R18 resolution that treats the orphan as a durable authorization
 certificate, especially option (c). The conservative A+ option (a) does not depend on that
 inference.
 
-Note the shape of the last three: R26 and R28 both reach R19's failure mode — a fence no
+Note the shape of the last five: R26 and R28 both reach R19's failure mode — a fence no
 sweep can enumerate — by routes R19 does not cover (a stale clear of another lifecycle's
-discovery row, and per-value TTL expiry). Treat "partial or undiscoverable orphan" as the
-failure class, not `UpdateS3OrphanAttempt` as the single defect.
+discovery row, and per-value TTL expiry). R29 is separate but related: it can remove the
+publication fence before permanent `fs:` refs take over. R30 is a bounded
+availability/retention consequence of fixing R29 with fresh identity, not a safety-closure
+criterion. R31 is the safety failure where that temporary fence expires before durable
+`fs:` repair. Treat "partial or undiscoverable orphan", "retractable publication handshake",
+"superseded attempt retention" and "non-durable published repair" as failure classes, not
+single call-site defects.
 
 **The invariant these add up to.** `P` has a monotonic authority lifecycle, and no
 authority transition ever runs backwards. An install outcome can be uncertain without
@@ -1005,8 +1015,8 @@ A conceptual diff, not an implementation list.
 | `RecoverS3Orphans` discovery | Takes `S3OrphanInfo` — `StorageClass` included — straight from `ListS3OrphansByDay` and destroys on it, never reloading the canonical row | `by_day` → load canonical orphan → require exact `P` match → destroy. Mismatch or missing canonical row repairs/drops the index entry and never deletes (**R22**) |
 | `DeleteS3Orphan` | The fence clear GC actually runs: unconditional `DELETE` (`store_cassandra.go:1776`) from `processBlock` and all three recovery exits (`worker.go:1261, 1411, 1429, 1584`); its projection half deletes by timestamp identity and resolves a zero `firstSeenAt` from whatever canonical row is current | Condition the canonical clear on the expected `P`, so a delayed clear from `K1`'s lifecycle cannot lift a fence belonging to a later one (B.1) — **and bind the projection clear the same way** (**R26**), or the stale lifecycle still erases the newer one's discoverability |
 | `upsertS3OrphanProjection` | Always derives `first_seen_day` from the original `firstSeenAt` (`store_cassandra.go:1561-1565`), so a re-projection lands in the day the cursor already passed | Give retry scheduling its own mutable fact (`next_retry_at`), separate from the immutable `first_seen_at`; without it R18(a)'s "re-project and retry" has no mechanism (**R27**) |
-| `repairPublishedSyncCommitBlockDelta` | Rebuilds the delta and calls `finalizeSyncCommitBlockDelta` directly (`sync.go:4113`), promoting `fs:` without ever calling `stageSyncCommitBlockDelta` | Re-stage before promoting: rebuild → stage `pub:` → R3 post-check → promote. Every promote path must establish the checked handshake (**R25**) |
-| `PromotePublishAttemptReferences` | Calls `registerPermanent()` and deletes whatever attempt rows exist; never requires a `pub:` row to be present (`block_references.go:519-544`) | Either keep it dumb and fix the callers (preferred, see R25), or require durable proof that this attempt's `pub:` rows were validated |
+| `repairPublishedSyncCommitBlockDelta` | Before R25, rebuilt the delta and called `finalizeSyncCommitBlockDelta` directly, promoting `fs:` without establishing `pub:` | Rebuild → fresh-ID `StagePublishAttemptReferences` with rollback scoped to that repair → R3 post-check → promote (**R25**) |
+| `PromotePublishAttemptReferences` | Calls `registerPermanent()` and deletes whatever attempt rows exist; never requires a `pub:` row to be present (`internal/db/block_references.go — PromotePublishAttemptReferences`) | Either keep it dumb and fix the callers (preferred, see R25), or require durable proof that this attempt's `pub:` rows were validated |
 | `DeleteBlockS3Orphan` | A **second** unconditional orphan `DELETE` (`internal/db/block_references.go:1199`) with **no caller anywhere in the repo**, not even tests | Delete it. It is R21's destructive twin: an exported way to clear a fence that no protocol step authorizes, in a design about to make the orphan load-bearing |
 | `B` → backend | Today this is the logical `storage_class` resolved through `m.backends[className]` (`internal/storage/storage.go:493`); bucket and endpoint come from config (`internal/config/config.go:3526,3532`) | Define `B` as an immutable namespace identity. `storage_class` is acceptable only under R23's append-only/non-reuse contract; otherwise persist an immutable `backend_id` and define `P = (backend_id, storage_key)` |
 
@@ -1026,15 +1036,34 @@ decisions come first.
    like a fix and is not one. Settle the three linearization shapes with it — the
    pre-install fence check, the post-install success check, and the post-stage `pub:`
    check are different observations and the ADR must say so.
-0b. **R25 — every promote path must have staged a checked `pub:`.** Ranked with R17
-   because it is the other place where the design's argument, not just its
-   implementation, is currently untrue: `repairPublishedSyncCommitBlockDelta` promotes
-   permanent `fs:` references without staging, and `PromotePublishAttemptReferences`
-   does not require a `pub:` row to exist. Decide the fix shape — re-stage on repair
-   (small, matches this design) versus durable proof of validation carried into
-   promote (more state) — before R3 is treated as settled. **This is the one item on
-   the list that already has an executable gate**, so it can be closed by a PR rather
-   than by a decision: `TestRepairPublishedSyncCommitBlockDeltaStagesBeforeFinalizing`.
+0b. **R25 — every known promote path must first establish `pub:`. ✅ SETTLED
+   structurally by implementation.** It was the other place where the design's argument,
+   not just its implementation, was untrue. The fix shape chosen was **fresh-ID stage on
+   repair**: a published-head repair uses `StagePublishAttemptReferences`, and any partial
+   rollback is scoped to that repair's unique ID.
+   Gated by `TestRepairPublishedSyncCommitBlockDeltaEstablishesHandshakeBeforeFinalizing` and
+   `TestPublishedSyncRepairPartialStageFailureDoesNotFinalize`. **What remains open here
+   is deliberate:** `PromotePublishAttemptReferences` still registers without requiring a
+   staged row, so the invariant lives in the callers. If a future promote caller is added,
+   this is the item to re-read. The "checked" half remains R3 — see item 8.
+0c. **R29 — publication attempt identity and CAS outcome.** `targetCommitID` must not be
+   the referrer identity for concurrent requests. Each sync publication needs a fresh
+   attempt ID carried through Stage/Promote/cleanup. A confirmed CAS loser may clean
+   only its own attempt; a same-target winner must enter idempotent repair, and an ambiguous
+   CAS or post-CAS error must retain its refs and return retryable. The unit gate covers the
+   fresh-ID shape; an integration leg still needs to exercise the cleanup policy and two
+   concurrent publishers against Cassandra.
+0d. **R30 — superseded publication-attempt retention.** A repair UUID is intentionally
+   fresh, so it cannot identify and remove a crashed original publisher's UUID ref. The
+   original `pub:` row remains a conservative liveness pin until its 35-day TTL expires.
+   Decide whether that bounded retention is acceptable or whether publication-attempt
+   lineage must become durable; do not treat the repair's successful `fs:` promotion as
+   proof that the old temporary row was retired.
+0e. **R31 — durable repair after a possibly successful publication.** A CAS timeout or a
+   post-CAS finalize failure can leave a visible HEAD protected only by a TTL-bound `pub:`
+   row. The current sync repair runs only when a later client request reaches the
+   idempotent path. X1 cannot close until a durable queue/record or equivalent background
+   reconciliation can converge `pub:` to permanent `fs:` without relying on that retry.
 1. **A+ claim identity.** Replace the candidate-derived claim with a fresh UUID per
    worker attempt; carry `(P, claimID, claimed_at)` through claim, release, finalize,
    stale takeover and candidate cleanup.
@@ -1132,14 +1161,18 @@ All instruments live in `internal/api/sync_publish_handshake_test.go` unless not
 
 | Leg | Property | Status |
 |---|---|---|
-| **R25 reproduction** | The idempotent-repair entry point promotes permanent `fs:` without staging a `pub:` — `TestRepairPublishedSyncCommitBlockDeltaStagesBeforeFinalizing` drives the real helper | **RED** |
+| **R25 handshake** | The idempotent-repair entry point establishes `pub:` before promoting permanent `fs:` — `TestRepairPublishedSyncCommitBlockDeltaEstablishesHandshakeBeforeFinalizing` drives the real helper | **GREEN** since the R25 fix. **Mutation:** revert `repairPublishedSyncCommitBlockDelta` to build the delta and call `finalizeSyncCommitBlockDelta` directly ⇒ **RED**. `TestPublishedSyncRepairPartialStageFailureDoesNotFinalize` also keeps a failed repair stage from reaching promote. |
 | R25 primitive | `PromotePublishAttemptReferences` registers without requiring a staged row — `TestPromotePublishAttemptReferencesDoesNotRequireAStagedRow` | PASS — pins current behaviour; invert it if promote is made to demand proof |
-| Fix shape | A fix that always re-stages must not make every warm retry pay the full reconciliation — `TestRepairSkipsEverythingOnceThisProcessFinalized` | PASS |
+| Fix shape | A fix that always restages must not make every warm retry pay the full reconciliation — `TestRepairSkipsEverythingOnceThisProcessFinalized` | PASS |
 | Staged shape | `stage → finalize` satisfies the handshake and promotes exactly what it staged — `TestStagedPublicationShapeSatisfiesTheHandshake` | PASS |
+| R29 identity | Two sync publications of the same target receive distinct attempt IDs — `TestSyncPublicationAttemptsUseDistinctIDsForTheSameTarget` | PASS — structural gate; concurrent Cassandra cleanup still needs integration evidence |
+| R29 outcome | A same-target CAS loser and an ambiguous CAS/post-CAS result retain the correct publication liveness | not built — needs a controlled CAS/cleanup integration leg |
+| R30 retention | A successful fresh-UUID repair retires the original crashed publisher's `pub:` refs | not built — availability/retention follow-up; requires durable attempt lineage or an explicit accepted 35-day retention bound |
+| R31 durable repair | A possibly successful published HEAD converges to permanent `fs:` without a later client request | **BLOCKER / not built** — requires a durable reconciliation record or background repair independent of the 35-day TTL |
 | R3 safety | A block under an active delete fence must not gain a permanent `fs:` reference through the retry path | not built — needs a second instance for a cold memo, and cannot go green until R3's post-check exists on any path |
 | Physical ABA | An authorized DELETE landing after a byte-identical rematerialization destroys live bytes | not built — needs deterministic control of the S3 delete between authorization and landing |
 
-**What the unit gate does not cover.** It proves the idempotent-repair bypass directly and
+**What the unit gate does not cover.** It gates the idempotent-repair handshake directly and
 pins the intended `stage → finalize` invariant. It is **not** control-flow coverage of the
 normal and auto-merge production branches: the staged-shape test calls
 `stageSyncCommitBlockDelta` itself, so a refactor that dropped staging from
@@ -1147,9 +1180,15 @@ normal and auto-merge production branches: the staged-shape test calls
 branches run inside the HEAD CAS retry loop and need a DB session, which puts them in the
 integration leg. Do not cite the unit file as proof that every production path stages.
 
-**The mutation is what makes a red meaningful.** The reproduction was verified both ways:
-red as the code stands, green when `repairPublishedSyncCommitBlockDelta` is routed through
-`stageSyncCommitBlockDelta`, with the memoized fast path still passing.
+**What R25's closure does and does not mean.** It restores the structural handshake, so
+every known promote path now establishes `pub:` and R3's post-check — once written — can
+apply to all of them instead of being bypassed by one, subject to R29's ownership and
+outcome-preservation contract. It does **not** add that check. The
+publication TOCTOU is still open exactly as before: between `stage pub:` and `finalize`,
+GC can still claim and authorize. R31 adds the independent requirement that a visible HEAD
+must have durable repair beyond the temporary TTL. Read the status as **R25 fixed, R3/R31
+open, X1 open**, and
+do not let a structural fix be quoted as evidence toward closing X1.
 
 **Why the physical-ABA leg is last rather than first.** Its obligatory mutation — derived
 key instead of minted key must go red — presupposes that minting exists. Today keys are

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Sesame-Disk/sesamefs/internal/traffic"
 	"github.com/aws/smithy-go"
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
@@ -46,7 +47,22 @@ var ErrHeadConflict = fmt.Errorf("HEAD was modified concurrently")
 
 var errSyncHeadAutoMergeConflict = errors.New("sync head auto-merge conflict")
 var errSyncHeadRepairPending = errors.New("sync head publish pending background repair")
+var errSyncHeadCASUncertain = errors.New("sync head CAS outcome uncertain")
+var errSyncHeadPostCAS = errors.New("sync head post-CAS repair pending")
 var errSeafileBlockIDsUnavailable = errors.New("seafile sha1 block ids unavailable")
+
+type syncHeadConflictError struct {
+	expectedHead string
+	currentHead  string
+}
+
+func (e *syncHeadConflictError) Error() string {
+	return fmt.Sprintf("%s: expected %s but found %s", ErrHeadConflict, e.expectedHead, e.currentHead)
+}
+
+func (e *syncHeadConflictError) Unwrap() error {
+	return ErrHeadConflict
+}
 
 // SyncTokenCreator interface for creating sync tokens
 type SyncTokenCreator interface {
@@ -421,10 +437,13 @@ var syncNewCanonicalBlockCheckReaderFn = streaming.NewCanonicalBlockCheckReaderW
 // The publication handshake seams. SeafHTTP already routes its stage/promote
 // pair through equivalent vars (stageSeafHTTPPublishAttemptReferencesFn,
 // promoteSeafHTTPPublishAttemptReferencesFn); sync did not, which is why no test
-// could observe that one of its entry points promotes without staging (R25 in
-// docs/GC-X1-CLOSURE-OPTIONS.md). Production wiring is unchanged.
+// could observe that one of its entry points promotes without establishing the
+// handshake (R25 in docs/GC-X1-CLOSURE-OPTIONS.md). The normal stage/promote
+// targets remain unchanged; published-head repair uses the same stage seam with
+// its own attempt ID.
 var stageSyncPublishAttemptReferencesFn = db.StagePublishAttemptReferences
 var promoteSyncPublishAttemptReferencesFn = db.PromotePublishAttemptReferences
+var newSyncPublishAttemptIDFn = uuid.NewString
 
 // buildSyncCommitBlockDeltaFn lets a test supply the delta without a DB session,
 // so the handshake property can be asserted over the real control flow of each
@@ -444,6 +463,7 @@ var resolveSyncBlockIDsFn = func(h *SyncHandler, orgID, repoID string, blockIDs 
 var syncGetBlockIDMappingFn = func(ctx context.Context, database *db.DB, orgID, representationID, externalID string) (string, bool, error) {
 	return database.GetBlockIDMappingContext(ctx, orgID, representationID, externalID)
 }
+
 // syncTouchBlockLastAccessFn runs inside the D5 admission slot, so it takes the
 // caller's context: without it a Cassandra stall would hold the slot for the
 // gocql driver timeout rather than the configured preparation deadline. The
@@ -3425,15 +3445,15 @@ func (h *SyncHandler) updateLibraryHeadWithStats(orgID, repoID, commitID, userID
 		IF head_commit_id = ?
 	`, commitID, now, totalSize, fileCount, orgID, repoID, expectedHead).MapScanCAS(casState)
 	if err != nil {
-		return fmt.Errorf("conditional head update failed: %w", err)
+		return fmt.Errorf("%w: conditional head update failed: %w", errSyncHeadCASUncertain, err)
 	}
 	if !applied {
 		currentHead, _ := casState["head_commit_id"].(string)
-		return fmt.Errorf("%w: expected %s but found %s", ErrHeadConflict, expectedHead, currentHead)
+		return &syncHeadConflictError{expectedHead: expectedHead, currentHead: currentHead}
 	}
 
 	if err := h.applySyncHeadPostCASMutations(orgID, repoID, userID, commitID, now, totalSize, fileCount, totalSize-previousSize, fileCount-previousFileCount); err != nil {
-		return err
+		return fmt.Errorf("%w: %w", errSyncHeadPostCAS, err)
 	}
 
 	log.Printf("[updateLibraryStats] Updated library %s: size=%d bytes, files=%d", repoID, totalSize, fileCount)
@@ -3821,6 +3841,7 @@ type syncCommitBlockDelta struct {
 	addedFiles            []syncCommitFileReference
 	removedFiles          []syncCommitFileReference
 	resolvedAddedBlockIDs []string
+	publishAttemptID      string // fresh pub: identity; never the target commit ID
 }
 
 func (d syncCommitBlockDelta) addedBlockIDs() []string {
@@ -4059,7 +4080,11 @@ func (h *SyncHandler) stageSyncCommitBlockDelta(orgID, repoID, targetCommitID st
 	if err != nil {
 		return syncCommitBlockDelta{}, err
 	}
-	resolved, err := stageSyncPublishAttemptReferencesFn(h.db, orgID, repoID, targetCommitID, delta.addedBlockIDs(), func(blockIDs []string) ([]string, error) {
+	delta.publishAttemptID = strings.TrimSpace(newSyncPublishAttemptIDFn())
+	if delta.publishAttemptID == "" {
+		return syncCommitBlockDelta{}, fmt.Errorf("create publish attempt ID for sync commit %s: empty ID", targetCommitID)
+	}
+	resolved, err := stageSyncPublishAttemptReferencesFn(h.db, orgID, repoID, delta.publishAttemptID, delta.addedBlockIDs(), func(blockIDs []string) ([]string, error) {
 		return resolveSyncBlockIDsFn(h, orgID, repoID, blockIDs)
 	})
 	if err != nil {
@@ -4077,6 +4102,9 @@ func (h *SyncHandler) removeSyncCommitFileReferences(orgID, repoID string, remov
 }
 
 func (h *SyncHandler) finalizeSyncCommitBlockDelta(orgID, repoID, targetCommitID string, delta syncCommitBlockDelta) error {
+	if strings.TrimSpace(delta.publishAttemptID) == "" {
+		return fmt.Errorf("finalize sync commit %s: missing publication attempt ID", targetCommitID)
+	}
 	if len(delta.resolvedAddedBlockIDs) == 0 && len(delta.addedFiles) > 0 {
 		resolved, err := resolveSyncBlockIDsFn(h, orgID, repoID, delta.addedBlockIDs())
 		if err != nil {
@@ -4086,7 +4114,7 @@ func (h *SyncHandler) finalizeSyncCommitBlockDelta(orgID, repoID, targetCommitID
 	}
 
 	fsHelper := v2.NewFSHelper(h.db)
-	if err := promoteSyncPublishAttemptReferencesFn(h.db, orgID, targetCommitID, delta.resolvedAddedBlockIDs, func() error {
+	if err := promoteSyncPublishAttemptReferencesFn(h.db, orgID, delta.publishAttemptID, delta.resolvedAddedBlockIDs, func() error {
 		for _, file := range delta.addedFiles {
 			if err := fsHelper.RegisterFSObjectBlockReferences(orgID, repoID, file.fsID, file.blockIDs); err != nil {
 				return err
@@ -4112,6 +4140,30 @@ func (h *SyncHandler) finalizeSyncCommitBlockDelta(orgID, repoID, targetCommitID
 // part, so skipping it spares every idempotent retry once finalize has succeeded
 // here. A miss (cold process, another instance, evicted entry) safely falls back
 // to the full reconciliation, which is idempotent.
+//
+// It STAGES pub: references before it finalizes, exactly like a first publish,
+// using a fresh attempt ID so a partial rollback can only remove this repair's
+// own rows. This used to build the delta and go straight to finalize, which made
+// it the one production path that wrote permanent fs: references without ever
+// holding this attempt's pub: rows — and PromotePublishAttemptReferences does not
+// require them to exist, so it failed silently rather than erroring. Every
+// publication safety check the X1 work adds (R3's post-write validation of the
+// canonical incarnation) hangs off this handshake, so a path that skips it is a
+// path those checks cannot see.
+// Filed as R25 in docs/GC-X1-CLOSURE-OPTIONS.md.
+//
+// This closes R25 only. It does not add the publication fence check itself —
+// R3's post-stage validation of the canonical incarnation does not exist on any
+// path yet. What it buys is that the check, once written, applies here too
+// instead of being bypassed. R3 and X1 stay open.
+//
+// The extra cost is one staged pub: reference per added block, on a retry that
+// already committed to the full-tree reconciliation. Today that is one statement
+// each: addPublishAttemptReferencesRows writes them in a loop rather than a
+// batch (internal/db/block_references.go:460-473). Stated as an implementation
+// cost on purpose — if that loop ever becomes a batch, this comment is what
+// stops the figure being quoted as a protocol-level per-block round trip. The
+// memo above still absorbs the common warm case before either step runs.
 func (h *SyncHandler) repairPublishedSyncCommitBlockDelta(orgID, repoID, targetCommitID string) error {
 	if h == nil {
 		return nil
@@ -4125,7 +4177,7 @@ func (h *SyncHandler) repairPublishedSyncCommitBlockDelta(orgID, repoID, targetC
 	if h.db == nil {
 		return nil
 	}
-	delta, err := buildSyncCommitBlockDeltaFn(h, repoID, targetCommitID)
+	delta, err := h.stageSyncCommitBlockDelta(orgID, repoID, targetCommitID)
 	if err != nil {
 		return err
 	}
@@ -4181,20 +4233,31 @@ func (h *SyncHandler) tryAutoMergeSyncHeadPromotion(c *gin.Context, orgID, userI
 		if !cleanupStaged {
 			return
 		}
-		if cleanupErr := db.RemovePublishAttemptReferences(h.db, orgID, mergedCommitID, delta.resolvedAddedBlockIDs); cleanupErr != nil {
+		if cleanupErr := db.RemovePublishAttemptReferences(h.db, orgID, delta.publishAttemptID, delta.resolvedAddedBlockIDs); cleanupErr != nil {
 			log.Printf("%s: failed to cleanup staged refs for auto-merged commit %s in repo %s: %v", operation, mergedCommitID, repoID, cleanupErr)
 		}
 	}()
 
 	if err := h.updateLibraryHeadWithStats(orgID, repoID, mergedCommitID, userID, currentHead); err != nil {
-		if errors.Is(err, errSyncHeadRepairPending) {
+		if errors.Is(err, errSyncHeadRepairPending) || errors.Is(err, errSyncHeadPostCAS) {
 			cleanupStaged = false
 			if finalizeErr := h.finalizeSyncCommitBlockDelta(orgID, repoID, mergedCommitID, delta); finalizeErr != nil {
 				return false, fmt.Errorf("finalize auto-merged sync commit %s after publish: %w", mergedCommitID, finalizeErr)
 			}
 			go h.updateFullPaths(repoID, mergedRootFSID)
 			c.Header("Retry-After", "1")
-			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "sync head publish pending storage reconciliation; retry"})
+			if errors.Is(err, errSyncHeadRepairPending) {
+				c.JSON(http.StatusServiceUnavailable, gin.H{"error": "sync head publish pending storage reconciliation; retry"})
+			} else {
+				c.JSON(http.StatusServiceUnavailable, gin.H{"error": "sync head publish derived state repair pending; retry"})
+			}
+			return true, nil
+		}
+		if errors.Is(err, errSyncHeadCASUncertain) {
+			cleanupStaged = false
+			log.Printf("%s: auto-merge CAS outcome is uncertain for repo %s targeting %s; retaining publication refs for retry: %v", operation, repoID, mergedCommitID, err)
+			c.Header("Retry-After", "1")
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "sync head publish outcome uncertain; retry"})
 			return true, nil
 		}
 		return false, err
@@ -4308,14 +4371,14 @@ func (h *SyncHandler) handleSyncHeadPromotion(c *gin.Context, orgID, userID, rep
 			if !cleanupStaged {
 				return
 			}
-			if cleanupErr := db.RemovePublishAttemptReferences(h.db, orgID, targetHead, delta.resolvedAddedBlockIDs); cleanupErr != nil {
+			if cleanupErr := db.RemovePublishAttemptReferences(h.db, orgID, delta.publishAttemptID, delta.resolvedAddedBlockIDs); cleanupErr != nil {
 				log.Printf("%s: failed to cleanup staged refs for repo %s head %s: %v", operation, repoID, targetHead, cleanupErr)
 			}
 		}
 
 		if err := h.updateLibraryHeadWithStats(orgID, repoID, targetHead, userID, currentHead); err != nil {
 			if !errors.Is(err, ErrHeadConflict) {
-				if errors.Is(err, errSyncHeadRepairPending) {
+				if errors.Is(err, errSyncHeadRepairPending) || errors.Is(err, errSyncHeadPostCAS) {
 					cleanupStaged = false
 					if finalizeErr := h.finalizeSyncCommitBlockDelta(orgID, repoID, targetHead, delta); finalizeErr != nil {
 						log.Printf("%s: published repo %s head to %s but block-reference reconciliation failed: %v", operation, repoID, targetHead, finalizeErr)
@@ -4326,12 +4389,27 @@ func (h *SyncHandler) handleSyncHeadPromotion(c *gin.Context, orgID, userID, rep
 						c.JSON(http.StatusServiceUnavailable, gin.H{"error": "sync head publish block-reference reconciliation pending; retry"})
 						return
 					}
-					log.Printf("%s: published repo %s head to %s but aggregate storage reconciliation is still pending: %v", operation, repoID, targetHead, err)
+					if errors.Is(err, errSyncHeadRepairPending) {
+						log.Printf("%s: published repo %s head to %s but aggregate storage reconciliation is still pending: %v", operation, repoID, targetHead, err)
+					} else {
+						log.Printf("%s: published repo %s head to %s but derived-state reconciliation is still pending: %v", operation, repoID, targetHead, err)
+					}
 					if rootFSID != "" {
 						go h.updateFullPaths(repoID, rootFSID)
 					}
 					c.Header("Retry-After", "1")
-					c.JSON(http.StatusServiceUnavailable, gin.H{"error": "sync head publish pending storage reconciliation; retry"})
+					if errors.Is(err, errSyncHeadRepairPending) {
+						c.JSON(http.StatusServiceUnavailable, gin.H{"error": "sync head publish pending storage reconciliation; retry"})
+					} else {
+						c.JSON(http.StatusServiceUnavailable, gin.H{"error": "sync head publish derived state repair pending; retry"})
+					}
+					return
+				}
+				if errors.Is(err, errSyncHeadCASUncertain) {
+					cleanupStaged = false
+					log.Printf("%s: CAS outcome is uncertain for repo %s targeting %s; retaining publication refs for retry: %v", operation, repoID, targetHead, err)
+					c.Header("Retry-After", "1")
+					c.JSON(http.StatusServiceUnavailable, gin.H{"error": "sync head publish outcome uncertain; retry"})
 					return
 				}
 				cleanupAttempt()
@@ -4340,6 +4418,14 @@ func (h *SyncHandler) handleSyncHeadPromotion(c *gin.Context, orgID, userID, rep
 				return
 			}
 
+			var conflictErr *syncHeadConflictError
+			if errors.As(err, &conflictErr) && conflictErr.currentHead == targetHead {
+				// This request lost to another publisher of the same target. Its
+				// publication attempt ID is unique, so cleanup cannot touch the winner.
+				cleanupAttempt()
+				h.handleSyncHeadIdempotentSuccess(c, orgID, repoID, targetHead, operation)
+				return
+			}
 			cleanupAttempt()
 			log.Printf("%s: CAS conflict for repo %s on attempt %d/%d", operation, repoID, attempt+1, maxAttempts)
 			if attempt == maxAttempts-1 {

--- a/internal/api/sync_publish_handshake_test.go
+++ b/internal/api/sync_publish_handshake_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/Sesame-Disk/sesamefs/internal/db"
@@ -14,16 +15,16 @@ import (
 // pub: rows and (once R3 lands) had them post-checked against the canonical
 // incarnation. Every future publication safety check hangs off that handshake.
 //
-// The structure is real but the inference is not: PromotePublishAttemptReferences
-// never verifies that a pub: row exists, and sync's idempotent-retry path reaches
-// finalize without ever staging one. A check added to staging is therefore
-// unreachable from that path, which is what makes this a design defect rather
-// than a missing validation.
+// The historical defect was that PromotePublishAttemptReferences never verifies
+// that a pub: row exists, while sync's idempotent-retry path reached finalize
+// without staging one. A check added to staging was therefore unreachable from
+// that path. The production fix now establishes pub: first; this test keeps the
+// handshake and its ordering executable.
 //
 // WHAT THESE TESTS DO AND DO NOT PROVE
 // -------------------------------------
-// TestRepairPublishedSyncCommitBlockDeltaStagesBeforeFinalizing drives the real
-// entry point and is the reproduction of R25. It is RED today.
+// TestRepairPublishedSyncCommitBlockDeltaEstablishesHandshakeBeforeFinalizing drives the real
+// entry point and is the executable R25 gate. It must stay green after the fix.
 //
 // TestStagedPublicationShapeSatisfiesTheHandshake pins the intended stage→finalize
 // shape. It is NOT control-flow coverage of the normal and auto-merge production
@@ -38,8 +39,8 @@ import (
 // The safety consequence — a fenced block must not gain a permanent reference —
 // belongs to the integration leg, which cannot go green until R3's post-check
 // exists on any path at all, so it gates X1 closure rather than one PR. The
-// handshake gates the R25 fix on its own: it goes green as soon as the repair
-// path re-stages, with no protocol decision required.
+// handshake gates the R25 fix on its own: it is green as soon as the repair
+// path re-establishes pub:, with no protocol decision required.
 
 const (
 	handshakeOrgID    = "00000000-0000-0000-0000-000000000001"
@@ -55,6 +56,12 @@ const (
 type handshakeRecord struct {
 	staged   map[string][]string
 	promoted map[string][]string
+	events   []handshakeEvent
+}
+
+type handshakeEvent struct {
+	attemptID string
+	phase     string
 }
 
 // installHandshakeSeams swaps in recording seams for the publication primitives
@@ -68,37 +75,44 @@ func installHandshakeSeams(t *testing.T) *handshakeRecord {
 
 	origStage := stageSyncPublishAttemptReferencesFn
 	origPromote := promoteSyncPublishAttemptReferencesFn
+	origAttemptID := newSyncPublishAttemptIDFn
 	origBuild := buildSyncCommitBlockDeltaFn
 	origResolve := resolveSyncBlockIDsFn
 	t.Cleanup(func() {
 		stageSyncPublishAttemptReferencesFn = origStage
 		promoteSyncPublishAttemptReferencesFn = origPromote
+		newSyncPublishAttemptIDFn = origAttemptID
 		buildSyncCommitBlockDeltaFn = origBuild
 		resolveSyncBlockIDsFn = origResolve
 	})
 
-	stageSyncPublishAttemptReferencesFn = func(_ *db.DB, _, _, attemptID string, blockIDs []string, resolve db.BlockIDResolver) ([]string, error) {
-		resolved := blockIDs
-		if resolve != nil {
-			var err error
-			if resolved, err = resolve(blockIDs); err != nil {
-				return nil, err
+	recordPublishAttempt := func(phase string) func(*db.DB, string, string, string, []string, db.BlockIDResolver) ([]string, error) {
+		return func(_ *db.DB, _, _, attemptID string, blockIDs []string, resolve db.BlockIDResolver) ([]string, error) {
+			resolved := blockIDs
+			if resolve != nil {
+				var err error
+				if resolved, err = resolve(blockIDs); err != nil {
+					return nil, err
+				}
 			}
+			rec.staged[attemptID] = append(rec.staged[attemptID], resolved...)
+			rec.events = append(rec.events, handshakeEvent{attemptID: attemptID, phase: phase})
+			return resolved, nil
 		}
-		rec.staged[attemptID] = append(rec.staged[attemptID], resolved...)
-		return resolved, nil
 	}
+	stageSyncPublishAttemptReferencesFn = recordPublishAttempt("stage")
 	promoteSyncPublishAttemptReferencesFn = func(_ *db.DB, _, attemptID string, blockIDs []string, registerPermanent func() error) error {
 		// Deliberately NOT calling registerPermanent: this leg is about the
 		// handshake, and invoking it would drag in a real FSHelper. Note that the
 		// production implementation calls it without checking that any pub: row
 		// for attemptID exists — which is half of the defect.
+		rec.events = append(rec.events, handshakeEvent{attemptID: attemptID, phase: "promote"})
 		rec.promoted[attemptID] = append(rec.promoted[attemptID], blockIDs...)
 		return nil
 	}
 	// The delta every path publishes: one file carrying two blocks.
-	// resolvedAddedBlockIDs is left empty on purpose so finalize behaves exactly
-	// as it does for a caller that did not stage — including its own resolve.
+	// resolvedAddedBlockIDs is left empty on purpose so the stage seam must
+	// supply the resolved IDs before finalize.
 	buildSyncCommitBlockDeltaFn = func(_ *SyncHandler, _, _ string) (syncCommitBlockDelta, error) {
 		return syncCommitBlockDelta{
 			addedFiles: []syncCommitFileReference{{
@@ -107,9 +121,8 @@ func installHandshakeSeams(t *testing.T) *handshakeRecord {
 			}},
 		}, nil
 	}
-	// Resolution would need a DB, and finalize resolves when the delta arrives
-	// unresolved — exactly the repair path's shape. Identity keeps the difference
-	// under test on the handshake.
+	// Resolution would need a DB in production. Identity keeps the difference under
+	// test on the handshake while the stage seam supplies the resolved IDs.
 	resolveSyncBlockIDsFn = func(_ *SyncHandler, _, _ string, blockIDs []string) ([]string, error) {
 		return db.NormalizeBlockIDs(blockIDs), nil
 	}
@@ -125,10 +138,21 @@ func newHandshakeHandler() *SyncHandler {
 	}
 }
 
-// assertPromotedOnlyWhatItStaged fails when any attempt promoted blocks without
-// having staged a pub: for that same attempt.
+// assertPromotedOnlyWhatItStaged fails when any attempt promotes before staging
+// or promotes blocks that were not staged for that same attempt.
 func (rec *handshakeRecord) assertPromotedOnlyWhatItStaged(t *testing.T) {
 	t.Helper()
+	stagedAt := make(map[string]bool)
+	for _, event := range rec.events {
+		switch event.phase {
+		case "stage":
+			stagedAt[event.attemptID] = true
+		case "promote":
+			if !stagedAt[event.attemptID] {
+				t.Fatalf("promoted before staging pub: for attempt %s", event.attemptID)
+			}
+		}
+	}
 	for attemptID, promoted := range rec.promoted {
 		staged := rec.staged[attemptID]
 		if len(staged) == 0 {
@@ -149,20 +173,17 @@ func (rec *handshakeRecord) assertPromotedOnlyWhatItStaged(t *testing.T) {
 	}
 }
 
-// TestRepairPublishedSyncCommitBlockDeltaStagesBeforeFinalizing is the R25
+// TestRepairPublishedSyncCommitBlockDeltaEstablishesHandshakeBeforeFinalizing is the R25
 // reproduction. It drives the real production entry point:
 // handleSyncHeadPromotion answers currentHead == targetHead with
-// handleSyncHeadIdempotentSuccess (sync.go:4221-4224), which calls exactly this
-// helper, which rebuilds the delta and goes straight to finalize.
+// handleSyncHeadIdempotentSuccess, which calls exactly this helper. The helper
+// must rebuild the delta, establish pub:, and then finalize.
 //
-// EXPECTED RESULT TODAY: RED.
+// EXPECTED RESULT AFTER THE R25 FIX: GREEN.
 //
-//	--- FAIL: TestRepairPublishedSyncCommitBlockDeltaStagesBeforeFinalizing
-//	    promoted 2 block(s) for attempt head-r25 with no pub: staged for it
-//
-// Routing this helper through stageSyncCommitBlockDelta turns it green. If it
-// goes green without that change, suspect the seams before believing the result.
-func TestRepairPublishedSyncCommitBlockDeltaStagesBeforeFinalizing(t *testing.T) {
+// Routing this helper directly to finalize must turn it red. If it goes green
+// without staging, suspect the seams before believing the result.
+func TestRepairPublishedSyncCommitBlockDeltaEstablishesHandshakeBeforeFinalizing(t *testing.T) {
 	rec := installHandshakeSeams(t)
 	h := newHandshakeHandler()
 
@@ -175,9 +196,58 @@ func TestRepairPublishedSyncCommitBlockDeltaStagesBeforeFinalizing(t *testing.T)
 	rec.assertPromotedOnlyWhatItStaged(t)
 }
 
+func TestPublishedSyncRepairPartialStageFailureDoesNotFinalize(t *testing.T) {
+	rec := installHandshakeSeams(t)
+	wantErr := errors.New("stage boom")
+	stageSyncPublishAttemptReferencesFn = func(_ *db.DB, _, _, attemptID string, blockIDs []string, _ db.BlockIDResolver) ([]string, error) {
+		if len(blockIDs) != 2 {
+			t.Fatalf("blockIDs = %#v, want two blocks", blockIDs)
+		}
+		// Model a successful stage for the first block followed by an error for
+		// the next one. The DB-level stage test verifies its rollback is scoped
+		// to this fresh attempt ID.
+		rec.staged[attemptID] = append(rec.staged[attemptID], blockIDs[0])
+		rec.events = append(rec.events, handshakeEvent{attemptID: attemptID, phase: "stage"})
+		return nil, wantErr
+	}
+
+	if err := newHandshakeHandler().repairPublishedSyncCommitBlockDelta(handshakeOrgID, handshakeRepoID, handshakeHeadID); !errors.Is(err, wantErr) {
+		t.Fatalf("repair error = %v, want %v", err, wantErr)
+	}
+	if len(rec.promoted) != 0 {
+		t.Fatalf("repair promoted %d attempt(s) after ensure failed", len(rec.promoted))
+	}
+}
+
+func TestSyncPublicationAttemptsUseDistinctIDsForTheSameTarget(t *testing.T) {
+	installHandshakeSeams(t)
+	ids := []string{"attempt-a", "attempt-b"}
+	newSyncPublishAttemptIDFn = func() string {
+		id := ids[0]
+		ids = ids[1:]
+		return id
+	}
+	h := newHandshakeHandler()
+
+	first, err := h.stageSyncCommitBlockDelta(handshakeOrgID, handshakeRepoID, handshakeHeadID)
+	if err != nil {
+		t.Fatalf("first stage returned error: %v", err)
+	}
+	second, err := h.stageSyncCommitBlockDelta(handshakeOrgID, handshakeRepoID, handshakeHeadID)
+	if err != nil {
+		t.Fatalf("second stage returned error: %v", err)
+	}
+	if first.publishAttemptID == second.publishAttemptID {
+		t.Fatalf("same target reused publication attempt ID %q", first.publishAttemptID)
+	}
+	if first.publishAttemptID == handshakeHeadID || second.publishAttemptID == handshakeHeadID {
+		t.Fatalf("target commit ID was used as publication attempt ID: %q/%q", first.publishAttemptID, second.publishAttemptID)
+	}
+}
+
 // TestRepairSkipsEverythingOnceThisProcessFinalized guards the fix's shape rather
 // than the defect: repairPublishedSyncCommitBlockDelta consults a per-process memo
-// first (sync.go:141,158-194), and a fix that simply always re-stages must not
+// first (sync.go:141,158-194), and a fix that simply always re-ensures must not
 // quietly make every idempotent retry pay the full reconciliation. A path that
 // promotes nothing satisfies the handshake trivially.
 //


### PR DESCRIPTION
Closes the red test merged in #169, and the identity defect found while fixing it.
Confined to `internal/api` plus docs — **`internal/db` is untouched**.

Two coupled defects in the same mechanism. Fixing only the first would have left the
second able to retract the handshake it establishes.

---

## R25 — the handshake was bypassable

`repairPublishedSyncCommitBlockDelta` built the block delta and went straight to
`finalizeSyncCommitBlockDelta`, so it was the one production path that wrote permanent
`fs:` references without ever holding this attempt's `pub:` rows.

```
already-published HEAD
  └─ handleSyncHeadPromotion            currentHead == targetHead
      └─ handleSyncHeadIdempotentSuccess
          └─ repairPublishedSyncCommitBlockDelta
              ├─ buildSyncCommitBlockDelta          ← no stage
              └─ finalizeSyncCommitBlockDelta
                  └─ PromotePublishAttemptReferences
                      └─ RegisterFSObjectBlockReferences  → permanent fs:
```

R3 of the X1 work concludes that `RegisterFSObjectBlockReferences` needs no fence check
of its own *precisely because* promotion only happens after a checked handshake. The
promote structure is real; the inference was false for this path — and it failed
**silently**, because `PromotePublishAttemptReferences` calls `registerPermanent()` and
then deletes whatever attempt rows it finds, never verifying that any exist.

Every publication safety check X1 adds hangs off the handshake, so a path that skips it
is a path those checks cannot see. The repair now stages like any first publication.

### Reachability

Narrower than "any retry", and still ordinary. `finalizedBlockDeltas` is a per-process
two-generation memo (4096 entries per generation) marked only after a successful
finalize, so a warm same-instance retry short-circuits. It is reached when the retry
lands on **another instance** (production is multi-node), when **the original finalize
failed** — the case this helper exists to heal — after a restart, or after eviction.

---

## R29 — the identity was shared

Sync used `targetCommitID` as the publication attempt ID, so two concurrent publishers of
the same commit shared one `pub:<commit>` referrer, and a loser's cleanup deleted the
winner's liveness.

Each delta now carries a fresh `publishAttemptID` threaded through stage, promote and
cleanup, so cleanup can only ever address its own attempt. `finalizeSyncCommitBlockDelta`
refuses a delta with no attempt ID rather than falling back to the commit.

Same family as R14/R16/R24 in the GC design: a shared identity means one attempt's
cleanup damages another's.

### Fixing R29 is what makes the R25 fix simple

An earlier revision of this branch added a separate no-rollback `Ensure` primitive for the
repair path, on the theory that rolling back a partial repair could remove liveness from a
commit that is already visible. **With a unique attempt ID that theory no longer holds:**
the only rows a repair can roll back are the ones it just wrote under its own UUID, while
the original publisher's rows — or the `fs:` refs a previous promote created — are
untouched. The repair therefore uses plain `StagePublishAttemptReferences`, and the extra
primitive is gone. That is why this PR no longer touches `internal/db`.

---

## Three CAS outcomes that were being handled as failure

| Outcome | Before | Now |
|---|---|---|
| CAS query itself errors | cleanup + error — but the CAS **may have applied** | `errSyncHeadCASUncertain`: retain refs, 503 + Retry-After |
| `applySyncHeadPostCASMutations` fails | cleanup + 500 — but HEAD **did** apply | `errSyncHeadPostCAS`: retain refs, finalize, 503 |
| CAS conflict whose current head **is** our target | generic conflict retry | idempotent success: clean up only this attempt, enter repair |

The last one is safe only because attempt IDs are now unique. This is R20's discipline —
an ambiguous conditional write is not evidence of failure — applied to the sync head CAS.

---

## Filed, not fixed

**R31 (blocker for X1 safety closure).** The residual of retaining refs on an uncertain
outcome: a visible HEAD can end up protected only by a TTL-bound `pub:` row, and sync
repair runs only when a later client request happens to reach the idempotent path. If none
arrives within 35 days, the temporary liveness expires with `fs:` still absent.

To be clear about direction: **this branch does not introduce R31, it lengthens the
window.** Previously an uncertain CAS ran cleanup and removed the refs immediately — the
window was zero. Converging it properly needs a durable reconciliation record or a
background worker, not a client retry, so it is recorded rather than closed here.

**R30 (decision).** The bounded retention cost of non-shared identity: a repair cannot
retire a crashed publisher's UUID refs, and repeated failed repairs accumulate attempts,
each bounded by the 35-day TTL.

---

## Scope

**R25 fixed. R29 identity fixed** (cleanup policy still wants integration evidence).
**R30 open as a decision, R31 open as a blocker, R3 open, X1 open.** `GC_ENABLED=false`
unchanged.

This adds **no** publication fence check — it makes the future one reachable from every
promote path instead of bypassable by one.

---

## Verification

Each mutation was verified to fail **its own** gate, not just "something":

| Mutation | Result |
|---|---|
| Handshake bypass (`build → finalize`, attempt ID present) | `...EstablishesHandshakeBeforeFinalizing` **RED** — `promoted before staging pub: for attempt mutant` |
| Shared identity (`attemptID = targetCommitID`) | `...UseDistinctIDsForTheSameTarget` **RED** — `same target reused publication attempt ID`; handshake gate stays **GREEN** |
| Restored | all **GREEN** |

That the second mutation leaves the first gate green is what shows the two defects are
detected independently.

The handshake gate asserts **order**, not presence: promote may never precede stage for
the same attempt.

Also green: `PartialStageFailureDoesNotFinalize`,
`SkipsEverythingOnceThisProcessFinalized`, `StagedPublicationShape`,
`PromoteDoesNotRequireAStagedRow`.

`gofmt`, `go vet ./...`, `go build ./...` and `go test -short` on `internal/api`,
`internal/db` and `internal/gc` all pass. Merging this makes `go test ./internal/api/`
green again — #169 deliberately merged the reproduction red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)