### PR TITLE
fix(gc): prune representation_id from the physical orphan row (R11b-1)

### DIFF
--- a/docs/BLOCK-REPRESENTATION-DESIGN.md
+++ b/docs/BLOCK-REPRESENTATION-DESIGN.md
@@ -60,6 +60,10 @@ the representation-aware primary key. New library creation paths now persist
 representation metadata on surviving library/block rows; it does not preserve the
 old org-wide forward-mapping namespace.
 
+R11b-1 drops `gc_s3_orphans.representation_id` from the physical GC recovery
+row. The representation column remains authoritative on `blocks` and in the
+logical mapping domains; it is not a physical orphan lifecycle field.
+
 ## PR1 runtime scope
 
 PR1 updates the live runtime consumers that resolve or persist mappings. R11a later
@@ -68,10 +72,11 @@ decouples the logical mapping lifecycle from physical block GC:
 - upload materialization and verified web block mapping writes
 - batch SHA-1 resolution for file view, share-link view, sync, and seafhttp reads
 - direct sync/seafhttp single-block lookups
-- canonical block metadata writes so GC can persist the exact representation and
-  external identity in durable orphan recovery metadata
-- GC orphan recovery and physical block cleanup, keyed by `representation_id`; physical
-  GC does not delete the forward mapping
+- canonical block metadata writes so the block row persists the exact
+  representation and external identity
+- GC orphan recovery and physical block cleanup, which use the canonical storage
+  class and retain only the external SHA-1 characterization; physical GC does not
+  delete the forward mapping
 - cross-repo batch copy/move guard: same-representation allowed, different
   representation rejected before copying `fs_objects`
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,28 @@ Session-by-session development history for SesameFS.
 
 ---
 
+## 2026-08-17 - R11b-1 prunes physical orphan representation state
+
+Migration `015_gc_s3_orphans_without_representation_id.cql` removes
+`gc_s3_orphans.representation_id`. R11a already removed physical GC authority
+over logical mappings, and the reachability audit confirmed that the remaining
+orphan recovery path did not use this field to select a backend, delete bytes,
+or advance a phase. `external_sha1` remains in the canonical orphan row and in
+the commit-point equality because its reachable empty-to-populated backfill is
+still characterized as a conservative fail-closed discriminator.
+
+The GC store contract, Cassandra/mock implementations, worker, and `BlockInfo`
+no longer carry the orphan representation field. Representation metadata remains
+in `blocks`, libraries, queue state, and mapping domains; this migration changes
+only the physical orphan recovery subsystem. Source and effective-schema gates
+reject reintroducing the field to canonical orphan statements or schema.
+
+This is a clean-cut schema change. No pre-R11b-1 binary may remain active after
+the migration is applied, and production destructive GC remains disabled while
+exact physical identity and lifecycle fencing remain open X1/R23 work.
+
+---
+
 ## 2026-08-17 - R11a decouples physical GC from logical mappings
 
 Physical block GC no longer deletes `block_id_mappings`. The SHA-1 -> SHA-256

--- a/docs/GC-X1-CLOSURE-OPTIONS.md
+++ b/docs/GC-X1-CLOSURE-OPTIONS.md
@@ -56,21 +56,36 @@ finalization, and because an orphan row is a writer fence (`ProbeBlockReuse` ans
 affected content for as long as it lasts. This is a liveness cost, not a reason to
 let the branch clear an unverified canonical state.
 
-**R11a canonical-state characterization (2026-08-17).** The canonical
-`external_sha1` and `representation_id` fields are no longer used for mapping
-cleanup, but they remain auxiliary canonical-state discriminators in the
+**Historical R11a canonical-state characterization (2026-08-17, before R11b-1).**
+The canonical `external_sha1` and `representation_id` fields were no longer used
+for mapping cleanup, but remained auxiliary canonical-state discriminators in the
 commit-point reload. `StartBlockDeleteOrphan` preserves `first_seen_at` when it
 resets an existing `(org_id, block_id)` row. Therefore two observations of the
-same canonical recovery row can have the same `first_seen_at`, `storage_class`,
-and `recovery_phase` while `external_sha1` changes through the reachable
+same canonical recovery row could have the same `first_seen_at`, `storage_class`,
+and `recovery_phase` while `external_sha1` changed through the reachable
 greenfield empty-to-populated metadata-backfill path. The sole production
 `blocks` INSERT validates and persists a non-empty `representation_id`; its
-empty-value repair is an imported/legacy-row path. The current reload detects
-the SHA-1 change. This does not establish a physical target change or prove that
-the discriminator is safety-load-bearing rather than defense-in-depth.
-Whether either field can be pruned must be established by reachability analysis,
-or the discriminator must first be replaced by explicit P/lifecycle identity.
-R11b remains deferred pending that proof or an explicit identity superseding it.
+empty-value repair is an imported/legacy-row path. That reload detected the
+SHA-1 change. This did not establish a physical target change or prove that the
+discriminator was safety-load-bearing rather than defense-in-depth. R11b-1 below
+resolved the reachability question for `representation_id` and retained only the
+conservative `external_sha1` characterization.
+
+**R11b-1 (2026-08-17).** The reachability audit established that
+`representation_id` is not used by physical orphan recovery to select a backend,
+authorize a delete, or advance a phase. Migration
+`015_gc_s3_orphans_without_representation_id.cql` therefore drops it from the
+canonical `gc_s3_orphans` table and the GC contract. `external_sha1` remains in
+the canonical row and in `s3OrphanRecoveryStateEqual`: its reachable
+empty-to-populated backfill is still retained as conservative fail-closed
+coverage. This is a metadata-surface reduction, not an X1 closure; the orphan
+still identifies a logical block and storage class rather than an immutable
+physical `P=(B,K)`.
+
+The older R28 discussion below describes the pre-R11b-1 writer set; its
+references to `representation_id` as an orphan identity writer are historical.
+After R11b-1, the remaining conditional orphan identity writers are
+`external_sha1` and `recovery_phase`.
 
 The recovery path also has two distinct post-S3 windows. If the orphan clear fails
 after `pending_mapping_cleanup` is durably recorded, retry recovery does not issue
@@ -102,8 +117,8 @@ separation into a storage separation: "the worker does not read the payload" bec
 "the payload does not exist". `upsertS3OrphanProjection` fell from seven parameters to
 three, and `MarkS3OrphanMappingCleanupPending` stopped reading `storage_class` and
 `representation_id` back, since it fetched them solely to refill projection cells no
-reader consulted. Canonical `gc_s3_orphans` keeps all four columns — only the copy is
-gone.
+reader consulted. At the time of R22b, canonical `gc_s3_orphans` kept all four
+columns; R11b-1 subsequently removes only its `representation_id` column.
 
 **What R22b changed about the table itself.** Every surviving column is a primary-key
 column, so a discovery row now carries no regular cells and its **primary-key liveness
@@ -1192,7 +1207,7 @@ A conceptual diff, not an implementation list.
 | `UpsertBlockMetadata` | `INSERT … IF NOT EXISTS` inheriting the session serial level | Store the exact key; raise the serial phase to `SERIAL` so one incarnation wins globally (R9) |
 | `ClaimBlockDelete` / `FinalizeBlockDelete` | Conditional on `gc_state` / `gc_claim_id` only | Bind the life: `AND backend_identity = B1 AND storage_key = K1`, with fresh per-attempt claim identity (R14/R16) |
 | `ReleaseBlockClaim`, `ReleaseStaleBlockClaim`, `ReleaseBlockDeleteClaim`, the stub-repair pair, both backfills | Conditional statements on `blocks`, inheriting the session serial level | Serial phase `SERIAL` — the one-serial-domain rule admits no exceptions on this partition (R12) |
-| `gc_s3_orphans` (+ `gc_s3_orphans_by_day`) | Canonical `gc_s3_orphans` has PK `((org_id, block_id))` and carries `external_sha1`/`recovery_phase` (migration 007) plus `representation_id` (009); R22b makes `gc_s3_orphans_by_day` identity-only with PK `((first_seen_day, bucket), first_seen_at, org_id, block_id)` (migration 014) | Add exact `(B, storage_key)` to both; the concrete backend field is `storage_class` only if R23 selects it as `B`. Recovery and `ListS3OrphansByDay` must not `hashToKey`; the clear becomes conditional on both tuple fields |
+| `gc_s3_orphans` (+ `gc_s3_orphans_by_day`) | Canonical `gc_s3_orphans` has PK `((org_id, block_id))` and carries `external_sha1`/`recovery_phase` (migration 007); R11b-1 removes the redundant `representation_id`, while R22b makes `gc_s3_orphans_by_day` identity-only with PK `((first_seen_day, bucket), first_seen_at, org_id, block_id)` (migration 014) | Add exact `(B, storage_key)` to both; the concrete backend field is `storage_class` only if R23 selects it as `B`. Recovery and `ListS3OrphansByDay` must not `hashToKey`; the clear becomes conditional on both tuple fields |
 | `StartBlockDeleteOrphan` | `INSERT … IF NOT EXISTS`, then **resets** an existing row to `pending_s3` | Return/classify applied, same-key idempotent, different-key conflict and ambiguous error; never overwrite/reset, never release on an ambiguous result, and postpone only a confirmed different lifecycle (B.1) |
 | `gcS3OrphanInitialScanLookbackDays = 90` | Cold-start horizon, matched to the TTL | Redefine together with the TTL removal |
 | `RecoverS3Orphans` | Re-verifies `BlockExists(L)` and `BlockHasReferencesGlobal(L)` | **A+:** retain `BlockHasReferencesGlobal(L)` and the canonical-row check, then delete exact validated `P1`. **B:** the orphan may carry the historical authorization for `P1`, but recovery still validates the canonical locator and legacy/keyless rows fail closed. |

--- a/internal/db/block_references_test.go
+++ b/internal/db/block_references_test.go
@@ -238,6 +238,22 @@ func TestUpsertBlockMetadataRejectsEmptyStorageClassBeforeInsert(t *testing.T) {
 	}
 }
 
+func TestUpsertBlockMetadataRejectsEmptyRepresentationBeforeInsert(t *testing.T) {
+	oldInsert := upsertBlockMetadataInsertWithRepresentationFn
+	t.Cleanup(func() {
+		upsertBlockMetadataInsertWithRepresentationFn = oldInsert
+	})
+	upsertBlockMetadataInsertWithRepresentationFn = func(*DB, string, string, string, string, int, string, string, time.Time) (bool, error) {
+		t.Fatal("representation insert must not run with an empty representation id")
+		return false, nil
+	}
+
+	err := (&DB{}).UpsertBlockMetadataWithRepresentationAndSHA1("org-1", "", "block-1", "", 1, "hot", "key")
+	if err == nil || !strings.Contains(err.Error(), "missing block representation id") {
+		t.Fatalf("UpsertBlockMetadataWithRepresentationAndSHA1() error = %v, want missing representation error", err)
+	}
+}
+
 func TestUpsertBlockMetadataRepairsReleasedStubAndRetriesInsert(t *testing.T) {
 	database := &DB{}
 	oldInsert := upsertBlockMetadataInsertFn

--- a/internal/db/migrations/015_gc_s3_orphans_without_representation_id.cql
+++ b/internal/db/migrations/015_gc_s3_orphans_without_representation_id.cql
@@ -1,0 +1,10 @@
+-- Migration 015: remove redundant block representation state from physical GC
+--
+-- R11a removed logical mapping cleanup from physical GC. The orphan's
+-- representation_id no longer selects a physical target or authorizes an
+-- action, and greenfield block creation already persists the canonical
+-- representation outside this recovery row. Keep external_sha1 for the
+-- remaining conservative canonical-state characterization.
+
+ALTER TABLE gc_s3_orphans
+    DROP IF EXISTS representation_id;

--- a/internal/db/migrator_test.go
+++ b/internal/db/migrator_test.go
@@ -233,6 +233,20 @@ func TestMigration005AddsSHA256CanonicalBlockIDColumns(t *testing.T) {
 	assert.Contains(t, content, "ALTER TABLE blocks ADD sha1 TEXT;")
 }
 
+func TestMigration015DropsOnlyGCOrphanRepresentationID(t *testing.T) {
+	raw, err := migrationsFS.ReadFile("migrations/015_gc_s3_orphans_without_representation_id.cql")
+	require.NoError(t, err)
+	content := string(raw)
+
+	statements := parseCQLStatements(content)
+	require.Len(t, statements, 1)
+	assert.Contains(t, statements[0], "ALTER TABLE gc_s3_orphans")
+	assert.Contains(t, statements[0], "DROP IF EXISTS representation_id")
+	statement := strings.Join(statements, " ")
+	assert.NotContains(t, statement, "external_sha1")
+	assert.NotContains(t, statement, "blocks")
+}
+
 func TestMigration008AddsBlockUploadStagingCapsAndFrozenAdmission(t *testing.T) {
 	raw, err := migrationsFS.ReadFile("migrations/008_block_upload_staging_caps.cql")
 	require.NoError(t, err)

--- a/internal/gc/s3_orphan_partial_row_test.go
+++ b/internal/gc/s3_orphan_partial_row_test.go
@@ -222,7 +222,7 @@ func TestMockUpdateS3OrphanAttemptGuardsTokenAndExpiry(t *testing.T) {
 			store := NewMockStore()
 			orgID := uuid.New()
 			const blockID = "mock-guarded-orphan"
-			if _, err := store.StartBlockDeleteOrphan(orgID, blockID, "hot", "plain", "", firstSeen); err != nil {
+			if _, err := store.StartBlockDeleteOrphan(orgID, blockID, "hot", "", firstSeen); err != nil {
 				t.Fatalf("StartBlockDeleteOrphan: %v", err)
 			}
 

--- a/internal/gc/s3_orphan_recovery_test.go
+++ b/internal/gc/s3_orphan_recovery_test.go
@@ -130,7 +130,7 @@ func TestWorker_ProcessBlock_UsesExistingOrphanFirstSeenAtForCleanup(t *testing.
 	orgID := uuid.New()
 	firstSeenAt := time.Now().Add(-24 * time.Hour).UTC().Truncate(time.Millisecond)
 	store.AddBlock(orgID, "block-orphan-cleanup", "hot", 0)
-	seedS3Orphan(t, store, orgID, "block-orphan-cleanup", "hot", db.PlainBlockRepresentationID, "", "previous failure", firstSeenAt)
+	seedS3Orphan(t, store, orgID, "block-orphan-cleanup", "hot", "", "previous failure", firstSeenAt)
 	if err := store.EnqueueItem(orgID, time.Now().Add(-2*time.Hour), ItemBlock, "block-orphan-cleanup", uuid.Nil, "hot", 0); err != nil {
 		t.Fatalf("EnqueueItem failed: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestWorker_RecoverS3Orphans_Success(t *testing.T) {
 
 	orgID := uuid.New()
 	// Seed an orphan directly.
-	seedS3Orphan(t, store, orgID, "orph-1", " hot ", db.PlainBlockRepresentationID, "", "earlier failure", time.Now())
+	seedS3Orphan(t, store, orgID, "orph-1", " hot ", "", "earlier failure", time.Now())
 
 	recovered, err := w.RecoverS3Orphans(context.Background(), 100)
 	if err != nil {
@@ -194,7 +194,7 @@ func TestWorker_RecoverS3Orphans_UsesCanonicalStorageClassForPhysicalDelete(t *t
 	w := NewWorker(store, sp, NewQueue(store), 100, 0, false, &Stats{})
 
 	orgID := uuid.New()
-	seedS3Orphan(t, store, orgID, "orph-canonical-class", "hot", db.PlainBlockRepresentationID, "", "previous failure", time.Now())
+	seedS3Orphan(t, store, orgID, "orph-canonical-class", "hot", "", "previous failure", time.Now())
 
 	recovered, err := w.RecoverS3Orphans(context.Background(), 100)
 	if err != nil {
@@ -217,9 +217,9 @@ func TestWorker_RecoverS3Orphans_UsesCanonicalPhaseForOrphanFinalization(t *test
 	orgID := uuid.New()
 	blockID := "orph-canonical-phase"
 	canonicalSHA1 := "sha1-canonical"
-	firstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", db.PlainBlockRepresentationID, canonicalSHA1, "previous failure", time.Now())
+	firstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", canonicalSHA1, "previous failure", time.Now())
 	store.AddBlockMapping(orgID, canonicalSHA1, blockID)
-	if err := store.MarkS3OrphanMappingCleanupPending(orgID, blockID, db.PlainBlockRepresentationID, canonicalSHA1, firstSeenAt.Add(time.Second)); err != nil {
+	if err := store.MarkS3OrphanMappingCleanupPending(orgID, blockID, canonicalSHA1, firstSeenAt.Add(time.Second)); err != nil {
 		t.Fatalf("advance canonical orphan phase: %v", err)
 	}
 
@@ -245,7 +245,7 @@ func TestWorker_RecoverS3Orphans_CanonicalMissingRetainsDiscoveryAndCursor(t *te
 
 	orgID := uuid.New()
 	blockID := "orph-canonical-missing"
-	firstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", db.PlainBlockRepresentationID, "", "previous failure", time.Now())
+	firstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", "", "previous failure", time.Now())
 	store.DeleteS3OrphanCanonicalForTest(orgID, blockID)
 
 	recovered, err := w.RecoverS3Orphans(context.Background(), 100)
@@ -277,7 +277,7 @@ func TestWorker_RecoverS3Orphans_DiscoveryTokenMismatchFailsClosed(t *testing.T)
 
 	orgID := uuid.New()
 	blockID := "orph-discovery-token-mismatch"
-	canonicalFirstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", db.PlainBlockRepresentationID, "", "previous failure", time.Now())
+	canonicalFirstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", "", "previous failure", time.Now())
 	store.DeleteS3OrphanProjectionForTest(orgID, blockID, canonicalFirstSeenAt)
 	staleFirstSeenAt := canonicalFirstSeenAt.Add(-time.Hour)
 	store.AddS3OrphanProjectionForTest(S3OrphanDiscoveryInfo{
@@ -307,7 +307,7 @@ func TestWorker_RecoverS3Orphans_CanonicalReadErrorFailsClosed(t *testing.T) {
 	w := NewWorker(store, sp, NewQueue(store), 100, 0, false, &Stats{})
 
 	orgID := uuid.New()
-	seedS3Orphan(t, store, orgID, "orph-canonical-read-error", "hot", db.PlainBlockRepresentationID, "", "previous failure", time.Now())
+	seedS3Orphan(t, store, orgID, "orph-canonical-read-error", "hot", "", "previous failure", time.Now())
 	store.SetGetS3OrphanGlobalErrForTest(errors.New("EACH_QUORUM unavailable"))
 
 	recovered, err := w.RecoverS3Orphans(context.Background(), 100)
@@ -331,7 +331,7 @@ func TestWorker_RecoverS3Orphans_CanonicalStateChangeBeforeCommitFailsClosed(t *
 	w := NewWorker(store, sp, NewQueue(store), 100, 0, false, &Stats{})
 
 	orgID := uuid.New()
-	seedS3Orphan(t, store, orgID, "orph-canonical-reload", "hot", db.PlainBlockRepresentationID, "", "previous failure", time.Now())
+	seedS3Orphan(t, store, orgID, "orph-canonical-reload", "hot", "", "previous failure", time.Now())
 	store.SetGetS3OrphanGlobalHookForTest(func(_ uuid.UUID, _ string, call int, info S3OrphanInfo) (S3OrphanInfo, error) {
 		if call == 2 {
 			info.StorageClass = "cold"
@@ -358,9 +358,9 @@ func TestWorker_RecoverS3Orphans_CanonicalStateChangeBeforeCommitFailsClosed(t *
 // removed the external SHA-1 field. StartBlockDeleteOrphan preserves
 // first_seen_at when it resets an existing row, so phase and storage class can
 // remain unchanged while a later metadata repair fills a previously empty SHA-1.
-// This test does not establish a physical lifecycle change. representation_id is
-// intentionally not mutated here because production inserts validate and persist
-// it; its empty-value repair is an imported/legacy-row path.
+// This test does not establish a physical lifecycle change. The physical orphan
+// state no longer carries representation_id; the block writer invariant remains
+// a separate global metadata contract.
 func TestWorker_RecoverS3Orphans_BackfilledSHA1ChangeBeforeCommitFailsClosed(t *testing.T) {
 	store := NewMockStore()
 	sp := &MockStorageProvider{}
@@ -369,11 +369,11 @@ func TestWorker_RecoverS3Orphans_BackfilledSHA1ChangeBeforeCommitFailsClosed(t *
 	orgID := uuid.New()
 	blockID := "orph-logical-identity-reload"
 	backfilledSHA1 := strings.Repeat("2", 40)
-	seedS3Orphan(t, store, orgID, blockID, "hot", db.PlainBlockRepresentationID, "", "", time.Now())
+	seedS3Orphan(t, store, orgID, blockID, "hot", "", "", time.Now())
 	store.SetGetS3OrphanGlobalHookForTest(func(_ uuid.UUID, _ string, call int, info S3OrphanInfo) (S3OrphanInfo, error) {
 		if call == 2 {
-			// Keep first_seen_at, storage_class, recovery_phase and representation_id
-			// identical. Only the SHA-1 is backfilled while canonical recovery state
+			// Keep first_seen_at, storage_class and recovery_phase identical. Only the
+			// SHA-1 is backfilled while canonical recovery state
 			// remains otherwise unchanged.
 			info.ExternalSHA1 = backfilledSHA1
 		}
@@ -414,8 +414,8 @@ func TestWorker_RecoverS3Orphans_MappingCleanupCanonicalStateChangeBeforeCommitF
 	// No AddBlock: the canonical block row is gone, so the resurrection guard
 	// falls through to the mapping-cleanup commit point.
 	store.AddBlockMapping(orgID, canonicalSHA1, blockID)
-	firstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", db.PlainBlockRepresentationID, canonicalSHA1, "", time.Now())
-	if err := store.MarkS3OrphanMappingCleanupPending(orgID, blockID, db.PlainBlockRepresentationID, canonicalSHA1, firstSeenAt.Add(time.Second)); err != nil {
+	firstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", canonicalSHA1, "", time.Now())
+	if err := store.MarkS3OrphanMappingCleanupPending(orgID, blockID, canonicalSHA1, firstSeenAt.Add(time.Second)); err != nil {
 		t.Fatalf("advance canonical orphan phase: %v", err)
 	}
 	store.SetGetS3OrphanGlobalHookForTest(func(_ uuid.UUID, _ string, call int, info S3OrphanInfo) (S3OrphanInfo, error) {
@@ -455,8 +455,8 @@ func TestWorker_RecoverS3Orphans_ResurrectedDiscardCanonicalStateChangeBeforeCom
 	// whose irreversible action is DeleteS3Orphan rather than a mapping delete.
 	store.AddBlock(orgID, blockID, "hot", 0)
 	store.AddBlockMapping(orgID, canonicalSHA1, blockID)
-	firstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", db.PlainBlockRepresentationID, canonicalSHA1, "", time.Now())
-	if err := store.MarkS3OrphanMappingCleanupPending(orgID, blockID, db.PlainBlockRepresentationID, canonicalSHA1, firstSeenAt.Add(time.Second)); err != nil {
+	firstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", canonicalSHA1, "", time.Now())
+	if err := store.MarkS3OrphanMappingCleanupPending(orgID, blockID, canonicalSHA1, firstSeenAt.Add(time.Second)); err != nil {
 		t.Fatalf("advance canonical orphan phase: %v", err)
 	}
 	store.SetGetS3OrphanGlobalHookForTest(func(_ uuid.UUID, _ string, call int, info S3OrphanInfo) (S3OrphanInfo, error) {
@@ -493,7 +493,7 @@ func TestWorker_RecoverS3Orphans_EmptyStorageClassFailsClosed(t *testing.T) {
 	w := NewWorker(store, sp, NewQueue(store), 100, 0, false, &Stats{})
 
 	orgID := uuid.New()
-	seedS3Orphan(t, store, orgID, "orph-empty-class", "", db.PlainBlockRepresentationID, "", "earlier failure", time.Now())
+	seedS3Orphan(t, store, orgID, "orph-empty-class", "", "", "earlier failure", time.Now())
 
 	recovered, err := w.RecoverS3Orphans(context.Background(), 100)
 	if err == nil {
@@ -521,7 +521,7 @@ func TestWorker_RecoverS3Orphans_SameHashInTwoOrgsDeletesBothScopes(t *testing.T
 	orgA := uuid.New()
 	orgB := uuid.New()
 	for _, orgID := range []uuid.UUID{orgA, orgB} {
-		seedS3Orphan(t, store, orgID, "shared-hash", "hot", db.PlainBlockRepresentationID, "", "earlier failure", time.Now())
+		seedS3Orphan(t, store, orgID, "shared-hash", "hot", "", "earlier failure", time.Now())
 	}
 
 	recovered, err := w.RecoverS3Orphans(context.Background(), 100)
@@ -557,7 +557,7 @@ func TestWorker_RecoverS3Orphans_S3ThenOrphanFinalization(t *testing.T) {
 
 	orgID := uuid.New()
 	store.AddBlockMapping(orgID, "sha1-recover", "orph-map")
-	seedS3Orphan(t, store, orgID, "orph-map", "hot", db.PlainBlockRepresentationID, "sha1-recover", "prev", time.Now())
+	seedS3Orphan(t, store, orgID, "orph-map", "hot", "sha1-recover", "prev", time.Now())
 
 	recovered, err := w.RecoverS3Orphans(context.Background(), 100)
 	if err != nil {
@@ -587,8 +587,8 @@ func TestWorker_RecoverS3Orphans_CompletesPendingMappingCleanupWithoutS3(t *test
 
 	orgID := uuid.New()
 	store.AddBlockMapping(orgID, "sha1-pending-cleanup", "orph-cleanup")
-	firstSeenAt := seedS3Orphan(t, store, orgID, "orph-cleanup", "hot", db.PlainBlockRepresentationID, "sha1-pending-cleanup", "", time.Now())
-	if err := store.MarkS3OrphanMappingCleanupPending(orgID, "orph-cleanup", db.PlainBlockRepresentationID, "sha1-pending-cleanup", firstSeenAt.Add(5*time.Second)); err != nil {
+	firstSeenAt := seedS3Orphan(t, store, orgID, "orph-cleanup", "hot", "sha1-pending-cleanup", "", time.Now())
+	if err := store.MarkS3OrphanMappingCleanupPending(orgID, "orph-cleanup", "sha1-pending-cleanup", firstSeenAt.Add(5*time.Second)); err != nil {
 		t.Fatalf("advance orphan phase: %v", err)
 	}
 
@@ -620,15 +620,15 @@ func TestWorker_RecoverS3Orphans_NewDeleteResetsStalePhaseAndStillDeletesS3(t *t
 	orgID := uuid.New()
 	store.AddBlock(orgID, "blk-redelete", "hot", 0)
 	store.AddBlockMapping(orgID, "sha1-new", "blk-redelete")
-	firstSeenAt := seedS3Orphan(t, store, orgID, "blk-redelete", "hot", db.PlainBlockRepresentationID, "sha1-old", "prev", time.Now().Add(-time.Hour))
-	if err := store.MarkS3OrphanMappingCleanupPending(orgID, "blk-redelete", db.PlainBlockRepresentationID, "sha1-old", firstSeenAt.Add(5*time.Minute)); err != nil {
+	firstSeenAt := seedS3Orphan(t, store, orgID, "blk-redelete", "hot", "sha1-old", "prev", time.Now().Add(-time.Hour))
+	if err := store.MarkS3OrphanMappingCleanupPending(orgID, "blk-redelete", "sha1-old", firstSeenAt.Add(5*time.Minute)); err != nil {
 		t.Fatalf("advance stale orphan phase: %v", err)
 	}
 	applied, err := store.ClaimBlockDelete(orgID, "blk-redelete", "claim-1")
 	if err != nil || !applied {
 		t.Fatalf("claim block delete: applied=%v err=%v", applied, err)
 	}
-	if _, err := store.StartBlockDeleteOrphan(orgID, "blk-redelete", "hot", db.PlainBlockRepresentationID, "sha1-new", time.Now().UTC()); err != nil {
+	if _, err := store.StartBlockDeleteOrphan(orgID, "blk-redelete", "hot", "sha1-new", time.Now().UTC()); err != nil {
 		t.Fatalf("StartBlockDeleteOrphan: %v", err)
 	}
 	if err := store.FinalizeBlockDelete(orgID, "blk-redelete", "claim-1"); err != nil {
@@ -672,8 +672,8 @@ func TestWorker_RecoverS3Orphans_PendingMappingCleanupFinalizesWithResurrectedBl
 	store.AddBlock(orgID, "blk-resurrected", "hot", 0)
 	store.AddBlockMapping(orgID, "sha1-resurrected", "blk-resurrected")
 	// Stale recovery row stuck at pending_mapping_cleanup from the earlier delete.
-	firstSeenAt := seedS3Orphan(t, store, orgID, "blk-resurrected", "hot", db.PlainBlockRepresentationID, "sha1-resurrected", "", time.Now())
-	if err := store.MarkS3OrphanMappingCleanupPending(orgID, "blk-resurrected", db.PlainBlockRepresentationID, "sha1-resurrected", firstSeenAt.Add(5*time.Second)); err != nil {
+	firstSeenAt := seedS3Orphan(t, store, orgID, "blk-resurrected", "hot", "sha1-resurrected", "", time.Now())
+	if err := store.MarkS3OrphanMappingCleanupPending(orgID, "blk-resurrected", "sha1-resurrected", firstSeenAt.Add(5*time.Second)); err != nil {
 		t.Fatalf("advance orphan phase: %v", err)
 	}
 
@@ -710,8 +710,8 @@ func TestWorker_RecoverS3Orphans_PendingMappingCleanupPreservesSiblingRepresenta
 
 	store.AddBlockMappingForRepresentation(orgID, db.PlainBlockRepresentationID, externalSHA1, plainBlockID)
 	store.AddBlockMappingForRepresentation(orgID, encRep, externalSHA1, encBlockID)
-	firstSeenAt := seedS3Orphan(t, store, orgID, encBlockID, "hot", encRep, externalSHA1, "", time.Now())
-	if err := store.MarkS3OrphanMappingCleanupPending(orgID, encBlockID, encRep, externalSHA1, firstSeenAt.Add(5*time.Second)); err != nil {
+	firstSeenAt := seedS3Orphan(t, store, orgID, encBlockID, "hot", externalSHA1, "", time.Now())
+	if err := store.MarkS3OrphanMappingCleanupPending(orgID, encBlockID, externalSHA1, firstSeenAt.Add(5*time.Second)); err != nil {
 		t.Fatalf("advance orphan phase: %v", err)
 	}
 
@@ -744,9 +744,9 @@ func TestWorker_RecoverS3Orphans_PendingMappingCleanupDoesNotReadBlockExists(t *
 	orgID := uuid.New()
 	blockID := "orph-post-s3-no-block-read"
 	sha1 := "sha1-post-s3-no-block-read"
-	firstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", db.PlainBlockRepresentationID, sha1, "", time.Now())
+	firstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", sha1, "", time.Now())
 	store.AddBlockMapping(orgID, sha1, blockID)
-	if err := store.MarkS3OrphanMappingCleanupPending(orgID, blockID, db.PlainBlockRepresentationID, sha1, firstSeenAt.Add(time.Second)); err != nil {
+	if err := store.MarkS3OrphanMappingCleanupPending(orgID, blockID, sha1, firstSeenAt.Add(time.Second)); err != nil {
 		t.Fatalf("advance orphan phase: %v", err)
 	}
 	store.SetBlockExistsErrForTest(errors.New("BlockExists must not be called for post-S3 finalization"))
@@ -775,7 +775,7 @@ func TestWorker_RecoverS3Orphans_PostS3ClearRetryDoesNotRepeatS3(t *testing.T) {
 	blockID := "orph-post-s3-clear-retry"
 	sha1 := "sha1-post-s3-clear-retry"
 	store.AddBlockMapping(orgID, sha1, blockID)
-	seedS3Orphan(t, store, orgID, blockID, "hot", db.PlainBlockRepresentationID, sha1, "", time.Now())
+	seedS3Orphan(t, store, orgID, blockID, "hot", sha1, "", time.Now())
 	store.SetDeleteS3OrphanErrOnceForTest(errors.New("simulated crash before orphan clear"))
 
 	if _, err := w.RecoverS3Orphans(context.Background(), 100); err == nil {
@@ -816,7 +816,7 @@ func TestWorker_RecoverS3Orphans_PhysicalDeleteBeforePhaseAdvanceCanRepeatS3(t *
 
 	orgID := uuid.New()
 	blockID := "orph-phase-advance-window"
-	firstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", db.PlainBlockRepresentationID, "sha1-phase-window", "", time.Now())
+	firstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", "sha1-phase-window", "", time.Now())
 	store.SetMarkS3OrphanMappingCleanupPendingErrOnceForTest(errors.New("simulated phase advance failure"))
 
 	if _, err := w.RecoverS3Orphans(context.Background(), 100); err == nil {
@@ -856,8 +856,8 @@ func TestWorker_RecoverS3Orphans_PartialFailure(t *testing.T) {
 
 	orgID := uuid.New()
 	now := time.Now()
-	seedS3Orphan(t, store, orgID, "orph-A", "hot", db.PlainBlockRepresentationID, "", "prev", now)
-	seedS3Orphan(t, store, orgID, "orph-B", "hot", db.PlainBlockRepresentationID, "", "prev", now)
+	seedS3Orphan(t, store, orgID, "orph-A", "hot", "", "prev", now)
+	seedS3Orphan(t, store, orgID, "orph-B", "hot", "", "prev", now)
 
 	// Fail one call during this recovery attempt. Since iteration order over a
 	// map is random, assert on totals rather than which block survives.
@@ -894,7 +894,7 @@ func TestWorker_RecoverS3Orphans_DryRun(t *testing.T) {
 	w := NewWorker(store, sp, q, 100, 0, true, stats) // dryRun=true
 
 	orgID := uuid.New()
-	seedS3Orphan(t, store, orgID, "orph-dr", "hot", db.PlainBlockRepresentationID, "", "prev", time.Now())
+	seedS3Orphan(t, store, orgID, "orph-dr", "hot", "", "prev", time.Now())
 
 	recovered, err := w.RecoverS3Orphans(context.Background(), 100)
 	if err != nil {
@@ -925,7 +925,7 @@ func TestWorker_RecoverS3Orphans_SkipsClaimedRows(t *testing.T) {
 	if err != nil || !applied {
 		t.Fatalf("claim block delete: applied=%v err=%v", applied, err)
 	}
-	seedS3Orphan(t, store, orgID, "orph-claimed", "hot", db.PlainBlockRepresentationID, "", "", time.Now())
+	seedS3Orphan(t, store, orgID, "orph-claimed", "hot", "", "", time.Now())
 
 	recovered, err := w.RecoverS3Orphans(context.Background(), 100)
 	if err == nil {
@@ -960,7 +960,7 @@ func TestWorker_RecoverS3Orphans_ColdStartSeesOldRows(t *testing.T) {
 
 	orgID := uuid.New()
 	firstSeenAt := now.AddDate(0, 0, -30)
-	seedS3Orphan(t, store, orgID, "orph-old", "hot", db.PlainBlockRepresentationID, "", "old failure", firstSeenAt)
+	seedS3Orphan(t, store, orgID, "orph-old", "hot", "", "old failure", firstSeenAt)
 
 	recovered, err := w.RecoverS3Orphans(context.Background(), 100)
 	if err != nil {
@@ -999,7 +999,7 @@ func TestWorker_RecoverS3Orphans_PartitionLimitKeepsCursorUnchanged(t *testing.T
 		if db.GCDiscoveryBucket(orgID.String(), blockID) != targetBucket {
 			continue
 		}
-		seedS3Orphan(t, store, orgID, blockID, "hot", db.PlainBlockRepresentationID, "", "prev", now.AddDate(0, 0, -30))
+		seedS3Orphan(t, store, orgID, blockID, "hot", "", "prev", now.AddDate(0, 0, -30))
 		seeded++
 	}
 
@@ -1050,7 +1050,7 @@ func TestWorker_RecoverS3Orphans_RefCountLookupErrorKeepsCursorUnchanged(t *test
 	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
 	w.clock = func() time.Time { return now }
 	orgID := uuid.New()
-	seedS3Orphan(t, store, orgID, "orph-refcount-error", "hot", db.PlainBlockRepresentationID, "", "prev", now.AddDate(0, 0, -10))
+	seedS3Orphan(t, store, orgID, "orph-refcount-error", "hot", "", "prev", now.AddDate(0, 0, -10))
 	store.getBlockRefCountErr = fmt.Errorf("temporary cassandra failure")
 
 	recovered, err := w.RecoverS3Orphans(context.Background(), 100)
@@ -1102,7 +1102,7 @@ func TestScanner_S3OrphanRecoveryPhase_CallsRecoverer(t *testing.T) {
 	s.SetOrphanRecoverer(w)
 
 	orgID := uuid.New()
-	seedS3Orphan(t, store, orgID, "orph-phase", "hot", db.PlainBlockRepresentationID, "", "prev", time.Now())
+	seedS3Orphan(t, store, orgID, "orph-phase", "hot", "", "prev", time.Now())
 
 	n, err := s.scanS3OrphanRecovery(context.Background())
 	if err != nil {

--- a/internal/gc/s3_orphan_test_helpers_test.go
+++ b/internal/gc/s3_orphan_test_helpers_test.go
@@ -10,10 +10,10 @@ import (
 // seedS3Orphan creates test state through the production lifecycle entry point.
 // A failed initial delete is represented by the same follow-up mutation the
 // worker uses, rather than by a second row-creating API.
-func seedS3Orphan(t *testing.T, store GCStore, orgID uuid.UUID, blockID, storageClass, representationID, externalSHA1, errMsg string, firstSeenAt time.Time) time.Time {
+func seedS3Orphan(t *testing.T, store GCStore, orgID uuid.UUID, blockID, storageClass, externalSHA1, errMsg string, firstSeenAt time.Time) time.Time {
 	t.Helper()
 	firstSeenAt = firstSeenAt.UTC().Truncate(time.Millisecond)
-	effectiveFirstSeenAt, err := store.StartBlockDeleteOrphan(orgID, blockID, storageClass, representationID, externalSHA1, firstSeenAt)
+	effectiveFirstSeenAt, err := store.StartBlockDeleteOrphan(orgID, blockID, storageClass, externalSHA1, firstSeenAt)
 	if err != nil {
 		t.Fatalf("StartBlockDeleteOrphan: %v", err)
 	}

--- a/internal/gc/store.go
+++ b/internal/gc/store.go
@@ -188,7 +188,7 @@ type GCStore interface {
 	// deletion. It always resets recovery state to pending_s3 so a stale
 	// pending_mapping_cleanup row from an older delete cannot make recovery skip
 	// the physical object delete for this new lifecycle.
-	StartBlockDeleteOrphan(orgID uuid.UUID, blockID, storageClass, representationID, externalSHA1 string, now time.Time) (time.Time, error)
+	StartBlockDeleteOrphan(orgID uuid.UUID, blockID, storageClass, externalSHA1 string, now time.Time) (time.Time, error)
 	// GetS3OrphanGlobal reads the canonical orphan row at EACH_QUORUM for the
 	// destructive recovery path. It supplies recovery state and the physical
 	// backend selector; it is not a Paxos settlement read and does not authorize
@@ -203,7 +203,7 @@ type GCStore interface {
 	// delete has completed so restart recovery can finish the orphan lifecycle
 	// without touching S3 again. The phase name is historical: after R11a this
 	// transition performs no block-id mapping cleanup.
-	MarkS3OrphanMappingCleanupPending(orgID uuid.UUID, blockID, representationID, externalSHA1 string, now time.Time) error
+	MarkS3OrphanMappingCleanupPending(orgID uuid.UUID, blockID, externalSHA1 string, now time.Time) error
 	UpdateS3OrphanAttempt(orgID uuid.UUID, blockID string, expectedFirstSeenAt time.Time, errMsg string, now time.Time) error
 	DeleteS3Orphan(orgID uuid.UUID, blockID string, firstSeenAt time.Time) error
 
@@ -379,10 +379,9 @@ type CommitInfo struct {
 
 // BlockInfo holds data about a block needed by the scanner.
 type BlockInfo struct {
-	BlockID          string
-	StorageClass     string
-	CreatedAt        *time.Time
-	RepresentationID string
+	BlockID      string
+	StorageClass string
+	CreatedAt    *time.Time
 	// Sha1 is the block's external Seafile SHA-1 (blocks.sha1), retained for
 	// orphan recovery metadata and legacy diagnostics. Empty for legacy/pre-PR2
 	// rows.
@@ -474,16 +473,15 @@ type S3OrphanDiscoveryInfo struct {
 // row is physically removed, so a crash between DB and S3 phases remains
 // recoverable after restart.
 type S3OrphanInfo struct {
-	OrgID            uuid.UUID
-	BlockID          string
-	StorageClass     string
-	RepresentationID string
-	ExternalSHA1     string
-	RecoveryPhase    string
-	FirstSeenAt      time.Time
-	LastAttemptAt    time.Time
-	RetryCount       int
-	LastError        string
+	OrgID         uuid.UUID
+	BlockID       string
+	StorageClass  string
+	ExternalSHA1  string
+	RecoveryPhase string
+	FirstSeenAt   time.Time
+	LastAttemptAt time.Time
+	RetryCount    int
+	LastError     string
 }
 
 const (

--- a/internal/gc/store_cassandra.go
+++ b/internal/gc/store_cassandra.go
@@ -1571,7 +1571,7 @@ func (s *CassandraStore) upsertS3OrphanProjection(orgID uuid.UUID, blockID strin
 
 // GetS3OrphanGlobal reads the canonical recovery row at EACH_QUORUM. The
 // discovery projection is deliberately not consulted here: recovery uses this
-// row for phase, mapping identity, and backend selection. EACH_QUORUM provides
+// row for phase, external SHA-1 characterization, and backend selection. EACH_QUORUM provides
 // the same cross-DC visibility contract as the destructive liveness read, but
 // this ordinary SELECT is not a Paxos settlement and does not authorize a
 // physical delete by itself.
@@ -1579,13 +1579,12 @@ func (s *CassandraStore) GetS3OrphanGlobal(orgID uuid.UUID, blockID string) (S3O
 	var info S3OrphanInfo
 	var firstSeenAt time.Time
 	err := s.db.Session().Query(`
-		SELECT storage_class, representation_id, external_sha1, recovery_phase,
+		SELECT storage_class, external_sha1, recovery_phase,
 		       first_seen_at, last_attempt_at, retry_count, last_error
 		FROM gc_s3_orphans
 		WHERE org_id = ? AND block_id = ?
 	`, orgID.String(), blockID).Consistency(gocql.EachQuorum).Scan(
 		&info.StorageClass,
-		&info.RepresentationID,
 		&info.ExternalSHA1,
 		&info.RecoveryPhase,
 		&firstSeenAt,
@@ -1601,7 +1600,6 @@ func (s *CassandraStore) GetS3OrphanGlobal(orgID uuid.UUID, blockID string) (S3O
 	}
 	info.OrgID = orgID
 	info.BlockID = blockID
-	info.RepresentationID = strings.TrimSpace(info.RepresentationID)
 	info.ExternalSHA1 = strings.TrimSpace(info.ExternalSHA1)
 	info.RecoveryPhase = strings.TrimSpace(info.RecoveryPhase)
 	info.FirstSeenAt = firstSeenAt.UTC()
@@ -1611,14 +1609,13 @@ func (s *CassandraStore) GetS3OrphanGlobal(orgID uuid.UUID, blockID string) (S3O
 // StartBlockDeleteOrphan records the durable recovery row for a NEW block
 // delete lifecycle. It always resets the phase to pending_s3, even when a
 // stale row from an older delete already exists for the same block_id.
-func (s *CassandraStore) StartBlockDeleteOrphan(orgID uuid.UUID, blockID, storageClass, representationID, externalSHA1 string, now time.Time) (time.Time, error) {
+func (s *CassandraStore) StartBlockDeleteOrphan(orgID uuid.UUID, blockID, storageClass, externalSHA1 string, now time.Time) (time.Time, error) {
 	externalSHA1 = strings.TrimSpace(externalSHA1)
-	representationID = strings.TrimSpace(representationID)
 	existing := map[string]interface{}{}
 	applied, err := s.db.Session().Query(`
-		INSERT INTO gc_s3_orphans (org_id, block_id, storage_class, representation_id, external_sha1, recovery_phase, first_seen_at, last_attempt_at, retry_count, last_error)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) IF NOT EXISTS
-	`, orgID.String(), blockID, storageClass, representationID, externalSHA1, S3OrphanPhasePendingS3, now, now, 0, "").MapScanCAS(existing)
+		INSERT INTO gc_s3_orphans (org_id, block_id, storage_class, external_sha1, recovery_phase, first_seen_at, last_attempt_at, retry_count, last_error)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) IF NOT EXISTS
+	`, orgID.String(), blockID, storageClass, externalSHA1, S3OrphanPhasePendingS3, now, now, 0, "").MapScanCAS(existing)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("failed to record block delete orphan: %w", err)
 	}
@@ -1635,10 +1632,10 @@ func (s *CassandraStore) StartBlockDeleteOrphan(orgID uuid.UUID, blockID, storag
 		updateState := map[string]interface{}{}
 		updated, err := s.db.Session().Query(`
 			UPDATE gc_s3_orphans
-			SET storage_class = ?, representation_id = ?, external_sha1 = ?, recovery_phase = ?, last_attempt_at = ?, retry_count = ?, last_error = ?
+			SET storage_class = ?, external_sha1 = ?, recovery_phase = ?, last_attempt_at = ?, retry_count = ?, last_error = ?
 			WHERE org_id = ? AND block_id = ?
 			IF EXISTS
-		`, effectiveStorageClass, representationID, externalSHA1, S3OrphanPhasePendingS3, now, 0, "", orgID.String(), blockID).MapScanCAS(updateState)
+		`, effectiveStorageClass, externalSHA1, S3OrphanPhasePendingS3, now, 0, "", orgID.String(), blockID).MapScanCAS(updateState)
 		if err != nil {
 			return effectiveFirstSeenAt, fmt.Errorf("reset S3 orphan recovery state for org=%s block=%s: %w", orgID, blockID, err)
 		}
@@ -1652,9 +1649,8 @@ func (s *CassandraStore) StartBlockDeleteOrphan(orgID uuid.UUID, blockID, storag
 	return effectiveFirstSeenAt, nil
 }
 
-func (s *CassandraStore) MarkS3OrphanMappingCleanupPending(orgID uuid.UUID, blockID, representationID, externalSHA1 string, now time.Time) error {
+func (s *CassandraStore) MarkS3OrphanMappingCleanupPending(orgID uuid.UUID, blockID, externalSHA1 string, now time.Time) error {
 	externalSHA1 = strings.TrimSpace(externalSHA1)
-	representationID = strings.TrimSpace(representationID)
 	// IF EXISTS: a plain UPDATE is an upsert in Cassandra, so if a concurrent
 	// DeleteS3Orphan (multi-worker recovery race) already removed the row, an
 	// unconditional UPDATE would resurrect a partial phantom row (PK + these cols,
@@ -1662,10 +1658,10 @@ func (s *CassandraStore) MarkS3OrphanMappingCleanupPending(orgID uuid.UUID, bloc
 	// applied=false means another worker finished the recovery — nothing to advance.
 	applied, err := s.db.Session().Query(`
 		UPDATE gc_s3_orphans
-		SET representation_id = ?, external_sha1 = ?, recovery_phase = ?, last_attempt_at = ?, last_error = ?
+		SET external_sha1 = ?, recovery_phase = ?, last_attempt_at = ?, last_error = ?
 		WHERE org_id = ? AND block_id = ?
 		IF EXISTS
-	`, representationID, externalSHA1, S3OrphanPhasePendingMappingCleanup, now, "", orgID.String(), blockID).MapScanCAS(map[string]interface{}{})
+	`, externalSHA1, S3OrphanPhasePendingMappingCleanup, now, "", orgID.String(), blockID).MapScanCAS(map[string]interface{}{})
 	if err != nil {
 		return fmt.Errorf("mark S3 orphan mapping cleanup pending org=%s block=%s: %w", orgID, blockID, err)
 	}
@@ -1673,9 +1669,7 @@ func (s *CassandraStore) MarkS3OrphanMappingCleanupPending(orgID uuid.UUID, bloc
 		return nil
 	}
 	// Only first_seen_at is read back: it is the projection's clustering key, and
-	// since R22b the projection has nothing else to carry. Before R22b this also
-	// fetched storage_class and representation_id purely to refill projection
-	// payload columns that no reader consulted.
+	// since R22b the projection has nothing else to carry.
 	var firstSeenAt time.Time
 	err = s.db.Session().Query(`
 		SELECT first_seen_at FROM gc_s3_orphans WHERE org_id = ? AND block_id = ?
@@ -1732,9 +1726,9 @@ const gcS3OrphanTTLSeconds = 7776000
 //	coordinator-clock alignment remains a separate open requirement.
 //
 // Rewriting the identity columns to realign them was the other candidate and is
-// deliberately NOT what happens here: representation_id, external_sha1 and
-// recovery_phase all have other conditional writers (StartBlockDeleteOrphan's
-// reset and the pending_mapping_cleanup transition), so
+// deliberately NOT what happens here: external_sha1 and recovery_phase both
+// have other conditional writers (StartBlockDeleteOrphan's reset and the
+// pending_mapping_cleanup transition), so
 // echoing back values read a moment earlier would trade a TTL race for a
 // lost-update race — including a recovery_phase regression.
 //
@@ -2029,18 +2023,16 @@ func (s *CassandraStore) BlockReferenceExists(orgID uuid.UUID, blockID, referrer
 func (s *CassandraStore) GetBlockInfo(orgID uuid.UUID, blockID string) (BlockInfo, error) {
 	info := BlockInfo{BlockID: blockID}
 	var createdAt *time.Time
-	var representationID string
 	var sha1 string
 	// Single-partition point read by the full ((org_id), block_id) key. sha1 is
 	// the same row, so reading it adds no extra query and no tombstone scan.
 	err := s.db.Session().Query(`
-		SELECT storage_class, created_at, representation_id, sha1 FROM blocks WHERE org_id = ? AND block_id = ?
-	`, orgID.String(), blockID).Scan(&info.StorageClass, &createdAt, &representationID, &sha1)
+		SELECT storage_class, created_at, sha1 FROM blocks WHERE org_id = ? AND block_id = ?
+	`, orgID.String(), blockID).Scan(&info.StorageClass, &createdAt, &sha1)
 	if err != nil {
 		return BlockInfo{}, err
 	}
 	info.CreatedAt = createdAt
-	info.RepresentationID = strings.TrimSpace(representationID)
 	info.Sha1 = strings.TrimSpace(sha1)
 	return info, nil
 }

--- a/internal/gc/store_mock.go
+++ b/internal/gc/store_mock.go
@@ -1254,7 +1254,7 @@ func (m *MockStore) GetBlockInfo(orgID uuid.UUID, blockID string) (BlockInfo, er
 	if block == nil {
 		return BlockInfo{}, gocql.ErrNotFound
 	}
-	return BlockInfo{BlockID: block.BlockID, StorageClass: block.StorageClass, CreatedAt: block.CreatedAt, RepresentationID: block.RepresentationID, Sha1: block.Sha1}, nil
+	return BlockInfo{BlockID: block.BlockID, StorageClass: block.StorageClass, CreatedAt: block.CreatedAt, Sha1: block.Sha1}, nil
 }
 
 // BlockReferenceCount returns how many reference rows a block currently has.
@@ -3807,7 +3807,7 @@ func (m *MockStore) GetS3OrphanGlobal(orgID uuid.UUID, blockID string) (S3Orphan
 	return info, true, nil
 }
 
-func (m *MockStore) StartBlockDeleteOrphan(orgID uuid.UUID, blockID, storageClass, representationID, externalSHA1 string, now time.Time) (time.Time, error) {
+func (m *MockStore) StartBlockDeleteOrphan(orgID uuid.UUID, blockID, storageClass, externalSHA1 string, now time.Time) (time.Time, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	key := fmt.Sprintf("%s:%s", orgID, blockID)
@@ -3819,7 +3819,6 @@ func (m *MockStore) StartBlockDeleteOrphan(orgID uuid.UUID, blockID, storageClas
 			return firstSeenAt, fmt.Errorf("reset S3 orphan recovery state for org=%s block=%s: row disappeared before update", orgID, blockID)
 		}
 		existing.StorageClass = storageClass
-		existing.RepresentationID = strings.TrimSpace(representationID)
 		existing.ExternalSHA1 = strings.TrimSpace(externalSHA1)
 		existing.RecoveryPhase = S3OrphanPhasePendingS3
 		existing.LastAttemptAt = now
@@ -3829,21 +3828,20 @@ func (m *MockStore) StartBlockDeleteOrphan(orgID uuid.UUID, blockID, storageClas
 		return existing.FirstSeenAt, nil
 	}
 	orphan := &S3OrphanInfo{
-		OrgID:            orgID,
-		BlockID:          blockID,
-		StorageClass:     storageClass,
-		RepresentationID: strings.TrimSpace(representationID),
-		ExternalSHA1:     strings.TrimSpace(externalSHA1),
-		RecoveryPhase:    S3OrphanPhasePendingS3,
-		FirstSeenAt:      now.UTC(),
-		LastAttemptAt:    now,
+		OrgID:         orgID,
+		BlockID:       blockID,
+		StorageClass:  storageClass,
+		ExternalSHA1:  strings.TrimSpace(externalSHA1),
+		RecoveryPhase: S3OrphanPhasePendingS3,
+		FirstSeenAt:   now.UTC(),
+		LastAttemptAt: now,
 	}
 	m.s3Orphans[key] = orphan
 	m.upsertS3OrphanProjection(orphan.OrgID, orphan.BlockID, orphan.FirstSeenAt)
 	return orphan.FirstSeenAt, nil
 }
 
-func (m *MockStore) MarkS3OrphanMappingCleanupPending(orgID uuid.UUID, blockID, representationID, externalSHA1 string, now time.Time) error {
+func (m *MockStore) MarkS3OrphanMappingCleanupPending(orgID uuid.UUID, blockID, externalSHA1 string, now time.Time) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.markS3OrphanErrOnce != nil {
@@ -3853,7 +3851,6 @@ func (m *MockStore) MarkS3OrphanMappingCleanupPending(orgID uuid.UUID, blockID, 
 	}
 	key := fmt.Sprintf("%s:%s", orgID, blockID)
 	if existing, ok := m.s3Orphans[key]; ok {
-		existing.RepresentationID = strings.TrimSpace(representationID)
 		existing.ExternalSHA1 = strings.TrimSpace(externalSHA1)
 		existing.RecoveryPhase = S3OrphanPhasePendingMappingCleanup
 		existing.LastAttemptAt = now

--- a/internal/gc/store_projection_test.go
+++ b/internal/gc/store_projection_test.go
@@ -83,10 +83,10 @@ func TestStore_StartBlockDeleteOrphan_RepairsMissingProjectionAndPreservesFirstS
 	orgID := uuid.New()
 	firstSeenAt := time.Now().Add(-48 * time.Hour).UTC().Truncate(time.Millisecond)
 
-	seedS3Orphan(t, store, orgID, "orph-repair", "hot", db.PlainBlockRepresentationID, "", "prev", firstSeenAt)
+	seedS3Orphan(t, store, orgID, "orph-repair", "hot", "", "prev", firstSeenAt)
 	store.DeleteS3OrphanProjectionForTest(orgID, "orph-repair", firstSeenAt)
 
-	effectiveFirstSeenAt := seedS3Orphan(t, store, orgID, "orph-repair", "cold", db.PlainBlockRepresentationID, "", "", time.Now())
+	effectiveFirstSeenAt := seedS3Orphan(t, store, orgID, "orph-repair", "cold", "", "", time.Now())
 	if !effectiveFirstSeenAt.Equal(firstSeenAt) {
 		t.Fatalf("effective first_seen_at = %v, want %v", effectiveFirstSeenAt, firstSeenAt)
 	}
@@ -119,10 +119,10 @@ func TestStore_StartBlockDeleteOrphan_ResetRaceDoesNotResurrectRow(t *testing.T)
 	orgID := uuid.New()
 	firstSeenAt := time.Now().Add(-24 * time.Hour).UTC().Truncate(time.Millisecond)
 
-	seedS3Orphan(t, store, orgID, "orph-reset-race", "hot", db.PlainBlockRepresentationID, "sha1-old", "prev", firstSeenAt)
+	seedS3Orphan(t, store, orgID, "orph-reset-race", "hot", "sha1-old", "prev", firstSeenAt)
 	store.SetStartBlockDeleteOrphanResetRaceForTest(true)
 
-	if _, err := store.StartBlockDeleteOrphan(orgID, "orph-reset-race", "cold", db.PlainBlockRepresentationID, "sha1-new", time.Now().UTC()); err == nil {
+	if _, err := store.StartBlockDeleteOrphan(orgID, "orph-reset-race", "cold", "sha1-new", time.Now().UTC()); err == nil {
 		t.Fatal("StartBlockDeleteOrphan error = nil, want reset-race error")
 	}
 	if got := store.S3OrphanCount(); got != 0 {
@@ -142,12 +142,12 @@ func TestStore_StartBlockDeleteOrphan_ResetsStalePendingMappingCleanup(t *testin
 	orgID := uuid.New()
 	firstSeenAt := time.Now().Add(-48 * time.Hour).UTC().Truncate(time.Millisecond)
 
-	seedS3Orphan(t, store, orgID, "orph-reset", "cold", db.PlainBlockRepresentationID, "sha1-old", "prev", firstSeenAt)
-	if err := store.MarkS3OrphanMappingCleanupPending(orgID, "orph-reset", db.PlainBlockRepresentationID, "sha1-old", firstSeenAt.Add(5*time.Minute)); err != nil {
+	seedS3Orphan(t, store, orgID, "orph-reset", "cold", "sha1-old", "prev", firstSeenAt)
+	if err := store.MarkS3OrphanMappingCleanupPending(orgID, "orph-reset", "sha1-old", firstSeenAt.Add(5*time.Minute)); err != nil {
 		t.Fatalf("MarkS3OrphanMappingCleanupPending failed: %v", err)
 	}
 
-	effectiveFirstSeenAt, err := store.StartBlockDeleteOrphan(orgID, "orph-reset", "hot", db.PlainBlockRepresentationID, "sha1-new", time.Now().UTC())
+	effectiveFirstSeenAt, err := store.StartBlockDeleteOrphan(orgID, "orph-reset", "hot", "sha1-new", time.Now().UTC())
 	if err != nil {
 		t.Fatalf("StartBlockDeleteOrphan failed: %v", err)
 	}

--- a/internal/gc/worker.go
+++ b/internal/gc/worker.go
@@ -1191,7 +1191,7 @@ func (w *Worker) processBlock(ctx context.Context, item QueueItem) error {
 		return failedClosedError{Reason: "destructive topology gate rejected block at the commit point", ItemID: item.ItemID, Err: err}
 	}
 
-	orphanFirstSeenAt, err := w.store.StartBlockDeleteOrphan(item.OrgID, item.ItemID, storageClass, blockInfo.RepresentationID, blockInfo.Sha1, w.clock().UTC())
+	orphanFirstSeenAt, err := w.store.StartBlockDeleteOrphan(item.OrgID, item.ItemID, storageClass, blockInfo.Sha1, w.clock().UTC())
 	if err != nil {
 		return w.failClosedIfUnavailable("failed to record pending S3 delete", item.ItemID, err)
 	}
@@ -1222,7 +1222,7 @@ func (w *Worker) processBlock(ctx context.Context, item QueueItem) error {
 			metrics.GCAuditEventsTotal.WithLabelValues("gc_block_s3_orphaned").Inc()
 			// Do NOT return error — the block is recorded for recovery.
 			// Continue to post-delete cleanup so the queue item completes.
-		} else if err := w.store.MarkS3OrphanMappingCleanupPending(item.OrgID, item.ItemID, blockInfo.RepresentationID, blockInfo.Sha1, w.clock()); err != nil {
+		} else if err := w.store.MarkS3OrphanMappingCleanupPending(item.OrgID, item.ItemID, blockInfo.Sha1, w.clock()); err != nil {
 			log.Printf("[GC Worker] WARNING: S3 delete for block %s succeeded but failed to advance recovery row: %v", item.ItemID, err)
 			clearRecoveryRow = true
 		} else {
@@ -1591,7 +1591,7 @@ func (w *Worker) RecoverS3Orphans(ctx context.Context, perBucketLimit int) (int,
 					}
 					continue
 				}
-				if err := w.store.MarkS3OrphanMappingCleanupPending(canonicalCommit.OrgID, canonicalCommit.BlockID, canonicalCommit.RepresentationID, canonicalCommit.ExternalSHA1, w.clock()); err != nil {
+				if err := w.store.MarkS3OrphanMappingCleanupPending(canonicalCommit.OrgID, canonicalCommit.BlockID, canonicalCommit.ExternalSHA1, w.clock()); err != nil {
 					log.Printf("[GC Worker] S3 orphan recovery: failed to advance %s to mapping cleanup: %v", canonicalCommit.BlockID, err)
 					if phaseErr == nil {
 						phaseErr = fmt.Errorf("advance recovered block %s to mapping cleanup: %w", canonicalCommit.BlockID, err)
@@ -1654,7 +1654,6 @@ func s3OrphanRecoveryStateEqual(left, right S3OrphanInfo) bool {
 		left.BlockID == right.BlockID &&
 		normalizeS3OrphanRecoveryTime(left.FirstSeenAt).Equal(normalizeS3OrphanRecoveryTime(right.FirstSeenAt)) &&
 		strings.TrimSpace(left.StorageClass) == strings.TrimSpace(right.StorageClass) &&
-		strings.TrimSpace(left.RepresentationID) == strings.TrimSpace(right.RepresentationID) &&
 		strings.TrimSpace(left.ExternalSHA1) == strings.TrimSpace(right.ExternalSHA1) &&
 		strings.TrimSpace(left.RecoveryPhase) == strings.TrimSpace(right.RecoveryPhase)
 }

--- a/internal/gc/x2_audit_followups_test.go
+++ b/internal/gc/x2_audit_followups_test.go
@@ -768,7 +768,7 @@ func TestX2_DestructiveTimestampsArePerPath(t *testing.T) {
 
 	// Orphan recovery cannot authorize anything: its liveness read fails.
 	orgID := uuid.New()
-	seedS3Orphan(t, store, orgID, "orph-1", "hot", db.PlainBlockRepresentationID, "", "", now.AddDate(0, 0, -1))
+	seedS3Orphan(t, store, orgID, "orph-1", "hot", "", "", now.AddDate(0, 0, -1))
 	store.SetBlockHasReferencesGlobalErrForTest(fakeRequestError{code: gocql.ErrCodeUnavailable, msg: "Cannot achieve consistency level EACH_QUORUM in DC dc-asia"})
 	if _, err := w.RecoverS3Orphans(context.Background(), 100); err == nil {
 		t.Fatal("expected the sweep to fail closed")
@@ -864,7 +864,7 @@ func TestX2_OrphanRecoveryClassifiesItsGlobalVerifyFailure(t *testing.T) {
 	seedRefusedOrphan := func(t *testing.T, w *Worker, store *MockStore, sp *MockStorageProvider, at time.Time, livenessErr error) {
 		t.Helper()
 		orgID := uuid.New()
-		seedS3Orphan(t, store, orgID, "orph-1", "hot", db.PlainBlockRepresentationID, "", "", at.AddDate(0, 0, -1))
+		seedS3Orphan(t, store, orgID, "orph-1", "hot", "", "", at.AddDate(0, 0, -1))
 		store.SetBlockHasReferencesGlobalErrForTest(livenessErr)
 		if _, err := w.RecoverS3Orphans(context.Background(), 100); err == nil {
 			t.Fatal("the sweep must defer when its global verify fails, whatever the error was")
@@ -948,7 +948,7 @@ func TestX2_OrphanRecoveryCanonicalReadUnavailableMovesBlockedMark(t *testing.T)
 	resetDestructivePairForTest(destructivePathOrphan)
 
 	orgID := uuid.New()
-	seedS3Orphan(t, store, orgID, "orph-canonical-unavailable", "hot", db.PlainBlockRepresentationID, "", "previous failure", now.AddDate(0, 0, -1))
+	seedS3Orphan(t, store, orgID, "orph-canonical-unavailable", "hot", "", "previous failure", now.AddDate(0, 0, -1))
 	store.SetGetS3OrphanGlobalErrForTest(fakeRequestError{
 		code: gocql.ErrCodeUnavailable,
 		msg:  "Cannot achieve consistency level EACH_QUORUM in DC dc-asia",
@@ -998,7 +998,7 @@ func TestX2_OrphanRecoveryCanonicalReadPermanentErrorIsNotAnOutage(t *testing.T)
 	_, baselineSuccess := destructivePairForTest(t, destructivePathOrphan)
 
 	orgID := uuid.New()
-	seedS3Orphan(t, store, orgID, "orph-canonical-read-permanent", "hot", db.PlainBlockRepresentationID, "", "previous failure", now.AddDate(0, 0, -1))
+	seedS3Orphan(t, store, orgID, "orph-canonical-read-permanent", "hot", "", "previous failure", now.AddDate(0, 0, -1))
 	store.SetGetS3OrphanGlobalErrForTest(fakeRequestError{
 		code: gocql.ErrCodeReadFailure,
 		msg:  "Operation failed - received 0 responses and 1 failures: TOMBSTONE_OVERWHELMING",
@@ -1035,7 +1035,7 @@ func TestX2_OrphanRecoveryCanonicalReloadUnavailableMovesBlockedMark(t *testing.
 	resetDestructivePairForTest(destructivePathOrphan)
 
 	orgID := uuid.New()
-	seedS3Orphan(t, store, orgID, "orph-reload-unavailable", "hot", db.PlainBlockRepresentationID, "", "previous failure", now.AddDate(0, 0, -1))
+	seedS3Orphan(t, store, orgID, "orph-reload-unavailable", "hot", "", "previous failure", now.AddDate(0, 0, -1))
 	store.SetGetS3OrphanGlobalHookForTest(func(_ uuid.UUID, _ string, call int, info S3OrphanInfo) (S3OrphanInfo, error) {
 		if call == 2 {
 			return S3OrphanInfo{}, fakeRequestError{
@@ -1082,7 +1082,7 @@ func TestX2_OrphanRecoveryCanonicalReloadMissingIsDistinctFromInitialMissing(t *
 
 	orgID := uuid.New()
 	blockID := "orph-reload-missing"
-	seedS3Orphan(t, store, orgID, blockID, "hot", db.PlainBlockRepresentationID, "", "previous failure", now.AddDate(0, 0, -1))
+	seedS3Orphan(t, store, orgID, blockID, "hot", "", "previous failure", now.AddDate(0, 0, -1))
 	store.SetGetS3OrphanGlobalHookForTest(func(_ uuid.UUID, _ string, call int, info S3OrphanInfo) (S3OrphanInfo, error) {
 		if call == 1 {
 			// The first read has already returned a canonical row. Remove it before
@@ -1124,7 +1124,7 @@ func TestX2_OrphanRecoveryCanonicalReloadPermanentErrorIsNotAnOutage(t *testing.
 	resetDestructivePairForTest(destructivePathOrphan)
 
 	orgID := uuid.New()
-	seedS3Orphan(t, store, orgID, "orph-reload-failed", "hot", db.PlainBlockRepresentationID, "", "previous failure", now.AddDate(0, 0, -1))
+	seedS3Orphan(t, store, orgID, "orph-reload-failed", "hot", "", "previous failure", now.AddDate(0, 0, -1))
 	store.SetGetS3OrphanGlobalHookForTest(func(_ uuid.UUID, _ string, call int, info S3OrphanInfo) (S3OrphanInfo, error) {
 		if call == 2 {
 			return S3OrphanInfo{}, errors.New("canonical row has an incompatible recovery schema")

--- a/internal/gc/x2_cross_dc_liveness_test.go
+++ b/internal/gc/x2_cross_dc_liveness_test.go
@@ -742,7 +742,7 @@ func TestX2_OrphanRecoveryRefusesAReferencedBlock(t *testing.T) {
 	w.clock = func() time.Time { return now }
 
 	orgID := uuid.New()
-	seedS3Orphan(t, store, orgID, "orph-referenced", "hot", db.PlainBlockRepresentationID, "", "", now.AddDate(0, 0, -1))
+	seedS3Orphan(t, store, orgID, "orph-referenced", "hot", "", "", now.AddDate(0, 0, -1))
 	// The canonical row is gone (that is why there is an orphan row at all), but a
 	// reference to the content exists somewhere in the fleet.
 	store.AddBlockReferenceForTest(orgID, "orph-referenced", "fs:lib:obj")
@@ -781,7 +781,7 @@ func TestX2_OrphanRecoveryFailsClosedOnAnUnavailableDatacenter(t *testing.T) {
 	w.clock = func() time.Time { return now }
 
 	orgID := uuid.New()
-	seedS3Orphan(t, store, orgID, "orph-dc-down", "hot", db.PlainBlockRepresentationID, "", "", now.AddDate(0, 0, -1))
+	seedS3Orphan(t, store, orgID, "orph-dc-down", "hot", "", "", now.AddDate(0, 0, -1))
 	store.SetBlockHasReferencesGlobalErrForTest(fakeRequestError{code: gocql.ErrCodeUnavailable, msg: "Cannot achieve consistency level EACH_QUORUM in DC dc-asia"})
 
 	recovered, err := w.RecoverS3Orphans(context.Background(), 100)

--- a/internal/integration/gc_integration_test.go
+++ b/internal/integration/gc_integration_test.go
@@ -1365,7 +1365,7 @@ func TestUploadLink_ReuploadBlockedByS3OrphanFence(t *testing.T) {
 		t.Fatalf("parse orgID %q: %v", orgID, err)
 	}
 	firstSeenAt := time.Now().UTC().Truncate(time.Millisecond)
-	effectiveFirstSeenAt := seedS3Orphan(t, store, orgUUID, blockID, "hot", db.PlainBlockRepresentationID, "", "seed orphan fence", firstSeenAt)
+	effectiveFirstSeenAt := seedS3Orphan(t, store, orgUUID, blockID, "hot", "", "seed orphan fence", firstSeenAt)
 	t.Cleanup(func() {
 		if err := store.DeleteS3Orphan(orgUUID, blockID, effectiveFirstSeenAt); err != nil {
 			t.Errorf("cleanup DeleteS3Orphan(%s): %v", blockID, err)
@@ -2089,7 +2089,7 @@ func TestGC_StartBlockDeleteOrphan_RepairsDiscoveryRowWhenCanonicalExists(t *tes
 	blockID := fmt.Sprintf("orph-repair-%d", time.Now().UnixNano())
 	firstSeenAt := time.Now().UTC().Truncate(time.Millisecond)
 
-	effectiveFirstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", db.PlainBlockRepresentationID, "", "seed", firstSeenAt)
+	effectiveFirstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", "", "seed", firstSeenAt)
 	if !effectiveFirstSeenAt.Equal(firstSeenAt) {
 		t.Fatalf("effective first_seen_at = %v, want %v", effectiveFirstSeenAt, firstSeenAt)
 	}
@@ -2108,7 +2108,7 @@ func TestGC_StartBlockDeleteOrphan_RepairsDiscoveryRowWhenCanonicalExists(t *tes
 		t.Fatal("expected S3 orphan projection row to be deleted before repair")
 	}
 
-	repairedFirstSeenAt := seedS3Orphan(t, store, orgID, blockID, "cold", db.PlainBlockRepresentationID, "", "", time.Now().UTC())
+	repairedFirstSeenAt := seedS3Orphan(t, store, orgID, blockID, "cold", "", "", time.Now().UTC())
 	if !repairedFirstSeenAt.Equal(firstSeenAt) {
 		t.Fatalf("repaired first_seen_at = %v, want original %v", repairedFirstSeenAt, firstSeenAt)
 	}
@@ -2126,7 +2126,7 @@ func TestGC_DeleteS3Orphan_RemovesDiscoveryRowWithoutCanonical(t *testing.T) {
 	blockID := fmt.Sprintf("orph-cleanup-%d", time.Now().UnixNano())
 	firstSeenAt := time.Now().UTC().Truncate(time.Millisecond)
 
-	effectiveFirstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", db.PlainBlockRepresentationID, "", "seed", firstSeenAt)
+	effectiveFirstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", "", "seed", firstSeenAt)
 	if !gcS3OrphanProjectionExists(t, orgID.String(), blockID, firstSeenAt) {
 		t.Fatal("expected gc_s3_orphans_by_day projection row to exist")
 	}
@@ -2151,11 +2151,11 @@ func TestGC_StartBlockDeleteOrphan_ResetsCurrentLifecycleState(t *testing.T) {
 	blockID := fmt.Sprintf("orph-reset-%d", time.Now().UnixNano())
 	firstSeenAt := time.Now().UTC().Truncate(time.Millisecond)
 
-	effectiveFirstSeenAt := seedS3Orphan(t, store, orgID, blockID, "cold", db.PlainBlockRepresentationID, "sha1-old", "seed", firstSeenAt)
+	effectiveFirstSeenAt := seedS3Orphan(t, store, orgID, blockID, "cold", "sha1-old", "seed", firstSeenAt)
 	if !effectiveFirstSeenAt.Equal(firstSeenAt) {
 		t.Fatalf("effective first_seen_at = %v, want %v", effectiveFirstSeenAt, firstSeenAt)
 	}
-	if err := store.MarkS3OrphanMappingCleanupPending(orgID, blockID, db.PlainBlockRepresentationID, "sha1-old", firstSeenAt.Add(5*time.Minute)); err != nil {
+	if err := store.MarkS3OrphanMappingCleanupPending(orgID, blockID, "sha1-old", firstSeenAt.Add(5*time.Minute)); err != nil {
 		t.Fatalf("MarkS3OrphanMappingCleanupPending: %v", err)
 	}
 	t.Cleanup(func() {
@@ -2164,7 +2164,7 @@ func TestGC_StartBlockDeleteOrphan_ResetsCurrentLifecycleState(t *testing.T) {
 		}
 	})
 
-	resetFirstSeenAt, err := store.StartBlockDeleteOrphan(orgID, blockID, "hot", db.PlainBlockRepresentationID, "sha1-new", time.Now().UTC())
+	resetFirstSeenAt, err := store.StartBlockDeleteOrphan(orgID, blockID, "hot", "sha1-new", time.Now().UTC())
 	if err != nil {
 		t.Fatalf("StartBlockDeleteOrphan: %v", err)
 	}

--- a/internal/integration/gc_s3_deletion_test.go
+++ b/internal/integration/gc_s3_deletion_test.go
@@ -487,7 +487,7 @@ func TestGC_S3OrphanRecovery_DeletesLingeringObject(t *testing.T) {
 		_ = siblingStore.DeleteBlock(ctx, blockID)
 	})
 
-	seedS3Orphan(t, store, orgID, blockID, storageClass, db.PlainBlockRepresentationID, "", "seed: simulated S3 delete failure", time.Now().UTC())
+	seedS3Orphan(t, store, orgID, blockID, storageClass, "", "seed: simulated S3 delete failure", time.Now().UTC())
 	if _, found, err := shareProjectionDBForTest(t).GetBlockS3OrphanInfo(orgID.String(), blockID); err != nil || !found {
 		t.Fatalf("orphan fence not recorded (found=%v err=%v)", found, err)
 	}

--- a/internal/integration/gc_s3_orphan_helpers_test.go
+++ b/internal/integration/gc_s3_orphan_helpers_test.go
@@ -13,10 +13,10 @@ import (
 // seedS3Orphan creates integration state through the production lifecycle
 // entry point. A failed initial delete is represented by the same follow-up
 // mutation the worker uses, rather than by a second row-creating API.
-func seedS3Orphan(t *testing.T, store gcpkg.GCStore, orgID uuid.UUID, blockID, storageClass, representationID, externalSHA1, errMsg string, firstSeenAt time.Time) time.Time {
+func seedS3Orphan(t *testing.T, store gcpkg.GCStore, orgID uuid.UUID, blockID, storageClass, externalSHA1, errMsg string, firstSeenAt time.Time) time.Time {
 	t.Helper()
 	firstSeenAt = firstSeenAt.UTC().Truncate(time.Millisecond)
-	effectiveFirstSeenAt, err := store.StartBlockDeleteOrphan(orgID, blockID, storageClass, representationID, externalSHA1, firstSeenAt)
+	effectiveFirstSeenAt, err := store.StartBlockDeleteOrphan(orgID, blockID, storageClass, externalSHA1, firstSeenAt)
 	if err != nil {
 		t.Fatalf("StartBlockDeleteOrphan: %v", err)
 	}

--- a/internal/integration/gc_s3_orphan_partial_row_test.go
+++ b/internal/integration/gc_s3_orphan_partial_row_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Sesame-Disk/sesamefs/internal/db"
 	gcpkg "github.com/Sesame-Disk/sesamefs/internal/gc"
 	"github.com/google/uuid"
 )
@@ -40,7 +39,7 @@ func TestGC_UpdateS3OrphanAttempt_DoesNotResurrectClearedOrphan(t *testing.T) {
 	firstSeenAt := time.Now().UTC().Truncate(time.Millisecond)
 
 	// Establish a normal orphan through the canonical lifecycle entry point.
-	if _, err := store.StartBlockDeleteOrphan(orgID, blockID, "hot", db.PlainBlockRepresentationID, "", firstSeenAt); err != nil {
+	if _, err := store.StartBlockDeleteOrphan(orgID, blockID, "hot", "", firstSeenAt); err != nil {
 		t.Fatalf("StartBlockDeleteOrphan: %v", err)
 	}
 	t.Cleanup(func() {
@@ -100,13 +99,13 @@ func TestGC_UpdateS3OrphanAttempt_RejectsDifferentLifecycleToken(t *testing.T) {
 	p1FirstSeenAt := time.Now().UTC().Truncate(time.Millisecond)
 	p2FirstSeenAt := p1FirstSeenAt.Add(time.Second)
 
-	if _, err := store.StartBlockDeleteOrphan(orgID, blockID, "hot", db.PlainBlockRepresentationID, "sha1-p1", p1FirstSeenAt); err != nil {
+	if _, err := store.StartBlockDeleteOrphan(orgID, blockID, "hot", "sha1-p1", p1FirstSeenAt); err != nil {
 		t.Fatalf("StartBlockDeleteOrphan P1: %v", err)
 	}
 	if err := store.DeleteS3Orphan(orgID, blockID, p1FirstSeenAt); err != nil {
 		t.Fatalf("DeleteS3Orphan P1: %v", err)
 	}
-	if _, err := store.StartBlockDeleteOrphan(orgID, blockID, "cold", db.PlainBlockRepresentationID, "sha1-p2", p2FirstSeenAt); err != nil {
+	if _, err := store.StartBlockDeleteOrphan(orgID, blockID, "cold", "sha1-p2", p2FirstSeenAt); err != nil {
 		t.Fatalf("StartBlockDeleteOrphan P2: %v", err)
 	}
 	t.Cleanup(func() {
@@ -172,7 +171,7 @@ func TestGC_UpdateS3OrphanAttempt_AnchorsDiagnosticTTLOnFirstSeenAt(t *testing.T
 	blockID := fmt.Sprintf("orph-ttl-anchor-%d", time.Now().UnixNano())
 
 	firstSeenAt := time.Now().UTC().Add(-backdate).Truncate(time.Millisecond)
-	if _, err := store.StartBlockDeleteOrphan(orgID, blockID, "hot", db.PlainBlockRepresentationID, "", firstSeenAt); err != nil {
+	if _, err := store.StartBlockDeleteOrphan(orgID, blockID, "hot", "", firstSeenAt); err != nil {
 		t.Fatalf("StartBlockDeleteOrphan: %v", err)
 	}
 	t.Cleanup(func() {
@@ -245,7 +244,7 @@ func TestGC_UpdateS3OrphanAttemptMatchesEffectiveTTL(t *testing.T) {
 	orgID := uuid.New()
 	blockID := fmt.Sprintf("orph-ttl-effective-%d", time.Now().UnixNano())
 	firstSeenAt := time.Now().UTC().Truncate(time.Millisecond)
-	if _, err := store.StartBlockDeleteOrphan(orgID, blockID, "hot", db.PlainBlockRepresentationID, "", firstSeenAt); err != nil {
+	if _, err := store.StartBlockDeleteOrphan(orgID, blockID, "hot", "", firstSeenAt); err != nil {
 		t.Fatalf("StartBlockDeleteOrphan: %v", err)
 	}
 	t.Cleanup(func() {

--- a/internal/integration/r11b_orphan_representation_surface_guard_test.go
+++ b/internal/integration/r11b_orphan_representation_surface_guard_test.go
@@ -20,8 +20,12 @@ func TestR11bCanonicalOrphanRepresentationSurface(t *testing.T) {
 		".git": true, "frontend": true, "mobile-frontend": true,
 		"node_modules": true, "vendor": true,
 	}
+	// `_` is a word character, so `gc_s3_orphans\b` already cannot match inside
+	// `gc_s3_orphans_by_day` — the same boundary the R22a gate relies on. Skipping
+	// literals that merely mention the projection would therefore buy nothing and
+	// would open an evasion: one literal naming both tables would carry a canonical
+	// violation past the gate.
 	canonicalOrphanTable := regexp.MustCompile(`(?i)\bgc_s3_orphans\b`)
-	projectionTable := regexp.MustCompile(`(?i)\bgc_s3_orphans_by_day\b`)
 
 	scanned := 0
 	err := filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
@@ -48,7 +52,7 @@ func TestR11bCanonicalOrphanRepresentationSurface(t *testing.T) {
 			return nil
 		}
 		for _, query := range stringLiteralsIn(file) {
-			if !canonicalOrphanTable.MatchString(query) || projectionTable.MatchString(query) {
+			if !canonicalOrphanTable.MatchString(query) {
 				continue
 			}
 			if strings.Contains(strings.ToLower(query), "representation_id") {

--- a/internal/integration/r11b_orphan_representation_surface_guard_test.go
+++ b/internal/integration/r11b_orphan_representation_surface_guard_test.go
@@ -1,0 +1,66 @@
+package integration
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestR11bCanonicalOrphanRepresentationSurface keeps representation_id out of
+// the physical GC orphan table while allowing the identifier in blocks, mapping
+// domains, queue state and library metadata. This is intentionally a source
+// gate: the effective Cassandra schema gate lives in the integration suite.
+func TestR11bCanonicalOrphanRepresentationSurface(t *testing.T) {
+	root := filepath.Join("..", "..")
+	skipDirs := map[string]bool{
+		".git": true, "frontend": true, "mobile-frontend": true,
+		"node_modules": true, "vendor": true,
+	}
+	canonicalOrphanTable := regexp.MustCompile(`(?i)\bgc_s3_orphans\b`)
+	projectionTable := regexp.MustCompile(`(?i)\bgc_s3_orphans_by_day\b`)
+
+	scanned := 0
+	err := filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			if skipDirs[info.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		scanned++
+		source, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), path, source, 0)
+		if err != nil {
+			t.Errorf("%s: parse: %v", path, err)
+			return nil
+		}
+		for _, query := range stringLiteralsIn(file) {
+			if !canonicalOrphanTable.MatchString(query) || projectionTable.MatchString(query) {
+				continue
+			}
+			if strings.Contains(strings.ToLower(query), "representation_id") {
+				t.Errorf("%s: canonical gc_s3_orphans statement names representation_id: %s", path, strings.Join(strings.Fields(query), " "))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan production Go sources: %v", err)
+	}
+	if scanned == 0 {
+		t.Fatal("scanned no production Go sources; the gate would pass vacuously")
+	}
+}

--- a/internal/integration/r11b_orphan_schema_test.go
+++ b/internal/integration/r11b_orphan_schema_test.go
@@ -1,0 +1,39 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+)
+
+func TestGC_R11bCanonicalOrphanSchemaOmitsRepresentationID(t *testing.T) {
+	requireCassandra(t)
+
+	keyspace := envOrDefault("CASSANDRA_KEYSPACE", "sesamefs")
+	session := shareProjectionDBForTest(t).Session()
+	iter := session.Query(`
+		SELECT column_name
+		FROM system_schema.columns
+		WHERE keyspace_name = ? AND table_name = ?
+	`, keyspace, "gc_s3_orphans").Iter()
+
+	columns := map[string]bool{}
+	var columnName string
+	for iter.Scan(&columnName) {
+		columns[columnName] = true
+	}
+	if err := iter.Close(); err != nil {
+		t.Fatalf("read effective gc_s3_orphans columns: %v", err)
+	}
+	if len(columns) == 0 {
+		t.Fatal("gc_s3_orphans has no columns in system_schema; the gate would pass vacuously")
+	}
+	if columns["representation_id"] {
+		t.Fatal("gc_s3_orphans still has representation_id after migration 015")
+	}
+	for _, required := range []string{"storage_class", "external_sha1", "recovery_phase", "first_seen_at"} {
+		if !columns[required] {
+			t.Fatalf("gc_s3_orphans is missing required surviving column %q", required)
+		}
+	}
+}

--- a/internal/integration/r22a_orphan_recovery_test.go
+++ b/internal/integration/r22a_orphan_recovery_test.go
@@ -19,7 +19,7 @@ func TestGC_R22aCanonicalReadAndDiscoveryIdentity(t *testing.T) {
 	orgID := uuid.New()
 	blockID := "r22a-canonical-" + uuid.NewString()
 	firstSeenAt := time.Now().UTC().Truncate(time.Millisecond)
-	effectiveFirstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", db.PlainBlockRepresentationID, "sha1-canonical", "seed", firstSeenAt)
+	effectiveFirstSeenAt := seedS3Orphan(t, store, orgID, blockID, "hot", "sha1-canonical", "seed", firstSeenAt)
 	t.Cleanup(func() {
 		if err := store.DeleteS3Orphan(orgID, blockID, effectiveFirstSeenAt); err != nil {
 			t.Errorf("cleanup DeleteS3Orphan: %v", err)
@@ -42,7 +42,7 @@ func TestGC_R22aCanonicalReadAndDiscoveryIdentity(t *testing.T) {
 	if !found {
 		t.Fatal("canonical orphan not found")
 	}
-	if canonical.StorageClass != "hot" || canonical.RepresentationID != db.PlainBlockRepresentationID || canonical.ExternalSHA1 != "sha1-canonical" {
+	if canonical.StorageClass != "hot" || canonical.ExternalSHA1 != "sha1-canonical" {
 		t.Fatalf("canonical orphan state changed unexpectedly: %+v", canonical)
 	}
 

--- a/internal/integration/r22b_projection_schema_test.go
+++ b/internal/integration/r22b_projection_schema_test.go
@@ -80,7 +80,7 @@ func TestGC_R22bProjectionRowIsIdentityOnly(t *testing.T) {
 	blockID := fmt.Sprintf("orph-r22b-identity-%d", time.Now().UnixNano())
 	firstSeenAt := time.Now().UTC().Truncate(time.Millisecond)
 
-	effectiveFirstSeenAt, err := store.StartBlockDeleteOrphan(orgID, blockID, "hot", db.PlainBlockRepresentationID, "sha1-r22b", firstSeenAt)
+	effectiveFirstSeenAt, err := store.StartBlockDeleteOrphan(orgID, blockID, "hot", "sha1-r22b", firstSeenAt)
 	if err != nil {
 		t.Fatalf("StartBlockDeleteOrphan: %v", err)
 	}


### PR DESCRIPTION
## What

Migration `015_gc_s3_orphans_without_representation_id.cql` drops `gc_s3_orphans.representation_id`. The field is removed from `S3OrphanInfo`, `BlockInfo`, both store signatures, both Cassandra statements, and the commit-point equality.

`external_sha1` deliberately stays everywhere. This is the early, separate half of R11b that the R11a fence-characterization PR anticipated: the two fields stopped being one decision once their reachability arguments diverged.

## Why representation_id is prunable and external_sha1 is not

Both lost their mapping-cleanup authority in R11a. What separates them is whether the empty-to-populated backfill can reach the orphan row.

- `external_sha1` **can** be empty there. `RegisterUploadedBlockAndMapping` accepts an empty external SHA-1, so a block first materialized by a SHA-256-addressed upload has `blocks.sha1` empty until a later SHA-1-addressed upload backfills it. That is ordinary greenfield traffic, and `TestWorker_RecoverS3Orphans_BackfilledSHA1ChangeBeforeCommitFailsClosed` pins that recovery fails closed on it.
- `representation_id` **cannot**. The sole production `INSERT INTO blocks` always persists a non-empty value and `ValidateBlockRepresentationID` rejects the empty one. And the orphan row is never written from an incomplete block: both stub paths in `processBlock` return before `StartBlockDeleteOrphan` — one deletes the claimed stub, the other releases the claim and routes the malformed row to the DLQ. Its empty-value repair path exists for imported/legacy rows, which the no-legacy-data policy excludes.

So this prunes the field whose discriminating power was never reachable, and keeps the one whose is.

## Scope

Representation metadata is untouched in `blocks`, `libraries`, `deleted_libraries`, `gc_queue` and the mapping domains. Only the physical orphan recovery subsystem changes. `gc_s3_orphans_by_day` already lost the column in migration 014.

## Gates

- `TestR11bCanonicalOrphanRepresentationSurface` — source gate rejecting `representation_id` in any canonical `gc_s3_orphans` statement. The second commit removes a redundant projection-table exclusion that made the gate evadable: a violation slipped through whenever the same literal also named `gc_s3_orphans_by_day`. Verified in both directions — with the clause gone the clean tree still passes, and the evasive violation fails.
- `TestGC_R11bCanonicalOrphanSchemaOmitsRepresentationID` — effective-schema gate over `system_schema.columns`, asserting the column is absent and the four surviving columns are present, with a vacuity guard. Deliberately not an exact-schema assertion, so it survives adding `backend_id`/`storage_key` later.
- `TestMigration015DropsOnlyGCOrphanRepresentationID` — pins the migration to one statement that names neither `external_sha1` nor `blocks`, so it cannot grow scope silently.

## Deployment

Clean-cut schema change: no pre-R11b-1 binary may remain active once the migration is applied, since it would still name the dropped column. Acceptable for the greenfield rollout and stated in the migration header and CHANGELOG. Destructive GC stays disabled; exact physical identity (`P`) and lifecycle fencing remain open X1/R23 work.

## Testing

`go build ./...`, `go vet`, and `go test` over `gc`, `db`, `integration`, `api`, `api/v2` all green. Verified the surviving discriminator still bites: removing `ExternalSHA1` from `s3OrphanRecoveryStateEqual` turns the characterization test red.

The effective-schema gate is `//go:build integration` and needs Cassandra; it was not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)