### PR TITLE
feat(storage): harden storage_class as the physical namespace identity (R23a, PARTIAL)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -114,10 +114,12 @@ what a rebind onto another cluster's bucket breaks too. Both halves silently
 retarget a persisted identity and neither is prevented; R23b must record a durable
 per-class namespace fingerprint, re-checked fail-closed.
 
-The class/legacy collision check closes a rebind the code could produce by itself:
-a class whose initialization fails is skipped with a warning, after which the legacy
-`backends:` loop registers the same name against a different bucket, so the binding
-depended on whether a transient failure happened at boot.
+The class/legacy collision check closes a rebind the code could produce by itself.
+Before R23a, a class whose initialization failed was skipped with a warning, after
+which the legacy `backends:` loop could register the same name against a different
+bucket, so the binding depended on whether a transient failure happened at boot.
+R23a now rejects the ambiguous configuration and makes initialization failure fatal,
+so the process cannot continue with a partial backend set.
 
 Validation now also covers the fields that REFERENCE a class — `default_class`,
 `failover_class` and `region_classes.*` — because a reference that does not resolve

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -58,12 +58,23 @@ dead `TrimSpace(probe.StorageClass)` copies are gone -- the probe already certif
 what it returns. The two no-manager fallbacks compared a stored identity against a
 trimmed copy of the fallback label; both sides are raw now.
 
+The first writer MINTS a block's physical identity -- `ResolveNeedsPutBlockStore`
+returns the class that gets persisted -- and it was the last normalization left on a
+write path. It now certifies instead of trimming, and does so before the PUT rather
+than leaving it to the write funnel: the object is stored before materialization, so
+a class rejected downstream would leave bytes in S3 that no row points at.
+
 **Not changed, deliberately.** `IsCanonicalStorageClassName` runs on every
 `GetBlockStoreForOrg` call, before the block-store cache lookup. Measured at 163
 ns/op against milliseconds of S3 I/O per block. Moving it behind the cache would
 buy nothing and would weaken unconditional validation at the resolution boundary
 into a cache-miss-only check, which is backwards for the contract this branch
 exists to certify.
+
+**Scope.** R23a is identity *hardening*; it does not prove the class-to-namespace
+binding. See the corrected 2026-08-17 note below and the R23 row in
+`docs/GC-X1-CLOSURE-OPTIONS.md`: both rebind and reuse silently retarget a persisted
+identity, and closing them needs R23b's durable per-class namespace fingerprint.
 
 **Deployment note.** Every class declared under `storage.classes` must now be
 registrable, not only the ones something references. `configs/config.prod.yaml`
@@ -75,21 +86,31 @@ or remove the class the deployment does not use.
 
 ---
 
-## 2026-08-17 - R23a certifies storage class as physical identity
+## 2026-08-17 - R23a hardens storage class as physical identity (PARTIAL)
 
-R23a defines `B = storage_class` under an append-only/non-reuse configuration
-contract. A storage class that has stored objects must never be rebound to another
+R23a adopts `storage_class` as the candidate `B` under an append-only/non-reuse
+configuration contract, and hardens every layer to preserve it exactly. The
+contract itself is asserted by operators, not enforced: see the corrected scope
+note below. A storage class that has stored objects must never be rebound to another
 physical namespace or reused for a different backend; moving data to a new namespace
 requires a new class name. Configuration validation now rejects ambiguous,
 non-canonical storage-class names and collisions between modern classes and legacy
 backend names.
 
-The two halves of the contract differ in how they fail. No-rebind is largely
-self-enforcing: repointing a class that holds objects makes every block in it
-unreadable at once, a loud outage rather than a quiet hazard. No-reuse is silent —
-reviving a decommissioned class name on a fresh bucket breaks nothing visibly while
-any surviving persisted `storage_class` starts resolving to the new namespace. Only
-the second half needs future machinery, and it belongs with R23b.
+**Corrected scope (2026-08-18).** An earlier version of this entry claimed no-rebind
+was largely self-enforcing, because repointing a class that holds objects would make
+every block unreadable at once. That is wrong for the most likely rebind — copy
+bucket A to B, then repoint — where reads keep working and nothing is loud. And
+"the system will probably make noise" is not a safety property in the first place.
+
+What actually makes a migration rebind survivable is narrower: keys are content
+addressed (`blocks/<org_id>/…/<hash>`, no namespace component) and liveness lives in
+Cassandra, so the garbage verdict still describes the same content and a misdirected
+delete removes the same condemned bytes. That holds only while the new namespace
+answers to the same liveness authority — which is exactly what reuse breaks, and
+what a rebind onto another cluster's bucket breaks too. Both halves silently
+retarget a persisted identity and neither is prevented; R23b must record a durable
+per-class namespace fingerprint, re-checked fail-closed.
 
 The class/legacy collision check closes a rebind the code could produce by itself:
 a class whose initialization fails is skipped with a warning, after which the legacy

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,14 +20,16 @@ Change-storage-class, library-creation defaults and bootstrap admission use the
 same raw canonical-name rule as configuration and physical resolution, and the
 bootstrap picker no longer offers a class the manager cannot register. Runtime
 backend failover now detects cycles and returns an error instead of recursing
-forever when every member is unhealthy. The legacy `hot` name remains reserved;
-rejecting a class/backend collision prevents a failed modern initialization from
-rebinding that name.
+forever when every member is unhealthy. The modern-class and legacy-backend
+namespaces may not share a name; rejecting that collision prevents a failed
+modern initialization from rebinding the same identity to a different backend.
 
 The canonical rule also holds at the persistence boundary:
 `UpsertBlockMetadataWithRepresentationAndSHA1` refuses a non-canonical
 `storage_class` as a permanent error, and the reuse probe refuses one it reads
-back.
+back. The provisional-reference tracker and discovery projection now reject an
+empty or non-canonical class before their batch is built, and that permanent
+identity error is not misclassified as retryable.
 
 **Every layer decides on the RAW value.** An audit pass found three places that
 still normalized first, which is how a name certifies at one layer and fails at

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,107 @@ Session-by-session development history for SesameFS.
 
 ---
 
+## 2026-08-18 - R23a validation hardening and raw-identity consistency
+
+Storage-class references now require a class that can actually be registered,
+including a non-empty bucket for modern classes. Literal empty optional references
+remain allowed, while whitespace-only values are rejected. Canonical names no
+longer allow consecutive hyphens, avoiding collisions in the
+`S3_CLASS_<CLASS>_*` environment-variable mapping.
+
+Change-storage-class, library-creation defaults and bootstrap admission use the
+same raw canonical-name rule as configuration and physical resolution, and the
+bootstrap picker no longer offers a class the manager cannot register. Runtime
+backend failover now detects cycles and returns an error instead of recursing
+forever when every member is unhealthy. The legacy `hot` name remains reserved;
+rejecting a class/backend collision prevents a failed modern initialization from
+rebinding that name.
+
+The canonical rule also holds at the persistence boundary:
+`UpsertBlockMetadataWithRepresentationAndSHA1` refuses a non-canonical
+`storage_class` as a permanent error, and the reuse probe refuses one it reads
+back.
+
+**Every layer decides on the RAW value.** An audit pass found three places that
+still normalized first, which is how a name certifies at one layer and fails at
+another.
+
+`resolveFlexibleCreateStorageClass` and `resolveStrictCreateStorageClass` trimmed
+the request before validating, so `" hot-v1 "` was accepted and persisted as
+`hot-v1` while `ChangeStorageClass` refused that same raw value. The asymmetry was
+the defect, not the padding: two doors onto one field disagreeing about what it
+means. Both now admit the raw request, as does `storageClassRegion`, whose only
+caller decides data residency with it.
+
+The upsert validated only its incoming argument. When the `IF NOT EXISTS` insert
+loses, the caller INHERITS the identity already on the row, and
+`ensureBlockIdentityRow` only checked that the stored class was non-empty after a
+trim -- so an upsert carrying a canonical class could return `nil` over a row whose
+stored class `ProbeBlockReuse` and GC would both refuse, finishing an upload whose
+metadata no reader can resolve. It is now checked there as
+`ErrBlockMetadataPermanent`: unlike a claim or a stub, a corrupt label never
+converges, so retrying it is wrong.
+
+Readers resolve the raw stored value throughout. The trims in canonical block
+reading, upload reuse and GC are gone, GC's orphan-recovery state comparison is as
+strict as the resolver it protects, and `loadZeroRefBlockStorageClasses` groups by
+the raw stored value under the canonical check (which subsumes its old empty check)
+instead of enqueueing GC work under a class name that was never persisted. The six
+dead `TrimSpace(probe.StorageClass)` copies are gone -- the probe already certifies
+what it returns. The two no-manager fallbacks compared a stored identity against a
+trimmed copy of the fallback label; both sides are raw now.
+
+**Not changed, deliberately.** `IsCanonicalStorageClassName` runs on every
+`GetBlockStoreForOrg` call, before the block-store cache lookup. Measured at 163
+ns/op against milliseconds of S3 I/O per block. Moving it behind the cache would
+buy nothing and would weaken unconditional validation at the resolution boundary
+into a cache-miss-only check, which is backwards for the contract this branch
+exists to certify.
+
+**Deployment note.** Every class declared under `storage.classes` must now be
+registrable, not only the ones something references. `configs/config.prod.yaml`
+declares `hot-s3-na`, `hot-s3-eu` and `hot-s3-asia` with empty buckets that
+deployment fills through `S3_CLASS_<CLASS>_BUCKET`; a node that provides only
+some of them now refuses to start instead of booting without the missing class
+and failing every request routed to it. Provide a bucket for each declared class,
+or remove the class the deployment does not use.
+
+---
+
+## 2026-08-17 - R23a certifies storage class as physical identity
+
+R23a defines `B = storage_class` under an append-only/non-reuse configuration
+contract. A storage class that has stored objects must never be rebound to another
+physical namespace or reused for a different backend; moving data to a new namespace
+requires a new class name. Configuration validation now rejects ambiguous,
+non-canonical storage-class names and collisions between modern classes and legacy
+backend names.
+
+The two halves of the contract differ in how they fail. No-rebind is largely
+self-enforcing: repointing a class that holds objects makes every block in it
+unreadable at once, a loud outage rather than a quiet hazard. No-reuse is silent —
+reviving a decommissioned class name on a fresh bucket breaks nothing visibly while
+any surviving persisted `storage_class` starts resolving to the new namespace. Only
+the second half needs future machinery, and it belongs with R23b.
+
+The class/legacy collision check closes a rebind the code could produce by itself:
+a class whose initialization fails is skipped with a warning, after which the legacy
+`backends:` loop registers the same name against a different bucket, so the binding
+depended on whether a transient failure happened at boot.
+
+Validation now also covers the fields that REFERENCE a class — `default_class`,
+`failover_class` and `region_classes.*` — because a reference that does not resolve
+is not an identity. `failover_class` motivated this: a typo there is invisible until
+the primary backend is down. `IsCanonicalStorageClassName` is now the single
+definition of the canon, shared by configuration and the storage runtime and applied
+to the raw value, so a name can no longer certify at one layer and fail at the other.
+
+No `backend_id` field, migration, storage-key change, or GC protocol change is
+introduced. R23b will persist the exact `storage_key` and form
+`P = (storage_class, storage_key)`.
+
+---
+
 ## 2026-08-17 - R11b-1 prunes physical orphan representation state
 
 Migration `015_gc_s3_orphans_without_representation_id.cql` removes

--- a/docs/GC-X1-CLOSURE-OPTIONS.md
+++ b/docs/GC-X1-CLOSURE-OPTIONS.md
@@ -56,6 +56,64 @@ finalization, and because an orphan row is a writer fence (`ProbeBlockReuse` ans
 affected content for as long as it lasts. This is a liveness cost, not a reason to
 let the branch clear an unverified canonical state.
 
+**R23a (2026-08-17).** SesameFS certifies `storage_class` itself as the immutable
+backend namespace identity `B`. A class name that has stored objects is append-only:
+it must never be rebound to another bucket, account, provider namespace, or data
+set, and it must never be reused for a different backend. Moving new data to a
+different namespace requires a new class name such as `hot-v2`; failover may select
+another class, but recovery always uses the class persisted with the object and
+does not follow failover. Configuration is treated as a deployed contract, so
+runtime cannot discover a historical rebind. R23a adds canonical-name, reference
+and class/legacy-name collision validation. References must resolve to a class
+that can actually be registered, and runtime failover is cycle-guarded, without
+adding a new identity field or persisting `P`; R23b will persist the exact
+`storage_key` and form
+`P=(storage_class, storage_key)`.
+
+**The contract's two halves have very different risk profiles, and only one needs
+future machinery.** *No-rebind* is largely self-enforcing: repointing a class that
+holds objects makes every block in it unreadable immediately, so it surfaces as a
+total, loud outage of existing content rather than as a quiet GC hazard. *No-reuse*
+is the silent half. Decommission `hot-v1`, remove it from configuration, and create
+a new `hot-v1` on a fresh bucket months later: nothing breaks loudly, because the
+old data was already gone — but any surviving persisted `storage_class` (a
+`gc_s3_orphans` row inside its 90-day TTL, a stale queue item) now resolves to the
+new namespace, and that is exactly where a stale delete lands quietly in the wrong
+bucket. A namespace fingerprint recorded per class and re-checked at boot would
+close the reuse half; it belongs with R23b's persistence decision, not here.
+
+**The collision check closes a rebind the code could produce on its own, with no
+operator action.** A class whose `initStorageClass` fails is skipped with only a
+warning (`internal/api/server.go`), and the legacy `backends:` loop then registers
+any name not already registered. With `classes: hot` and `backends: hot` both
+defined, a boot where the class initializes binds `hot` to the class bucket, and a
+boot where it fails transiently binds the same name to the legacy bucket. Same
+persisted `storage_class`, two physical namespaces, chosen by a transient failure.
+Rejecting the ambiguous configuration at startup is what makes the label usable as
+`B` at all.
+
+**The canon holds at the persistence boundary, not only at admission.** A stored
+`storage_class` is the identity, so the write funnel
+(`UpsertBlockMetadataWithRepresentationAndSHA1`) rejects a non-canonical value as a
+permanent error rather than normalizing it, and `ProbeBlockReuse` rejects one it
+reads back. Readers resolve the raw stored value: the trims that canonical block
+reading, upload reuse and GC used to apply are gone, because trimming resolves a
+label the writer never persisted — a silent rebind performed by the reader. The
+same reasoning removes the trim from GC's orphan-recovery state comparison, which
+must not read two different identities as the same state. Every class declared
+under `storage.classes` must be registrable, not only the referenced ones, so a
+declared-but-unbuildable class cannot be selected as a library default.
+
+**References are part of the identity.** `default_class`, each class's
+`failover_class`, and `region_classes.*` must name a class that actually resolves,
+under the same canon as the declared names — `IsCanonicalStorageClassName` is the
+single definition, shared by configuration validation and the storage runtime, and
+it checks the raw value because runtime resolution is an exact map lookup. The
+previous reference check trimmed before resolving, so a padded value certified at
+startup and failed at use time. `failover_class` is the sharp case: a typo there
+breaks nothing until the primary backend is down, which is precisely when it is
+needed, so startup validation is the only thing that can surface it in time.
+
 **Historical R11a canonical-state characterization (2026-08-17, before R11b-1).**
 The canonical `external_sha1` and `representation_id` fields were no longer used
 for mapping cleanup, but remained auxiliary canonical-state discriminators in the
@@ -1031,7 +1089,7 @@ an active canonical incarnation preserve its key.
 
 | R21 | A second API can create an orphan row, so the orphan cannot be trusted as an authorization certificate | **CLOSED by the R21 authority-surface PR.** `RecordS3Orphan` was removed from `GCStore`, `CassandraStore` and `MockStore`; all fixtures now enter through `StartBlockDeleteOrphan`, and failed-attempt state uses `UpdateS3OrphanAttempt`. The unused exported `DeleteBlockS3Orphan` helper was also removed. An untagged AST/source gate requires no forbidden production identifiers, exactly one production `INSERT INTO gc_s3_orphans`, conditional `UPDATE gc_s3_orphans` statements, and exactly one authorized production callsite in `Worker.processBlock`. This closes provenance of the orphan row only; it does not close X1, physical identity, publication fencing or lifecycle identity. |
 | R22 | Recovery destroys bytes using data read from the discovery projection, without re-reading the canonical orphan row | **Payload-authority half closed by R22a (2026-08-16) and made structural by R22b (2026-08-17); exact-`P` half still open.** The original defect: `RecoverS3Orphans` took its `S3OrphanInfo` straight from `ListS3OrphansByDay` and used those fields — `StorageClass` included — to resolve the backend and issue the delete, never reloading `gc_s3_orphans`, so a stale or diverged projection row could select the wrong backend for a physical delete or skip the physical delete entirely on a stale `pending_mapping_cleanup`. R22a removed the payload from the discovery type outright (`S3OrphanDiscoveryInfo` carries only `org_id`/`block_id`/`first_seen_at`), so the class is now a compile error rather than a rule; **R22b then dropped the four payload columns from `gc_s3_orphans_by_day` itself (migration 014), so the guarantee no longer rests on "no reader consults them" but on the columns not existing** — a re-wire is a Cassandra rejection, not a code review miss; recovery reloads canonical at `EACH_QUORUM` and re-reads it once more immediately before each irreversible action. R11a separately removes physical-GC authority over the logical forward mapping, so `pending_mapping_cleanup` now finalizes only the orphan row. **Still required and not delivered: an exact `P` match.** The correlation token is `first_seen_at`, which `StartBlockDeleteOrphan` reuses across a lifecycle reset, so matching tokens do not imply the same physical lifecycle; and the delete is still issued by logical block id plus storage class, not by an immutable `P=(B,K)`. A missing canonical row fails closed and retains the cursor when encountered, but repairing or dropping that projection entry remains gated on R20 because an ordinary read is not Paxos settlement. A discovery-token mismatch also fails closed and is conservatively deferred, but its identity/lifecycle resolution is not the same negative-authority problem and remains open under R23/R26. |
-| R23 | `storage_class` is rebound to a different bucket, account or backend namespace | **`P` is only an eternal physical identity when its backend namespace identity is immutable.** `storage_class` is a logical label resolved through `m.backends[className]` (`internal/storage/storage.go:493`), and bucket/endpoint for a class come from configuration (`internal/config/config.go:3526,3532`). Rebind `hot-s3-na` from bucket A to bucket B and every persisted `P` silently renames the object it addresses — a months-old orphan would then issue an exact DELETE into a namespace it never verified. Define `B` as an immutable backend identity: a storage-class name may serve as `B` only when it is append-only and never rebound or reused for another namespace; otherwise persist an immutable `backend_id` and define `P = (backend_id, storage_key)`. Credentials and endpoints may change as long as they keep naming the same namespace. **Removing the orphan TTL makes this contract permanent rather than 90-day-bounded.** |
+| R23 | `storage_class` is rebound to a different bucket, account or backend namespace | **R23a certifies `B = storage_class` under an append-only/non-reuse configuration contract.** Canonical storage-class names are validated and class/legacy-name collisions are rejected. A name that has stored objects must never be rebound or reused for another namespace; a new namespace requires a new class name. Recovery does not follow failover and uses the persisted class as `B`. R23a cannot detect an operator rebind after deployment and does not persist `P`; R23b must persist the exact `storage_key` and form `P = (storage_class, storage_key)` before exact-P deletes can be authoritative. **Removing the orphan TTL makes this contract permanent rather than 90-day-bounded.** |
 | R24 | An ambiguous install outcome is reused or cleaned before its status is settled | **The same ABA as X1, produced by the writer's own cleanup instead of by GC.** R9 has the losing writer best-effort delete its key; R17 forbids a stale *repair* from installing. Neither covers a stale **install**: `W2` loses the CAS to `W1`, schedules cleanup of `P2`, and that DELETE is slow; later GC removes `P1` and `blocks(L)` goes absent; a lingering retry of `W2` re-runs `INSERT … IF NOT EXISTS` with `P2`, which now applies — and the old cleanup DELETE lands on live bytes. **Rule: a minted `P` is a single-use installation identity.** A failed install whose outcome is known lost makes `P` burned and cleanup-eligible; an ambiguous outcome makes `P` **install-uncertain**: it is non-retryable, cannot be reused for another install, and is not cleanup-authorized until serial settlement proves it is not canonical. Settlement proving applied moves `P` to canonical; settlement proving another locator won moves `P` to burned and permits exact-key cleanup. If settlement cannot be established, `P` stays install-uncertain and the safe result is a possible X3 leak, not deletion. |
 | R25 | A promote path creates permanent `fs:` references without ever having staged a checked `pub:` | **FIXED structurally** — the published-head repair now stages the `pub:` rows with a fresh attempt ID before finalizing, gated by `TestRepairPublishedSyncCommitBlockDeltaEstablishesHandshakeBeforeFinalizing` and `TestPublishedSyncRepairPartialStageFailureDoesNotFinalize`. Before this fix, `repairPublishedSyncCommitBlockDelta` rebuilt the delta and called `finalizeSyncCommitBlockDelta` directly, bypassing the handshake. The repair now uses the same `StagePublishAttemptReferences` operation as first publication; its rollback is scoped to the fresh repair ID, so a partial repair cannot retract another attempt's liveness. The *primitive* half remains unchanged: `PromotePublishAttemptReferences` does not require a staged row, so a future promote caller can reintroduce the bypass. **R25 was the highest-severity item after R17, and it broke R3's argument as written.** R3 itself remains open: the post-stage canonical-incarnation check does not exist yet. **Reachability, stated precisely rather than as "any retry":** `repairPublishedSyncCommitBlockDelta` first consults `finalizedBlockDeltas`, a per-process two-generation set with 4096 entries per generation (up to 8192 retained pairs) (`sync.go:138-194`), marked only *after* a finalize fully succeeds (`sync.go — finalizeSyncCommitBlockDelta`). A warm same-instance retry therefore short-circuits. The path runs when the retry lands on **another instance**, when **the original finalize failed**, after a process restart, or after eviction. The normal sync path, the auto-merge path, the SeafHTTP path and the v2 path already establish the handshake. **Rule: every known path that can promote permanent `fs:` references must execute Stage before Promote; preservation of the established handshake against concurrent cleanup remains R29/R3.** R3's eventual post-stage check must be added to Stage. |
 | R26 | A stale lifecycle's clear removes another lifecycle's discovery row | **Liveness, not data loss — but under a removed TTL it is permanent.** R22 makes recovery *read* the projection non-authoritatively; nothing yet constrains *writes* to it. `DeleteS3Orphan` clears the canonical row and then deletes the projection by timestamp identity — `first_seen_day`/`bucket`/`first_seen_at`/`org`/`block` (`store_cassandra.go`) — and when the caller passes a zero `firstSeenAt` it *resolves that timestamp from whatever canonical row is current* (`store_cassandra.go`), which may already belong to `P2`. Making only the canonical clear conditional on `P` (B.1) therefore leaves the projection half unbound: a delayed `P1` cleanup can still erase `P2`'s discoverability while `P2`'s canonical orphan correctly keeps fencing the writer. The result is a fence recovery cannot enumerate — R19's failure mode reached by a different route. **Rule: every repair or delete of `_by_day` is scoped to the expected `P`, or `P` becomes part of the projection's identity. Prefer the second.** A conditional `DELETE … IF P = P1` buys a Paxos round on a structure that is explicitly *liveness, never authorization* — the wrong place to spend consensus. Fold `P` into the discovery row's identity instead and the problem disappears by construction: a stale `P1` clear simply cannot name `P2`'s row. That is the same reasoning that makes A+ attractive in the first place — an identity that is never reused beats a check that has to be remembered. `_by_day` is never authorization, but stale lifecycle work must never remove another lifecycle's recovery discoverability. |

--- a/docs/GC-X1-CLOSURE-OPTIONS.md
+++ b/docs/GC-X1-CLOSURE-OPTIONS.md
@@ -56,8 +56,13 @@ finalization, and because an orphan row is a writer fence (`ProbeBlockReuse` ans
 affected content for as long as it lasts. This is a liveness cost, not a reason to
 let the branch clear an unverified canonical state.
 
-**R23a (2026-08-17).** SesameFS certifies `storage_class` itself as the immutable
-backend namespace identity `B`. A class name that has stored objects is append-only:
+**R23a (2026-08-17). PARTIAL — identity hardening, not a proven binding.** SesameFS
+adopts `storage_class` as the candidate backend namespace identity `B` and hardens
+every layer that declares, admits, persists or resolves a class so the value is
+preserved exactly. What R23a does NOT do is bind a class name durably to the
+namespace it was first used with; until R23b does, `B = storage_class` is a
+configuration contract asserted by operators, not a property the system enforces.
+A class name that has stored objects is append-only:
 it must never be rebound to another bucket, account, provider namespace, or data
 set, and it must never be reused for a different backend. Moving new data to a
 different namespace requires a new class name such as `hot-v2`; failover may select
@@ -70,17 +75,38 @@ adding a new identity field or persisting `P`; R23b will persist the exact
 `storage_key` and form
 `P=(storage_class, storage_key)`.
 
-**The contract's two halves have very different risk profiles, and only one needs
-future machinery.** *No-rebind* is largely self-enforcing: repointing a class that
-holds objects makes every block in it unreadable immediately, so it surfaces as a
-total, loud outage of existing content rather than as a quiet GC hazard. *No-reuse*
-is the silent half. Decommission `hot-v1`, remove it from configuration, and create
-a new `hot-v1` on a fresh bucket months later: nothing breaks loudly, because the
-old data was already gone — but any surviving persisted `storage_class` (a
-`gc_s3_orphans` row inside its 90-day TTL, a stale queue item) now resolves to the
-new namespace, and that is exactly where a stale delete lands quietly in the wrong
-bucket. A namespace fingerprint recorded per class and re-checked at boot would
-close the reuse half; it belongs with R23b's persistence decision, not here.
+**Neither half is enforced, and an earlier version of this section justified the
+rebind half with an argument that does not hold.** That argument was: repointing a
+class that holds objects makes every block in it unreadable at once, so a rebind
+surfaces as a loud outage rather than a quiet GC hazard. It fails on the most likely
+shape of a rebind — copy bucket A to bucket B, then repoint `hot-v1` from A to B.
+Reads keep working; nothing is loud. And even where a rebind would break reads,
+"the system will probably make noise" is not a safety property: observability is not
+revocation of authority, and the rule for a destructive path is *when in doubt, do
+not delete*.
+
+**What actually makes a migration rebind survivable is narrower, and worth stating
+because it shows exactly where it stops working.** Storage keys are content
+addressed — `hashToKey` derives `blocks/<org_id>/<h[0:2]>/<h[2:4]>/<hash>` with no
+namespace component — and liveness lives in Cassandra, not in the bucket. So an
+object at key `K` for a given org is byte-identical content in whatever namespace it
+sits, and the garbage verdict that produced a `gc_s3_orphans` row still describes
+that same content after the rebind. A misdirected delete therefore removes the same
+condemned bytes, in the wrong namespace. It is survivable **by accident of key
+derivation, not by design**, and only while the new namespace answers to the same
+liveness authority.
+
+*No-reuse* is where that accident runs out. Decommission `hot-v1`, remove it from
+configuration, and create a new `hot-v1` months later on a bucket holding another
+deployment's data: any surviving persisted `storage_class` (a `gc_s3_orphans` row, a
+stale queue item) now resolves to a namespace governed by a different Cassandra,
+where key `K` can hold live content that no verdict here ever condemned. The same
+exposure exists for a rebind onto a bucket shared with another cluster.
+
+So the two halves do differ in how often they bite, but not in kind: **both silently
+retarget a persisted identity, and neither is prevented.** A namespace fingerprint
+recorded per class and re-checked fail-closed would close both. It belongs with
+R23b, and until it lands `B = storage_class` is asserted rather than certified.
 
 **The collision check closes a rebind the code could produce on its own, with no
 operator action.** A class whose `initStorageClass` fails is skipped with only a
@@ -1089,7 +1115,7 @@ an active canonical incarnation preserve its key.
 
 | R21 | A second API can create an orphan row, so the orphan cannot be trusted as an authorization certificate | **CLOSED by the R21 authority-surface PR.** `RecordS3Orphan` was removed from `GCStore`, `CassandraStore` and `MockStore`; all fixtures now enter through `StartBlockDeleteOrphan`, and failed-attempt state uses `UpdateS3OrphanAttempt`. The unused exported `DeleteBlockS3Orphan` helper was also removed. An untagged AST/source gate requires no forbidden production identifiers, exactly one production `INSERT INTO gc_s3_orphans`, conditional `UPDATE gc_s3_orphans` statements, and exactly one authorized production callsite in `Worker.processBlock`. This closes provenance of the orphan row only; it does not close X1, physical identity, publication fencing or lifecycle identity. |
 | R22 | Recovery destroys bytes using data read from the discovery projection, without re-reading the canonical orphan row | **Payload-authority half closed by R22a (2026-08-16) and made structural by R22b (2026-08-17); exact-`P` half still open.** The original defect: `RecoverS3Orphans` took its `S3OrphanInfo` straight from `ListS3OrphansByDay` and used those fields — `StorageClass` included — to resolve the backend and issue the delete, never reloading `gc_s3_orphans`, so a stale or diverged projection row could select the wrong backend for a physical delete or skip the physical delete entirely on a stale `pending_mapping_cleanup`. R22a removed the payload from the discovery type outright (`S3OrphanDiscoveryInfo` carries only `org_id`/`block_id`/`first_seen_at`), so the class is now a compile error rather than a rule; **R22b then dropped the four payload columns from `gc_s3_orphans_by_day` itself (migration 014), so the guarantee no longer rests on "no reader consults them" but on the columns not existing** — a re-wire is a Cassandra rejection, not a code review miss; recovery reloads canonical at `EACH_QUORUM` and re-reads it once more immediately before each irreversible action. R11a separately removes physical-GC authority over the logical forward mapping, so `pending_mapping_cleanup` now finalizes only the orphan row. **Still required and not delivered: an exact `P` match.** The correlation token is `first_seen_at`, which `StartBlockDeleteOrphan` reuses across a lifecycle reset, so matching tokens do not imply the same physical lifecycle; and the delete is still issued by logical block id plus storage class, not by an immutable `P=(B,K)`. A missing canonical row fails closed and retains the cursor when encountered, but repairing or dropping that projection entry remains gated on R20 because an ordinary read is not Paxos settlement. A discovery-token mismatch also fails closed and is conservatively deferred, but its identity/lifecycle resolution is not the same negative-authority problem and remains open under R23/R26. |
-| R23 | `storage_class` is rebound to a different bucket, account or backend namespace | **R23a certifies `B = storage_class` under an append-only/non-reuse configuration contract.** Canonical storage-class names are validated and class/legacy-name collisions are rejected. A name that has stored objects must never be rebound or reused for another namespace; a new namespace requires a new class name. Recovery does not follow failover and uses the persisted class as `B`. R23a cannot detect an operator rebind after deployment and does not persist `P`; R23b must persist the exact `storage_key` and form `P = (storage_class, storage_key)` before exact-P deletes can be authoritative. **Removing the orphan TTL makes this contract permanent rather than 90-day-bounded.** |
+| R23 | `storage_class` is rebound to a different bucket, account or backend namespace | **PARTIAL — R23a hardens the identity; the binding is still unproven.** R23a adopts `storage_class` as the candidate `B` and makes every layer preserve it exactly: canonical names are validated on the raw value from one shared definition, class/legacy-name collisions are rejected, references must resolve to a registrable class, and recovery uses the persisted class without following failover. What is NOT closed is the binding itself — R23a cannot detect an operator rebind or a reuse after deployment, so `B = storage_class` remains a contract operators assert, not one the system enforces. **Both halves silently retarget a persisted identity.** A migration rebind (copy A→B, then repoint) breaks no reads at all, and is survivable only by accident: keys are content addressed and liveness lives in Cassandra, so a misdirected delete removes the same condemned content — an accident that runs out as soon as the new namespace answers to a different liveness authority, which is exactly the reuse case. R23b must record a durable per-class namespace fingerprint, re-checked fail-closed, and persist the exact `storage_key` to form `P = (storage_class, storage_key)` before exact-P deletes can be authoritative. **Removing the orphan TTL makes this contract permanent rather than 90-day-bounded — which also means a stale identity survives indefinitely.** |
 | R24 | An ambiguous install outcome is reused or cleaned before its status is settled | **The same ABA as X1, produced by the writer's own cleanup instead of by GC.** R9 has the losing writer best-effort delete its key; R17 forbids a stale *repair* from installing. Neither covers a stale **install**: `W2` loses the CAS to `W1`, schedules cleanup of `P2`, and that DELETE is slow; later GC removes `P1` and `blocks(L)` goes absent; a lingering retry of `W2` re-runs `INSERT … IF NOT EXISTS` with `P2`, which now applies — and the old cleanup DELETE lands on live bytes. **Rule: a minted `P` is a single-use installation identity.** A failed install whose outcome is known lost makes `P` burned and cleanup-eligible; an ambiguous outcome makes `P` **install-uncertain**: it is non-retryable, cannot be reused for another install, and is not cleanup-authorized until serial settlement proves it is not canonical. Settlement proving applied moves `P` to canonical; settlement proving another locator won moves `P` to burned and permits exact-key cleanup. If settlement cannot be established, `P` stays install-uncertain and the safe result is a possible X3 leak, not deletion. |
 | R25 | A promote path creates permanent `fs:` references without ever having staged a checked `pub:` | **FIXED structurally** — the published-head repair now stages the `pub:` rows with a fresh attempt ID before finalizing, gated by `TestRepairPublishedSyncCommitBlockDeltaEstablishesHandshakeBeforeFinalizing` and `TestPublishedSyncRepairPartialStageFailureDoesNotFinalize`. Before this fix, `repairPublishedSyncCommitBlockDelta` rebuilt the delta and called `finalizeSyncCommitBlockDelta` directly, bypassing the handshake. The repair now uses the same `StagePublishAttemptReferences` operation as first publication; its rollback is scoped to the fresh repair ID, so a partial repair cannot retract another attempt's liveness. The *primitive* half remains unchanged: `PromotePublishAttemptReferences` does not require a staged row, so a future promote caller can reintroduce the bypass. **R25 was the highest-severity item after R17, and it broke R3's argument as written.** R3 itself remains open: the post-stage canonical-incarnation check does not exist yet. **Reachability, stated precisely rather than as "any retry":** `repairPublishedSyncCommitBlockDelta` first consults `finalizedBlockDeltas`, a per-process two-generation set with 4096 entries per generation (up to 8192 retained pairs) (`sync.go:138-194`), marked only *after* a finalize fully succeeds (`sync.go — finalizeSyncCommitBlockDelta`). A warm same-instance retry therefore short-circuits. The path runs when the retry lands on **another instance**, when **the original finalize failed**, after a process restart, or after eviction. The normal sync path, the auto-merge path, the SeafHTTP path and the v2 path already establish the handshake. **Rule: every known path that can promote permanent `fs:` references must execute Stage before Promote; preservation of the established handshake against concurrent cleanup remains R29/R3.** R3's eventual post-stage check must be added to Stage. |
 | R26 | A stale lifecycle's clear removes another lifecycle's discovery row | **Liveness, not data loss — but under a removed TTL it is permanent.** R22 makes recovery *read* the projection non-authoritatively; nothing yet constrains *writes* to it. `DeleteS3Orphan` clears the canonical row and then deletes the projection by timestamp identity — `first_seen_day`/`bucket`/`first_seen_at`/`org`/`block` (`store_cassandra.go`) — and when the caller passes a zero `firstSeenAt` it *resolves that timestamp from whatever canonical row is current* (`store_cassandra.go`), which may already belong to `P2`. Making only the canonical clear conditional on `P` (B.1) therefore leaves the projection half unbound: a delayed `P1` cleanup can still erase `P2`'s discoverability while `P2`'s canonical orphan correctly keeps fencing the writer. The result is a fence recovery cannot enumerate — R19's failure mode reached by a different route. **Rule: every repair or delete of `_by_day` is scoped to the expected `P`, or `P` becomes part of the projection's identity. Prefer the second.** A conditional `DELETE … IF P = P1` buys a Paxos round on a structure that is explicitly *liveness, never authorization* — the wrong place to spend consensus. Fold `P` into the discovery row's identity instead and the problem disappears by construction: a stale `P1` clear simply cannot name `P2`'s row. That is the same reasoning that makes A+ attractive in the first place — an identity that is never reused beats a check that has to be remembered. `_by_day` is never authorization, but stale lifecycle work must never remove another lifecycle's recovery discoverability. |

--- a/docs/GC-X1-CLOSURE-OPTIONS.md
+++ b/docs/GC-X1-CLOSURE-OPTIONS.md
@@ -109,14 +109,15 @@ recorded per class and re-checked fail-closed would close both. It belongs with
 R23b, and until it lands `B = storage_class` is asserted rather than certified.
 
 **The collision check closes a rebind the code could produce on its own, with no
-operator action.** A class whose `initStorageClass` fails is skipped with only a
-warning (`internal/api/server.go`), and the legacy `backends:` loop then registers
-any name not already registered. With `classes: hot` and `backends: hot` both
-defined, a boot where the class initializes binds `hot` to the class bucket, and a
-boot where it fails transiently binds the same name to the legacy bucket. Same
-persisted `storage_class`, two physical namespaces, chosen by a transient failure.
-Rejecting the ambiguous configuration at startup is what makes the label usable as
-`B` at all.
+operator action.** Before R23a, a class whose `initStorageClass` failed was skipped
+with only a warning (`internal/api/server.go`), and the legacy `backends:` loop then
+registered any name not already registered. With `classes: hot` and `backends: hot`
+both defined, a boot where the class initialized bound `hot` to the class bucket,
+and a boot where it failed transiently bound the same name to the legacy bucket.
+Same persisted `storage_class`, two physical namespaces, chosen by a transient
+failure. R23a rejects the ambiguous configuration and now aborts startup when a
+declared class fails to initialize, so the manager cannot silently continue with a
+partial backend set.
 
 **The canon holds at the persistence boundary, not only at admission.** A stored
 `storage_class` is the identity, so the write funnel

--- a/internal/api/bootstrap.go
+++ b/internal/api/bootstrap.go
@@ -296,6 +296,10 @@ func (s *Server) isBootstrapKnownStorageClass(storageClass string) bool {
 	if s == nil || s.config == nil || !config.IsCanonicalStorageClassName(storageClass) {
 		return false
 	}
+	if s.storageManager != nil {
+		_, registered := s.storageManager.GetBackend(storageClass)
+		return registered
+	}
 	return s.config.IsConfiguredStorageClass(storageClass)
 }
 

--- a/internal/api/bootstrap.go
+++ b/internal/api/bootstrap.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Sesame-Disk/sesamefs/internal/config"
 	"github.com/Sesame-Disk/sesamefs/internal/httputil"
 	"github.com/Sesame-Disk/sesamefs/internal/middleware"
 	"github.com/Sesame-Disk/sesamefs/internal/plans"
@@ -292,17 +293,10 @@ func (s *Server) resolveBootstrapDefaultStorageClass(hostname string) string {
 }
 
 func (s *Server) isBootstrapKnownStorageClass(storageClass string) bool {
-	storageClass = strings.TrimSpace(storageClass)
-	if storageClass == "" || s == nil || s.config == nil {
+	if s == nil || s.config == nil || !config.IsCanonicalStorageClassName(storageClass) {
 		return false
 	}
-	if _, ok := s.config.Storage.Classes[storageClass]; ok {
-		return true
-	}
-	if _, ok := s.config.Storage.Backends[storageClass]; ok {
-		return true
-	}
-	return false
+	return s.config.IsConfiguredStorageClass(storageClass)
 }
 
 func (s *Server) buildBootstrapStorageOptions(hostname string) []gin.H {
@@ -314,8 +308,7 @@ func (s *Server) buildBootstrapStorageOptions(hostname string) []gin.H {
 	options := make([]gin.H, 0)
 	seen := make(map[string]struct{})
 	appendOption := func(id, name string) {
-		id = strings.TrimSpace(id)
-		if id == "" {
+		if !s.isBootstrapKnownStorageClass(id) {
 			return
 		}
 		if _, ok := seen[id]; ok {

--- a/internal/api/bootstrap_test.go
+++ b/internal/api/bootstrap_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Sesame-Disk/sesamefs/internal/config"
+	"github.com/Sesame-Disk/sesamefs/internal/storage"
 	"github.com/gin-gonic/gin"
 )
 
@@ -465,6 +466,28 @@ func TestResolveBootstrapDefaultStorageClassUsesDeterministicSortedFallback(t *t
 
 	if got := s.resolveBootstrapDefaultStorageClass("unknown.example.com"); got != "hot-alpha" {
 		t.Fatalf("resolveBootstrapDefaultStorageClass = %q, want %q", got, "hot-alpha")
+	}
+}
+
+func TestBuildBootstrapStorageOptionsUsesRegisteredBackends(t *testing.T) {
+	s := createTestServer()
+	s.config.Storage.DefaultClass = "hot-broken"
+	s.config.Storage.Classes = map[string]config.StorageClassConfig{
+		"hot-broken": {Bucket: "broken"},
+		"hot-good":   {Bucket: "good"},
+	}
+	s.config.Storage.Backends = map[string]config.BackendConfig{}
+	s.storageManager = storage.NewManager()
+	s.storageManager.RegisterBackend("hot-good", &storage.S3Store{}, "")
+
+	options := s.buildBootstrapStorageOptions("unknown.example.com")
+	for _, option := range options {
+		if option["id"] == "hot-broken" {
+			t.Fatalf("bootstrap advertised an unregistered storage class: %v", options)
+		}
+	}
+	if len(options) != 1 || options[0]["id"] != "hot-good" {
+		t.Fatalf("bootstrap options = %v, want only hot-good", options)
 	}
 }
 

--- a/internal/api/bootstrap_test.go
+++ b/internal/api/bootstrap_test.go
@@ -295,8 +295,8 @@ func TestBuildBootstrapStorageOptionsUsesRegionLabelsAndDefault(t *testing.T) {
 		"eu":  {Hot: "hot-eu"},
 	}
 	s.config.Storage.Classes = map[string]config.StorageClassConfig{
-		"hot-usa": {},
-		"hot-eu":  {},
+		"hot-usa": {Bucket: "usa"},
+		"hot-eu":  {Bucket: "eu"},
 	}
 	s.config.Storage.Backends = map[string]config.BackendConfig{}
 
@@ -337,8 +337,8 @@ func TestBuildBootstrapStorageOptionsUsesConfiguredClassLabels(t *testing.T) {
 		"eu": {Hot: "hot-eu"},
 	}
 	s.config.Storage.Classes = map[string]config.StorageClassConfig{
-		"hot-na": {Label: "North America"},
-		"hot-eu": {Label: "Europe"},
+		"hot-na": {Label: "North America", Bucket: "na"},
+		"hot-eu": {Label: "Europe", Bucket: "eu"},
 	}
 	s.config.Storage.Backends = map[string]config.BackendConfig{}
 
@@ -364,8 +364,8 @@ func TestBuildBootstrapStorageOptionsUsesConfiguredClassLabelsWithoutRegionClass
 	s.config.Storage.EndpointRegions = map[string]string{}
 	s.config.Storage.RegionClasses = map[string]config.RegionClassConfig{}
 	s.config.Storage.Classes = map[string]config.StorageClassConfig{
-		"archive-hot": {Label: "Archive Storage"},
-		"hot-zeta":    {},
+		"archive-hot": {Label: "Archive Storage", Bucket: "archive"},
+		"hot-zeta":    {Bucket: "zeta"},
 	}
 	s.config.Storage.Backends = map[string]config.BackendConfig{}
 
@@ -394,8 +394,8 @@ func TestBuildBootstrapStorageOptionsFallsBackToServerRegion(t *testing.T) {
 		"eu":  {Hot: "hot-eu"},
 	}
 	s.config.Storage.Classes = map[string]config.StorageClassConfig{
-		"hot-usa": {},
-		"hot-eu":  {},
+		"hot-usa": {Bucket: "usa"},
+		"hot-eu":  {Bucket: "eu"},
 	}
 	s.config.Storage.Backends = map[string]config.BackendConfig{}
 
@@ -425,8 +425,8 @@ func TestBuildBootstrapStorageOptionsWildcardRoutingOverridesServerRegion(t *tes
 		"eu":  {Hot: "hot-eu"},
 	}
 	s.config.Storage.Classes = map[string]config.StorageClassConfig{
-		"hot-usa": {},
-		"hot-eu":  {},
+		"hot-usa": {Bucket: "usa"},
+		"hot-eu":  {Bucket: "eu"},
 	}
 	s.config.Storage.Backends = map[string]config.BackendConfig{}
 
@@ -458,8 +458,8 @@ func TestResolveBootstrapDefaultStorageClassUsesDeterministicSortedFallback(t *t
 	s := createTestServer()
 	s.config.Storage.DefaultClass = "missing"
 	s.config.Storage.Classes = map[string]config.StorageClassConfig{
-		"hot-zeta":  {},
-		"hot-alpha": {},
+		"hot-zeta":  {Bucket: "zeta"},
+		"hot-alpha": {Bucket: "alpha"},
 	}
 	s.config.Storage.Backends = map[string]config.BackendConfig{}
 

--- a/internal/api/seafhttp.go
+++ b/internal/api/seafhttp.go
@@ -1784,7 +1784,10 @@ func (h *SeafHTTPHandler) resolveLibraryBlockStore(hostname, orgID, repoID strin
 func (h *SeafHTTPHandler) resolveLibraryBlockStoreContext(ctx context.Context, hostname, orgID, repoID string) (*storage.BlockStore, string, error) {
 	libraryClass := h.lookupLibraryStorageClassContext(ctx, orgID, repoID)
 	if h.storageManager != nil {
-		preferredClass := h.storageManager.ResolveStorageClass(hostname, libraryClass, "hot")
+		preferredClass, err := h.storageManager.ResolveStorageClass(hostname, libraryClass, "hot")
+		if err != nil {
+			return nil, libraryClass, err
+		}
 		return h.storageManager.GetHealthyBlockStoreForOrg(orgID, preferredClass)
 	}
 	// Fallback: org-scoped store from the raw S3 store; never the org-less singleton.

--- a/internal/api/seafhttp.go
+++ b/internal/api/seafhttp.go
@@ -2503,7 +2503,7 @@ func (h *SeafHTTPHandler) HandleUpload(c *gin.Context) {
 		}
 		switch probe.Decision {
 		case db.BlockReuseReusable:
-			materializedStorageClass = strings.TrimSpace(probe.StorageClass)
+			materializedStorageClass = probe.StorageClass
 			_, ensureErr := ensureReusableBlockPresentForUploadFn(ctx, sha256ID, probe, storedContent, h.storageManager, blockStore, actualStorageClass, token.OrgID)
 			if ensureErr != nil {
 				return ensureErr
@@ -3014,7 +3014,7 @@ readLoop:
 					}
 					switch probe.Decision {
 					case db.BlockReuseReusable:
-						materializedStorageClass = strings.TrimSpace(probe.StorageClass)
+						materializedStorageClass = probe.StorageClass
 						_, ensureErr := ensureReusableBlockPresentForUploadFn(egCtx, sha256ID, probe, storedBlock, h.storageManager, blockStore, actualStorageClass, token.OrgID)
 						return ensureErr
 					case db.BlockReuseNeedsPut:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -420,8 +420,7 @@ func initStorageManager(cfg *config.Config) *storage.Manager {
 	for className, classCfg := range cfg.Storage.Classes {
 		s3Store, err := initStorageClass(className, classCfg)
 		if err != nil {
-			slog.Warn("Failed to initialize storage class", "class", className, "error", err)
-			continue
+			panic(fmt.Errorf("initialize storage class %q: %w", className, err))
 		}
 		manager.RegisterBackend(className, s3Store, classCfg.FailoverClass)
 		slog.Info("Registered storage class", "class", className, "type", classCfg.Type, "tier", classCfg.Tier, "bucket", classCfg.Bucket)
@@ -453,8 +452,7 @@ func initStorageManager(cfg *config.Config) *storage.Manager {
 		}
 		s3Store, err := initStorageClass(name, classCfg)
 		if err != nil {
-			slog.Warn("Failed to initialize legacy storage backend", "backend", name, "error", err)
-			continue
+			panic(fmt.Errorf("initialize legacy storage backend %q: %w", name, err))
 		}
 		manager.RegisterBackend(name, s3Store, "")
 		slog.Info("Registered legacy storage backend", "backend", name, "bucket", backendCfg.Bucket)

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -25,7 +25,10 @@ func (c *storageManagerHealthChecker) HeadBucket(ctx context.Context) error {
 		return fmt.Errorf("storage manager not configured")
 	}
 
-	preferredClass := c.manager.ResolveStorageClass("", "", "hot")
+	preferredClass, err := c.manager.ResolveStorageClass("", "", "hot")
+	if err != nil {
+		return err
+	}
 	backend, actualClass, err := c.manager.GetHealthyBackend(preferredClass)
 	if err != nil {
 		return err

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -220,6 +220,21 @@ func TestInitStorageManagerSkipsEmptyLegacyHotBackend(t *testing.T) {
 	}
 }
 
+func TestInitStorageManagerPanicsWhenConfiguredClassFails(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Storage.Classes = map[string]config.StorageClassConfig{
+		"hot-broken": {Type: "s3"},
+	}
+	cfg.Storage.Backends = nil
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("initStorageManager did not panic for a configured class that failed to initialize")
+		}
+	}()
+	initStorageManager(cfg)
+}
+
 func TestInitStorageClassUsesResolvedConfigBucketAndCredentials(t *testing.T) {
 	store, err := initStorageClass("hot-s3-na", config.StorageClassConfig{
 		Type:      "s3",

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -340,7 +340,7 @@ var lookupLibraryStorageClassForSyncFn = func(h *SyncHandler, orgID, repoID stri
 	return h.lookupLibraryStorageClass(orgID, repoID)
 }
 
-func (h *SyncHandler) resolvePreferredLibraryStorageClass(c *gin.Context, orgID, repoID string) string {
+func (h *SyncHandler) resolvePreferredLibraryStorageClass(c *gin.Context, orgID, repoID string) (string, error) {
 	libraryClass := lookupLibraryStorageClassForSyncFn(h, orgID, repoID)
 	if h.storageManager != nil {
 		configuredURL := ""
@@ -350,20 +350,23 @@ func (h *SyncHandler) resolvePreferredLibraryStorageClass(c *gin.Context, orgID,
 		return h.storageManager.ResolveStorageClass(httputil.GetRoutingHostname(c, configuredURL), libraryClass, "hot")
 	}
 	if libraryClass != "" {
-		return libraryClass
+		return libraryClass, nil
 	}
-	return "hot"
+	return "hot", nil
 }
 
-func (h *SyncHandler) resolveBlockLookupFallbackClass(c *gin.Context, orgID, repoID, storageClass string) string {
-	preferredClass := h.resolvePreferredLibraryStorageClass(c, orgID, repoID)
+func (h *SyncHandler) resolveBlockLookupFallbackClass(c *gin.Context, orgID, repoID, storageClass string) (string, error) {
+	preferredClass, err := h.resolvePreferredLibraryStorageClass(c, orgID, repoID)
+	if err != nil {
+		return "", err
+	}
 	if preferredClass != "" {
-		return preferredClass
+		return preferredClass, nil
 	}
 	if storageClass != "" {
-		return storageClass
+		return storageClass, nil
 	}
-	return "hot"
+	return "hot", nil
 }
 
 func (h *SyncHandler) resolveBlockStoreForLookup(c *gin.Context, orgID, repoID, storageClass string) (*storage.BlockStore, string, error) {
@@ -378,7 +381,10 @@ func (h *SyncHandler) resolveBlockStoreForLookup(c *gin.Context, orgID, repoID, 
 			log.Printf("resolveBlockStoreForLookup: storage class %s unavailable: %v", storageClass, err)
 		}
 
-		fallbackClass := h.resolveBlockLookupFallbackClass(c, orgID, repoID, storageClass)
+		fallbackClass, err := h.resolveBlockLookupFallbackClass(c, orgID, repoID, storageClass)
+		if err != nil {
+			return nil, fallbackClass, err
+		}
 		blockStore, actualClass, err := h.storageManager.GetHealthyBlockStoreForOrg(orgID, fallbackClass)
 		if err != nil {
 			return nil, fallbackClass, err
@@ -399,7 +405,10 @@ func (h *SyncHandler) resolveBlockStoreForLookup(c *gin.Context, orgID, repoID, 
 }
 
 func (h *SyncHandler) resolvePreferredBlockStore(c *gin.Context, orgID, repoID string) (*storage.BlockStore, string, error) {
-	preferredClass := h.resolvePreferredLibraryStorageClass(c, orgID, repoID)
+	preferredClass, err := h.resolvePreferredLibraryStorageClass(c, orgID, repoID)
+	if err != nil {
+		return nil, preferredClass, err
+	}
 	if h.storageManager != nil {
 		return h.storageManager.GetHealthyBlockStoreForOrg(orgID, preferredClass)
 	}
@@ -1349,7 +1358,12 @@ func (h *SyncHandler) GetBlock(c *gin.Context) {
 		}
 	} else {
 		// Preserve the legacy no-metadata routed fallback.
-		storageClass := h.resolveBlockLookupFallbackClass(c, orgID, repoID, "")
+		storageClass, resolveErr := h.resolveBlockLookupFallbackClass(c, orgID, repoID, "")
+		if resolveErr != nil {
+			lifecycle.ReleasePreparationError(resolveErr)
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "block storage not available"})
+			return
+		}
 		blockStore, _, resolveErr := h.resolveBlockStoreForLookup(c, orgID, repoID, storageClass)
 		if resolveErr != nil || blockStore == nil {
 			lifecycle.ReleasePreparationError(resolveErr)

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -356,11 +356,10 @@ func (h *SyncHandler) resolvePreferredLibraryStorageClass(c *gin.Context, orgID,
 }
 
 func (h *SyncHandler) resolveBlockLookupFallbackClass(c *gin.Context, orgID, repoID, storageClass string) string {
-	preferredClass := strings.TrimSpace(h.resolvePreferredLibraryStorageClass(c, orgID, repoID))
+	preferredClass := h.resolvePreferredLibraryStorageClass(c, orgID, repoID)
 	if preferredClass != "" {
 		return preferredClass
 	}
-	storageClass = strings.TrimSpace(storageClass)
 	if storageClass != "" {
 		return storageClass
 	}
@@ -368,7 +367,8 @@ func (h *SyncHandler) resolveBlockLookupFallbackClass(c *gin.Context, orgID, rep
 }
 
 func (h *SyncHandler) resolveBlockStoreForLookup(c *gin.Context, orgID, repoID, storageClass string) (*storage.BlockStore, string, error) {
-	storageClass = strings.TrimSpace(storageClass)
+	// Raw: the manager resolves the exact label, and a trimmed copy of it would
+	// select a namespace under a name nothing ever stored.
 	if h.storageManager != nil {
 		if storageClass != "" {
 			blockStore, err := h.storageManager.GetBlockStoreForOrg(orgID, storageClass)
@@ -2005,7 +2005,7 @@ func (h *SyncHandler) PutBlock(c *gin.Context) {
 			}
 			switch probe.Decision {
 			case db.BlockReuseReusable:
-				materializedStorageClass = strings.TrimSpace(probe.StorageClass)
+				materializedStorageClass = probe.StorageClass
 				_, ensureErr := syncEnsureReusableBlockPresentFn(c.Request.Context(), internalID, probe, data, h.storageManager, blockStore, storageClass, orgID)
 				return ensureErr
 			case db.BlockReuseNeedsPut:

--- a/internal/api/sync_test.go
+++ b/internal/api/sync_test.go
@@ -265,13 +265,18 @@ func TestResolvePreferredLibraryStorageClassUsesEndpointRouting(t *testing.T) {
 	manager.SetRegionClasses(map[string]storage.RegionClassConfig{
 		"eu": {Hot: "hot-s3-eu"},
 	})
+	manager.RegisterBackend("hot-s3-eu", &storage.S3Store{}, "")
 	h := &SyncHandler{storageManager: manager}
 
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 	c.Request = httptest.NewRequest(http.MethodPost, "/seafhttp/repo/repo-id/block/block-id", nil)
 	c.Request.Host = "eu.sesamefs.local"
 
-	if got := h.resolvePreferredLibraryStorageClass(c, "org-id", "repo-id"); got != "hot-s3-eu" {
+	got, err := h.resolvePreferredLibraryStorageClass(c, "org-id", "repo-id")
+	if err != nil {
+		t.Fatalf("resolvePreferredLibraryStorageClass returned error: %v", err)
+	}
+	if got != "hot-s3-eu" {
 		t.Fatalf("resolvePreferredLibraryStorageClass = %q, want %q", got, "hot-s3-eu")
 	}
 }
@@ -283,13 +288,18 @@ func TestResolveBlockLookupFallbackClassUsesLibraryPreference(t *testing.T) {
 	manager.SetRegionClasses(map[string]storage.RegionClassConfig{
 		"eu": {Hot: "hot-s3-eu"},
 	})
+	manager.RegisterBackend("hot-s3-eu", &storage.S3Store{}, "")
 	h := &SyncHandler{storageManager: manager}
 
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 	c.Request = httptest.NewRequest(http.MethodGet, "/seafhttp/repo/repo-id/block/block-id", nil)
 	c.Request.Host = "eu.sesamefs.local"
 
-	if got := h.resolveBlockLookupFallbackClass(c, "org-id", "repo-id", "missing-class"); got != "hot-s3-eu" {
+	got, err := h.resolveBlockLookupFallbackClass(c, "org-id", "repo-id", "missing-class")
+	if err != nil {
+		t.Fatalf("resolveBlockLookupFallbackClass returned error: %v", err)
+	}
+	if got != "hot-s3-eu" {
 		t.Fatalf("resolveBlockLookupFallbackClass = %q, want %q", got, "hot-s3-eu")
 	}
 }

--- a/internal/api/v2/batch_operations.go
+++ b/internal/api/v2/batch_operations.go
@@ -178,9 +178,12 @@ func loadZeroRefBlockStorageClasses(database *db.DB, orgID string, blockIDs []st
 			loadErr = errors.Join(loadErr, fmt.Errorf("load storage class for block %s: %w", blockID, err))
 			continue
 		}
-		storageClass = strings.TrimSpace(storageClass)
-		if storageClass == "" {
-			loadErr = errors.Join(loadErr, fmt.Errorf("load storage class for block %s: empty canonical storage class", blockID))
+		// R23a: this reads the persisted physical identity straight from `blocks`,
+		// so it groups by the RAW stored value. Trimming would enqueue the block
+		// under a class name that was never persisted, and GC resolves the stored
+		// one. The canonical check subsumes the empty case.
+		if !config.IsCanonicalStorageClassName(storageClass) {
+			loadErr = errors.Join(loadErr, fmt.Errorf("load storage class for block %s: non-canonical storage class %q", blockID, storageClass))
 			continue
 		}
 		grouped[storageClass] = append(grouped[storageClass], blockID)

--- a/internal/api/v2/blocks.go
+++ b/internal/api/v2/blocks.go
@@ -214,7 +214,11 @@ func (h *BlockHandler) getBlockStore(c *gin.Context) (*storage.BlockStore, strin
 
 	// Resolve storage class based on hostname
 	hostname := routingHostname(c, h.config)
-	storageClass := h.storageManager.ResolveStorageClass(hostname, "", "hot")
+	storageClass, err := h.storageManager.ResolveStorageClass(hostname, "", "hot")
+	if err != nil {
+		log.Printf("v2/blocks: failed to resolve storage class: %v\n", err)
+		return nil, storageClass
+	}
 
 	// Get healthy org-scoped BlockStore with failover
 	blockStore, actualClass, err := h.storageManager.GetHealthyBlockStoreForOrg(orgID, storageClass)
@@ -270,7 +274,11 @@ func (h *BlockHandler) getBlockStoreForRepo(c *gin.Context, orgID, repoID string
 		return bs, "legacy"
 	}
 	libraryClass := h.lookupLibraryStorageClass(orgID, repoID)
-	preferred := h.storageManager.ResolveStorageClass(routingHostname(c, h.config), libraryClass, "hot")
+	preferred, err := h.storageManager.ResolveStorageClass(routingHostname(c, h.config), libraryClass, "hot")
+	if err != nil {
+		log.Printf("v2/blocks: failed to resolve storage class for repo %s: %v\n", repoID, err)
+		return nil, preferred
+	}
 	blockStore, actualClass, err := h.storageManager.GetHealthyBlockStoreForOrg(orgID, preferred)
 	if err != nil {
 		log.Printf("v2/blocks: failed to get healthy backend for repo %s (%s): %v\n", repoID, preferred, err)

--- a/internal/api/v2/blocks_test.go
+++ b/internal/api/v2/blocks_test.go
@@ -660,8 +660,8 @@ func TestGetBlockStoreDoesNotFallBackToLegacyWhenStorageManagerFails(t *testing.
 	if blockStore != nil {
 		t.Fatal("expected nil blockStore when storage manager cannot resolve a healthy backend")
 	}
-	if storageClass != "hot-s3-eu" {
-		t.Fatalf("storageClass = %q, want %q", storageClass, "hot-s3-eu")
+	if storageClass != "" {
+		t.Fatalf("storageClass = %q, want empty on resolution error", storageClass)
 	}
 }
 

--- a/internal/api/v2/files.go
+++ b/internal/api/v2/files.go
@@ -351,7 +351,10 @@ func (h *FileHandler) lookupLibraryStorageClass(orgID, repoID string) string {
 func (h *FileHandler) resolveLibraryBlockStore(c *gin.Context, orgID, repoID string) (*storage.BlockStore, string, error) {
 	libraryClass := h.lookupLibraryStorageClass(orgID, repoID)
 	if h.storageManager != nil {
-		preferredClass := h.storageManager.ResolveStorageClass(routingHostname(c, h.config), libraryClass, "hot")
+		preferredClass, err := h.storageManager.ResolveStorageClass(routingHostname(c, h.config), libraryClass, "hot")
+		if err != nil {
+			return nil, libraryClass, err
+		}
 		return h.storageManager.GetHealthyBlockStoreForOrg(orgID, preferredClass)
 	}
 

--- a/internal/api/v2/files.go
+++ b/internal/api/v2/files.go
@@ -1353,7 +1353,7 @@ func (h *FileHandler) CreateFile(c *gin.Context) {
 				}
 				switch probe.Decision {
 				case db.BlockReuseReusable:
-					templateMaterializedStorageClass = strings.TrimSpace(probe.StorageClass)
+					templateMaterializedStorageClass = probe.StorageClass
 					if _, ensureErr := EnsureReusableBlockPresent(c.Request.Context(), templateBlockData.Hash, probe, templateBlockData.Data, h.storageManager, templateBlockStore, templateStorageClass, orgID); ensureErr != nil {
 						return fmt.Errorf("failed to verify reusable template block: %w", ensureErr)
 					}
@@ -3447,7 +3447,7 @@ func (h *FileHandler) UploadFile(c *gin.Context) {
 		}
 		switch probe.Decision {
 		case db.BlockReuseReusable:
-			materializedStorageClass = strings.TrimSpace(probe.StorageClass)
+			materializedStorageClass = probe.StorageClass
 			_, ensureErr := EnsureReusableBlockPresent(c.Request.Context(), sha256ID, probe, storedContent, h.storageManager, blockStore, storageClass, orgID)
 			return ensureErr
 		case db.BlockReuseNeedsPut:

--- a/internal/api/v2/fs_helpers.go
+++ b/internal/api/v2/fs_helpers.go
@@ -976,7 +976,8 @@ func (h *FSHelper) ResolveStoredBlockIDs(orgID, libraryID string, blockIDs []str
 // The provisional reference and its GC expiry tracking are written in a single
 // logged batch (F10). They used to be two writes with a compensating rollback on
 // the second one's failure; a batch removes the split state instead of cleaning up
-// after it, so every failure here is simply retryable.
+// after it, so storage/database I/O failures here are retryable while permanent
+// identity failures are returned without a retry tag.
 //
 // Cassandra I/O in this helper is transient and tagged ErrBlockMaterializationTransient
 // so the wrapper retries it inside its bounded budget instead of failing on the
@@ -990,6 +991,9 @@ func (h *FSHelper) RegisterUploadedBlock(orgID, libraryID, blockID, operationID 
 		// One logged batch: the reference and its GC tracking either both landed or
 		// neither did, so there is no half-written state to compensate for and a
 		// plain transient retry is safe.
+		if errors.Is(err, db.ErrBlockMetadataPermanent) {
+			return fmt.Errorf("add provisional block reference for %s: %w", blockID, err)
+		}
 		return fmt.Errorf("%w: add provisional block reference for %s: %w", ErrBlockMaterializationTransient, blockID, err)
 	}
 

--- a/internal/api/v2/fs_helpers_test.go
+++ b/internal/api/v2/fs_helpers_test.go
@@ -296,6 +296,31 @@ func TestRegisterUploadedBlock_ReturnsPermanentMetadataFailureUntagged(t *testin
 	}
 }
 
+func TestRegisterUploadedBlockReturnsPermanentProvisionalStorageClassFailureUntagged(t *testing.T) {
+	oldAdd := registerUploadedBlockAddProvisionalRefFn
+	oldFence := registerUploadedBlockFenceActiveFn
+	t.Cleanup(func() {
+		registerUploadedBlockAddProvisionalRefFn = oldAdd
+		registerUploadedBlockFenceActiveFn = oldFence
+	})
+
+	registerUploadedBlockAddProvisionalRefFn = func(*FSHelper, string, string, string, string, string, time.Time) error {
+		return fmt.Errorf("provisional identity: %w", db.ErrBlockMetadataPermanent)
+	}
+	registerUploadedBlockFenceActiveFn = func(*FSHelper, string, string) (bool, error) {
+		t.Fatal("fence check must not run after a permanent provisional-identity failure")
+		return false, nil
+	}
+
+	err := (&FSHelper{}).RegisterUploadedBlock("org-1", "lib-1", "block-1", "op-1", 1, "hot", "key", "")
+	if !errors.Is(err, db.ErrBlockMetadataPermanent) {
+		t.Fatalf("error = %v, want db.ErrBlockMetadataPermanent", err)
+	}
+	if errors.Is(err, ErrBlockMaterializationTransient) || IsRetryableBlockMaterializationError(err) {
+		t.Fatalf("permanent provisional failure must not be retryable: %v", err)
+	}
+}
+
 // TestRegisterUploadedBlock_TranslatesContendedStubRepairToRetryableFence proves
 // that a benign lost stub-repair race inside the metadata upsert (the backstop for
 // the unprobed web-session funnel) surfaces as the retryable ErrBlockDeleteInProgress

--- a/internal/api/v2/libraries_test.go
+++ b/internal/api/v2/libraries_test.go
@@ -148,8 +148,8 @@ func TestResolveRequestedStorageClass(t *testing.T) {
 			Storage: config.StorageConfig{
 				DefaultClass: "hot-usa",
 				Classes: map[string]config.StorageClassConfig{
-					"hot-usa": {},
-					"hot-eu":  {},
+					"hot-usa": {Bucket: "usa"},
+					"hot-eu":  {Bucket: "eu"},
 				},
 				EndpointRegions: map[string]string{
 					"eu.example.com": "eu",
@@ -193,8 +193,8 @@ func TestResolveRequestedStorageClass(t *testing.T) {
 		h.config.Storage.EndpointRegions = map[string]string{}
 		h.config.Storage.RegionClasses = map[string]config.RegionClassConfig{}
 		h.config.Storage.Classes = map[string]config.StorageClassConfig{
-			"hot-zeta":  {},
-			"hot-alpha": {},
+			"hot-zeta":  {Bucket: "zeta"},
+			"hot-alpha": {Bucket: "alpha"},
 		}
 		h.config.Storage.Backends = map[string]config.BackendConfig{}
 

--- a/internal/api/v2/library_live_write_fence_test.go
+++ b/internal/api/v2/library_live_write_fence_test.go
@@ -626,10 +626,28 @@ func newLibraryHandlerForLiveFenceTests() *LibraryHandler {
 		config: &config.Config{
 			Storage: config.StorageConfig{
 				Classes: map[string]config.StorageClassConfig{
-					"standard": {},
+					"standard": {Bucket: "standard"},
 				},
 			},
 		},
+	}
+}
+
+func TestChangeStorageClassRejectsNonCanonicalReference(t *testing.T) {
+	r := gin.New()
+	handler := newLibraryHandlerForLiveFenceTests()
+	r.POST("/repos/:repo_id/storage-class", func(c *gin.Context) {
+		c.Set("org_id", "00000000-0000-0000-0000-000000000001")
+		handler.ChangeStorageClass(c)
+	})
+
+	req := httptest.NewRequest("POST", "/repos/11111111-1111-1111-1111-111111111111/storage-class", strings.NewReader(`{"storage_class":" standard "}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
 	}
 }
 

--- a/internal/api/v2/onlyoffice.go
+++ b/internal/api/v2/onlyoffice.go
@@ -1221,7 +1221,7 @@ func (h *OnlyOfficeHandler) saveEditedDocument(ctx context.Context, repoID, file
 		}
 		switch probe.Decision {
 		case db.BlockReuseReusable:
-			materializedStorageClass = strings.TrimSpace(probe.StorageClass)
+			materializedStorageClass = probe.StorageClass
 			var ensureErr error
 			storageKey, ensureErr = EnsureReusableBlockPresent(ctx, internalBlockID, probe, content, h.storageManager, blockStore, storageClass, orgID)
 			return ensureErr

--- a/internal/api/v2/onlyoffice.go
+++ b/internal/api/v2/onlyoffice.go
@@ -172,7 +172,10 @@ func (h *OnlyOfficeHandler) lookupLibraryStorageClass(orgID, repoID string) stri
 func (h *OnlyOfficeHandler) resolveLibraryBlockStore(orgID, repoID string) (*storage.BlockStore, string, error) {
 	libraryClass := h.lookupLibraryStorageClass(orgID, repoID)
 	if h.storageManager != nil {
-		preferredClass := h.storageManager.ResolveStorageClass("", libraryClass, "hot")
+		preferredClass, err := h.storageManager.ResolveStorageClass("", libraryClass, "hot")
+		if err != nil {
+			return nil, libraryClass, err
+		}
 		return h.storageManager.GetHealthyBlockStoreForOrg(orgID, preferredClass)
 	}
 	if libraryClass == "" && h.config != nil {

--- a/internal/api/v2/storage_policy.go
+++ b/internal/api/v2/storage_policy.go
@@ -54,29 +54,20 @@ func (p orgStoragePolicy) storageConfig() map[string]string {
 }
 
 func isKnownStorageClass(cfg *config.Config, class string) bool {
-	class = strings.TrimSpace(class)
-	if class == "" || cfg == nil {
+	if cfg == nil || !config.IsCanonicalStorageClassName(class) {
 		return false
 	}
-	if _, ok := cfg.Storage.Classes[class]; ok {
-		return true
-	}
-	if _, ok := cfg.Storage.Backends[class]; ok {
-		return true
-	}
-	return false
+	return cfg.IsConfiguredStorageClass(class)
 }
 
 func isHotStorageClass(cfg *config.Config, class string) bool {
-	class = strings.TrimSpace(class)
-	if class == "" || cfg == nil {
+	if cfg == nil || !config.IsCanonicalStorageClassName(class) || !cfg.IsConfiguredStorageClass(class) {
 		return false
 	}
 	if classCfg, ok := cfg.Storage.Classes[class]; ok {
 		return strings.ToLower(strings.TrimSpace(classCfg.Tier)) != "cold"
 	}
-	_, ok := cfg.Storage.Backends[class]
-	return ok
+	return true
 }
 
 func resolveEndpointRegion(cfg *config.Config, hostname string) string {
@@ -107,7 +98,9 @@ func storageClassRegion(cfg *config.Config, storageClass string) string {
 	if cfg == nil {
 		return ""
 	}
-	storageClass = strings.TrimSpace(storageClass)
+	// Raw on both sides: the only caller decides data residency with this, and the
+	// class it passes was already certified canonical. Regions are not classes and
+	// keep their own lenient matching below.
 	if storageClass == "" {
 		return ""
 	}
@@ -125,7 +118,7 @@ func resolveGlobalDefaultHotStorageClass(cfg *config.Config) string {
 	}
 
 	if isHotStorageClass(cfg, cfg.Storage.DefaultClass) {
-		return strings.TrimSpace(cfg.Storage.DefaultClass)
+		return cfg.Storage.DefaultClass
 	}
 
 	classNames := make([]string, 0, len(cfg.Storage.Classes))
@@ -186,7 +179,9 @@ func validateOrgStoragePolicy(cfg *config.Config, policy orgStoragePolicy) error
 }
 
 func resolveFlexibleCreateStorageClass(cfg *config.Config, policy orgStoragePolicy, hostname, requestedClass string) (string, error) {
-	requestedClass = strings.TrimSpace(requestedClass)
+	// R23a: admit the RAW request. Trimming first would accept " hot-v1 " here and
+	// persist an identity the caller never named, while ChangeStorageClass refuses
+	// that same value -- two doors onto one field disagreeing about what it means.
 	if requestedClass != "" {
 		if err := validateRequestedCreateStorageClass(cfg, requestedClass); err != nil {
 			return "", err
@@ -220,7 +215,7 @@ func resolveStrictCreateStorageClass(cfg *config.Config, policy orgStoragePolicy
 		return "", fmt.Errorf("organization data residency policy is misconfigured; contact an administrator or support")
 	}
 
-	requestedClass = strings.TrimSpace(requestedClass)
+	// Raw, for the same reason as the flexible path above.
 	if requestedClass != "" {
 		if err := validateRequestedCreateStorageClass(cfg, requestedClass); err != nil {
 			return "", err

--- a/internal/api/v2/storage_policy_test.go
+++ b/internal/api/v2/storage_policy_test.go
@@ -11,9 +11,9 @@ func testStoragePolicyConfig() *config.Config {
 		Storage: config.StorageConfig{
 			DefaultClass: "hot-s3-usa",
 			Classes: map[string]config.StorageClassConfig{
-				"hot-s3-usa": {Tier: "hot"},
-				"hot-s3-eu":  {Tier: "hot"},
-				"cold-s3-eu": {Tier: "cold"},
+				"hot-s3-usa": {Tier: "hot", Bucket: "usa"},
+				"hot-s3-eu":  {Tier: "hot", Bucket: "eu"},
+				"cold-s3-eu": {Tier: "cold", Bucket: "archive"},
 			},
 			EndpointRegions: map[string]string{
 				"eu.example.com": "eu",
@@ -46,6 +46,23 @@ func TestNormalizeOrgStoragePolicy(t *testing.T) {
 			t.Fatal("expected error for invalid data_residency")
 		}
 	})
+}
+
+func TestIsKnownStorageClassRequiresCanonicalName(t *testing.T) {
+	cfg := testStoragePolicyConfig()
+	cfg.Storage.Classes["empty"] = config.StorageClassConfig{Tier: "hot"}
+
+	if !isKnownStorageClass(cfg, "hot-s3-usa") {
+		t.Fatal("canonical storage class should be known")
+	}
+	if isKnownStorageClass(cfg, "empty") {
+		t.Fatal("storage class without a registrable bucket should not be known")
+	}
+	for _, name := range []string{" hot-s3-usa ", "hot_s3_usa", "Hot-s3-usa", "   "} {
+		if isKnownStorageClass(cfg, name) {
+			t.Fatalf("storage class %q should not be accepted as canonical", name)
+		}
+	}
 }
 
 func TestResolveCreateStorageClass(t *testing.T) {
@@ -124,6 +141,35 @@ func TestResolveCreateStorageClass(t *testing.T) {
 			t.Fatal("expected cold tier rejection")
 		}
 	})
+}
+
+// Create is the other door onto the same field ChangeStorageClass guards, and both
+// must answer the same way about the same raw value. Normalizing the request here
+// would persist an identity the caller never named while the change endpoint
+// refuses it -- the asymmetry, not the padding, is the defect.
+func TestResolveCreateStorageClassRejectsNonCanonicalRequests(t *testing.T) {
+	cfg := testStoragePolicyConfig()
+
+	for _, requested := range []string{" hot-s3-eu", "hot-s3-eu ", " hot-s3-eu ", "Hot-S3-EU", "hot_s3_eu"} {
+		t.Run("flexible/"+requested, func(t *testing.T) {
+			resolved, err := resolveCreateStorageClass(cfg, orgStoragePolicy{
+				DataResidency: orgDataResidencyFlexible,
+			}, "eu.example.com", requested)
+			if err == nil {
+				t.Fatalf("resolveCreateStorageClass(%q) = %q, want rejection", requested, resolved)
+			}
+		})
+
+		t.Run("strict/"+requested, func(t *testing.T) {
+			resolved, err := resolveCreateStorageClass(cfg, orgStoragePolicy{
+				DataResidency: orgDataResidencyStrict,
+				DefaultRegion: "eu",
+			}, "eu.example.com", requested)
+			if err == nil {
+				t.Fatalf("resolveCreateStorageClass(%q) = %q, want rejection", requested, resolved)
+			}
+		})
+	}
 }
 
 func TestValidateOrgStoragePolicy(t *testing.T) {

--- a/internal/api/v2/storage_resolution.go
+++ b/internal/api/v2/storage_resolution.go
@@ -52,17 +52,17 @@ func lookupLibraryStorageClassContext(ctx context.Context, database *db.DB, orgI
 	return storageClass
 }
 
-func resolvePreferredLibraryStorageClassForRequest(c *gin.Context, cfg *config.Config, storageManager *storage.Manager, libraryClass, defaultClass string) string {
+func resolvePreferredLibraryStorageClassForRequest(c *gin.Context, cfg *config.Config, storageManager *storage.Manager, libraryClass, defaultClass string) (string, error) {
 	if storageManager != nil {
 		hostname := routingHostname(c, cfg)
 		return storageManager.ResolveStorageClass(hostname, libraryClass, "hot")
 	}
 
 	if libraryClass != "" {
-		return libraryClass
+		return libraryClass, nil
 	}
 
-	return defaultClass
+	return defaultClass, nil
 }
 
 func resolveLibraryBlockStoreForRequest(c *gin.Context, database *db.DB, cfg *config.Config, storageManager *storage.Manager, s3Store *storage.S3Store, orgID, repoID string) (*storage.BlockStore, string, error) {
@@ -76,7 +76,10 @@ func resolveLibraryBlockStoreForRequestContext(ctx context.Context, c *gin.Conte
 		defaultClass = cfg.Storage.DefaultClass
 	}
 
-	preferredClass := resolvePreferredLibraryStorageClassForRequest(c, cfg, storageManager, libraryClass, defaultClass)
+	preferredClass, err := resolvePreferredLibraryStorageClassForRequest(c, cfg, storageManager, libraryClass, defaultClass)
+	if err != nil {
+		return nil, libraryClass, err
+	}
 	if storageManager != nil {
 		return storageManager.GetHealthyBlockStoreForOrg(orgID, preferredClass)
 	}

--- a/internal/api/v2/storage_resolution_test.go
+++ b/internal/api/v2/storage_resolution_test.go
@@ -23,7 +23,11 @@ func TestResolvePreferredLibraryStorageClassForRequestUsesLibraryOverride(t *tes
 	c.Request = httptest.NewRequest(http.MethodGet, "/repo/repo-id/raw/file.txt", nil)
 	c.Request.Host = "eu.sesamefs.local"
 
-	if got := resolvePreferredLibraryStorageClassForRequest(c, nil, manager, "hot-s3-usa", ""); got != "hot-s3-usa" {
+	got, err := resolvePreferredLibraryStorageClassForRequest(c, nil, manager, "hot-s3-usa", "")
+	if err != nil {
+		t.Fatalf("resolvePreferredLibraryStorageClassForRequest returned error: %v", err)
+	}
+	if got != "hot-s3-usa" {
 		t.Fatalf("resolvePreferredLibraryStorageClassForRequest = %q, want %q", got, "hot-s3-usa")
 	}
 }
@@ -41,7 +45,11 @@ func TestResolvePreferredLibraryStorageClassForRequestUsesEndpointRoutingFallbac
 	c.Request = httptest.NewRequest(http.MethodGet, "/repo/repo-id/raw/file.txt", nil)
 	c.Request.Host = "eu.sesamefs.local"
 
-	if got := resolvePreferredLibraryStorageClassForRequest(c, nil, manager, "", ""); got != "hot-s3-eu" {
+	got, err := resolvePreferredLibraryStorageClassForRequest(c, nil, manager, "", "")
+	if err != nil {
+		t.Fatalf("resolvePreferredLibraryStorageClassForRequest returned error: %v", err)
+	}
+	if got != "hot-s3-eu" {
 		t.Fatalf("resolvePreferredLibraryStorageClassForRequest = %q, want %q", got, "hot-s3-eu")
 	}
 }
@@ -59,13 +67,21 @@ func TestResolvePreferredLibraryStorageClassForRequestIgnoresServerURLForRouting
 	c.Request = httptest.NewRequest(http.MethodGet, "/repo/repo-id/raw/file.txt", nil)
 	c.Request.Host = "eu.sesamefs.local"
 
-	if got := resolvePreferredLibraryStorageClassForRequest(c, nil, manager, "", ""); got != "hot-s3-eu" {
+	got, err := resolvePreferredLibraryStorageClassForRequest(c, nil, manager, "", "")
+	if err != nil {
+		t.Fatalf("resolvePreferredLibraryStorageClassForRequest returned error: %v", err)
+	}
+	if got != "hot-s3-eu" {
 		t.Fatalf("resolvePreferredLibraryStorageClassForRequest = %q, want %q", got, "hot-s3-eu")
 	}
 }
 
 func TestResolvePreferredLibraryStorageClassForRequestUsesDefaultWithoutManager(t *testing.T) {
-	if got := resolvePreferredLibraryStorageClassForRequest(nil, nil, nil, "", "hot-minio-local"); got != "hot-minio-local" {
+	got, err := resolvePreferredLibraryStorageClassForRequest(nil, nil, nil, "", "hot-minio-local")
+	if err != nil {
+		t.Fatalf("resolvePreferredLibraryStorageClassForRequest returned error: %v", err)
+	}
+	if got != "hot-minio-local" {
 		t.Fatalf("resolvePreferredLibraryStorageClassForRequest = %q, want %q", got, "hot-minio-local")
 	}
 }

--- a/internal/api/v2/upload_reuse.go
+++ b/internal/api/v2/upload_reuse.go
@@ -96,7 +96,6 @@ func PrepareUploadedBlockProbe(database *db.DB, orgID, blockID string, probe db.
 // object (blocks/<org_id>/...). The fallback store must already be org-scoped by
 // the caller.
 func ResolveCanonicalBlockStore(storageManager *storage.Manager, fallbackStore *storage.BlockStore, fallbackClass, canonicalClass, orgID string) (*storage.BlockStore, error) {
-	canonicalClass = strings.TrimSpace(canonicalClass)
 	if canonicalClass == "" {
 		return nil, errors.New("canonical storage class is empty")
 	}
@@ -104,7 +103,6 @@ func ResolveCanonicalBlockStore(storageManager *storage.Manager, fallbackStore *
 		return storageManager.GetBlockStoreForOrg(orgID, canonicalClass)
 	}
 	if fallbackStore != nil {
-		fallbackClass = strings.TrimSpace(fallbackClass)
 		if fallbackClass != "" && fallbackClass == canonicalClass {
 			return fallbackStore, nil
 		}
@@ -121,7 +119,7 @@ func ResolveNeedsPutBlockStore(storageManager *storage.Manager, preferredStore *
 		return nil, "", "", fmt.Errorf("block %s does not need a PUT", blockID)
 	}
 
-	canonicalClass := strings.TrimSpace(probe.StorageClass)
+	canonicalClass := probe.StorageClass
 	if canonicalClass == "" {
 		if preferredStore == nil {
 			return nil, "", "", fmt.Errorf("preferred block store is unavailable for %s", blockID)
@@ -150,30 +148,33 @@ func ResolveNeedsPutBlockStore(storageManager *storage.Manager, preferredStore *
 func StoreUploadedBlockForProbe(ctx context.Context, blockID string, probe db.BlockReuseProbe, data []byte, storageManager *storage.Manager, preferredStore *storage.BlockStore, preferredClass, orgID string, beforePut func() error) (storageKey, storageClass string, didPut bool, err error) {
 	switch probe.Decision {
 	case db.BlockReuseReusable:
-		canonicalStore, resolveErr := resolveCanonicalBlockStoreFn(storageManager, preferredStore, preferredClass, probe.StorageClass, orgID)
+		// The class this returns is re-persisted by the caller, so it must be the
+		// stored identity itself, never a normalized copy of it.
+		canonicalClass := probe.StorageClass
+		canonicalStore, resolveErr := resolveCanonicalBlockStoreFn(storageManager, preferredStore, preferredClass, canonicalClass, orgID)
 		if resolveErr != nil {
-			return "", strings.TrimSpace(probe.StorageClass), false, fmt.Errorf("resolve canonical block store for %s: %w", blockID, resolveErr)
+			return "", canonicalClass, false, fmt.Errorf("resolve canonical block store for %s: %w", blockID, resolveErr)
 		}
 		storageKey = canonicalStore.StorageKeyForHash(blockID)
 		if storedKey := strings.TrimSpace(probe.StorageKey); storedKey != "" && storedKey != storageKey {
-			return "", strings.TrimSpace(probe.StorageClass), false, fmt.Errorf("canonical block %s storage key %q does not match derived org-scoped key %q", blockID, storedKey, storageKey)
+			return "", canonicalClass, false, fmt.Errorf("canonical block %s storage key %q does not match derived org-scoped key %q", blockID, storedKey, storageKey)
 		}
 		exists, existsErr := reusableCanonicalObjectExistsFn(ctx, canonicalStore, storageKey)
 		if existsErr != nil {
-			return storageKey, strings.TrimSpace(probe.StorageClass), false, fmt.Errorf("%w: verify canonical block %s in %s: %w", ErrBlockMaterializationTransient, blockID, probe.StorageClass, existsErr)
+			return storageKey, canonicalClass, false, fmt.Errorf("%w: verify canonical block %s in %s: %w", ErrBlockMaterializationTransient, blockID, canonicalClass, existsErr)
 		}
 		if exists {
-			return storageKey, strings.TrimSpace(probe.StorageClass), false, nil
+			return storageKey, canonicalClass, false, nil
 		}
 		if beforePut != nil {
 			if beforeErr := beforePut(); beforeErr != nil {
-				return storageKey, strings.TrimSpace(probe.StorageClass), false, beforeErr
+				return storageKey, canonicalClass, false, beforeErr
 			}
 		}
 		if _, putErr := repairCanonicalBlockDirectFn(ctx, canonicalStore, storageKey, data); putErr != nil {
-			return storageKey, strings.TrimSpace(probe.StorageClass), false, fmt.Errorf("%w: repair canonical block %s in %s: %w", ErrBlockMaterializationTransient, blockID, probe.StorageClass, putErr)
+			return storageKey, canonicalClass, false, fmt.Errorf("%w: repair canonical block %s in %s: %w", ErrBlockMaterializationTransient, blockID, canonicalClass, putErr)
 		}
-		return storageKey, strings.TrimSpace(probe.StorageClass), true, nil
+		return storageKey, canonicalClass, true, nil
 	case db.BlockReuseNeedsPut:
 		putStore, resolvedClass, resolvedKey, resolveErr := ResolveNeedsPutBlockStore(storageManager, preferredStore, preferredClass, probe, orgID, blockID)
 		if resolveErr != nil {

--- a/internal/api/v2/upload_reuse.go
+++ b/internal/api/v2/upload_reuse.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Sesame-Disk/sesamefs/internal/config"
 	"github.com/Sesame-Disk/sesamefs/internal/db"
 	"github.com/Sesame-Disk/sesamefs/internal/metrics"
 	"github.com/Sesame-Disk/sesamefs/internal/storage"
@@ -124,9 +125,20 @@ func ResolveNeedsPutBlockStore(storageManager *storage.Manager, preferredStore *
 		if preferredStore == nil {
 			return nil, "", "", fmt.Errorf("preferred block store is unavailable for %s", blockID)
 		}
-		preferredClass = strings.TrimSpace(preferredClass)
+		// The first writer MINTS this block's physical identity: the class returned
+		// here is the one persisted, so it is certified, never normalized. Trimming
+		// would store an identity the writer never named -- and now that the write
+		// funnel refuses a non-canonical class outright, a trim's only remaining
+		// effect would be to turn that hard refusal into a silent rewrite.
+		//
+		// Certifying here rather than leaving it to the funnel also keeps the PUT
+		// from landing: the object is written before materialization, so a class
+		// rejected downstream would leave bytes in S3 that no row points at.
 		if preferredClass == "" {
 			return nil, "", "", fmt.Errorf("preferred storage class is empty for %s", blockID)
+		}
+		if !config.IsCanonicalStorageClassName(preferredClass) {
+			return nil, "", "", fmt.Errorf("preferred storage class %q for block %s is not canonical", preferredClass, blockID)
 		}
 		return preferredStore, preferredClass, preferredStore.StorageKeyForHash(blockID), nil
 	}

--- a/internal/api/v2/upload_reuse.go
+++ b/internal/api/v2/upload_reuse.go
@@ -97,8 +97,11 @@ func PrepareUploadedBlockProbe(database *db.DB, orgID, blockID string, probe db.
 // object (blocks/<org_id>/...). The fallback store must already be org-scoped by
 // the caller.
 func ResolveCanonicalBlockStore(storageManager *storage.Manager, fallbackStore *storage.BlockStore, fallbackClass, canonicalClass, orgID string) (*storage.BlockStore, error) {
-	if canonicalClass == "" {
-		return nil, errors.New("canonical storage class is empty")
+	if !config.IsCanonicalStorageClassName(canonicalClass) {
+		if canonicalClass == "" {
+			return nil, errors.New("canonical storage class is empty")
+		}
+		return nil, fmt.Errorf("canonical storage class %q is not canonical", canonicalClass)
 	}
 	if storageManager != nil {
 		return storageManager.GetBlockStoreForOrg(orgID, canonicalClass)

--- a/internal/api/v2/upload_reuse_test.go
+++ b/internal/api/v2/upload_reuse_test.go
@@ -763,6 +763,23 @@ func TestResolveCanonicalBlockStoreRejectsInexactFallbackClass(t *testing.T) {
 	}
 }
 
+func TestResolveCanonicalBlockStoreRejectsNonCanonicalFallbackIdentity(t *testing.T) {
+	const orgID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+	fallback, err := storage.NewOrgBlockStore(&storage.S3Store{}, "blocks/", orgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, class := range []string{"CANONICAL", " canonical", "canonical ", "canonical_v1"} {
+		t.Run(fmt.Sprintf("class_%q", class), func(t *testing.T) {
+			got, err := ResolveCanonicalBlockStore(nil, fallback, class, class, orgID)
+			if got != nil || err == nil {
+				t.Fatalf("ResolveCanonicalBlockStore() = (%p, %v), want non-canonical identity rejection", got, err)
+			}
+		})
+	}
+}
+
 func TestResolveNeedsPutBlockStoreUsesPreferredPlacementForFirstWriter(t *testing.T) {
 	const orgID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
 	preferred, err := storage.NewOrgBlockStore(&storage.S3Store{}, "blocks/", orgID)

--- a/internal/api/v2/upload_reuse_test.go
+++ b/internal/api/v2/upload_reuse_test.go
@@ -779,6 +779,30 @@ func TestResolveNeedsPutBlockStoreUsesPreferredPlacementForFirstWriter(t *testin
 	}
 }
 
+// The first writer MINTS the block's physical identity -- the class this returns is
+// the one persisted. It is the last write-path door a non-canonical label could
+// enter through, and it must refuse rather than normalize: a trim here would turn
+// the write funnel's hard refusal into a silent rewrite, and it would do so AFTER
+// the PUT, leaving bytes in S3 that no row ends up pointing at.
+func TestResolveNeedsPutBlockStoreRefusesNonCanonicalFirstWriterClass(t *testing.T) {
+	const orgID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+	preferred, err := storage.NewOrgBlockStore(&storage.S3Store{}, "blocks/", orgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, preferredClass := range []string{" hot-v1", "hot-v1 ", " hot-v1 ", "Hot-V1", "hot_v1", "hot--v1", "   "} {
+		gotStore, gotClass, gotKey, err := ResolveNeedsPutBlockStore(nil, preferred, preferredClass,
+			db.BlockReuseProbe{Decision: db.BlockReuseNeedsPut}, orgID, "abcd1234")
+		if err == nil {
+			t.Fatalf("preferred class %q: placement = %p/%q/%q, want refusal", preferredClass, gotStore, gotClass, gotKey)
+		}
+		if gotStore != nil || gotClass != "" || gotKey != "" {
+			t.Fatalf("preferred class %q: refusal must return no placement, got %p/%q/%q", preferredClass, gotStore, gotClass, gotKey)
+		}
+	}
+}
+
 func TestResolveNeedsPutBlockStoreUsesExistingCanonicalPlacement(t *testing.T) {
 	oldResolve := resolveCanonicalBlockStoreFn
 	t.Cleanup(func() { resolveCanonicalBlockStoreFn = oldResolve })

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1438,6 +1438,9 @@ func DefaultConfig() *Config {
 		Storage: StorageConfig{
 			Mode:         "",
 			DefaultClass: "hot",
+			// "hot" is the reserved legacy backend name. Modern classes must use a
+			// distinct name so a failed class initialization cannot fall through to
+			// the legacy registration loop and silently bind another namespace.
 			Backends: map[string]BackendConfig{
 				"hot": {
 					Type:   "s3",
@@ -2281,21 +2284,33 @@ func (c *Config) shouldUseLegacySingleRegionStorage() bool {
 	return strings.TrimSpace(hot.Bucket) != ""
 }
 
+// configuredStorageClass reports whether name resolves to a backend the storage
+// manager will actually register. It does NOT trim: runtime resolution is an
+// exact map lookup, and a lenient check here would certify a name that fails at
+// use time (R23a). Modern classes use the same non-empty bucket requirement as
+// initStorageClass; an entry that cannot be initialized is not a backend.
 func (c *Config) configuredStorageClass(name string) bool {
-	name = strings.TrimSpace(name)
 	if name == "" || c == nil {
 		return false
 	}
-	if _, ok := c.Storage.Classes[name]; ok {
-		return true
+	if class, ok := c.Storage.Classes[name]; ok {
+		return strings.TrimSpace(class.Bucket) != ""
 	}
 	if backend, ok := c.Storage.Backends[name]; ok {
-		if strings.EqualFold(backend.Type, "s3") {
-			return strings.TrimSpace(backend.Bucket) != ""
-		}
-		return true
+		// initStorageManager converts legacy backends to StorageClassConfig and
+		// sends them through initStorageClass, which requires a bucket for every
+		// backend type it can currently register.
+		return strings.TrimSpace(backend.Bucket) != ""
 	}
 	return false
+}
+
+// IsConfiguredStorageClass reports whether name identifies a backend that the
+// storage manager can register from this configuration. It intentionally uses
+// exact-name and registrability checks so API callers cannot persist a class
+// that configuration validation would later fail to resolve.
+func (c *Config) IsConfiguredStorageClass(name string) bool {
+	return c.configuredStorageClass(name)
 }
 
 func (c *Config) regionClassConfig(region string) (RegionClassConfig, bool) {
@@ -3150,14 +3165,6 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("storage.mode must be one of: single, multi")
 	}
 	storageMode := c.storageMode()
-	for region, regionConfig := range c.Storage.RegionClasses {
-		if strings.TrimSpace(regionConfig.Hot) != "" && !c.configuredStorageClass(regionConfig.Hot) {
-			return fmt.Errorf("storage.region_classes.%s.hot references unknown or unconfigured storage class %q", region, regionConfig.Hot)
-		}
-		if strings.TrimSpace(regionConfig.Cold) != "" && !c.configuredStorageClass(regionConfig.Cold) {
-			return fmt.Errorf("storage.region_classes.%s.cold references unknown or unconfigured storage class %q", region, regionConfig.Cold)
-		}
-	}
 	if !c.Auth.DevMode && storageMode == "multi" {
 		if len(c.Storage.RegionClasses) == 0 {
 			return fmt.Errorf("storage.mode=multi requires storage.region_classes to be configured")
@@ -3377,6 +3384,113 @@ func (c *Config) Validate() error {
 	c.Server.TrustedProxies = normalizedTrustedProxies
 	if c.Auth.OIDC.Enabled && !hasConfiguredStrings(c.Auth.OIDC.RedirectURIs) {
 		return fmt.Errorf("auth.oidc.redirect_uris must contain at least one redirect URI when OIDC is enabled")
+	}
+	if err := c.validateStorageClassIdentity(); err != nil {
+		return err
+	}
+	return nil
+}
+
+var storageClassNamePattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+// IsCanonicalStorageClassName is the single definition of a canonical storage
+// class name, shared by configuration validation and the storage runtime. R23a
+// makes a persisted storage_class the physical namespace identity itself, so
+// "canonical" must mean one thing in both places: a second, looser copy of this
+// rule would let a name certify at one layer and fail at the other.
+//
+// The check is deliberately on the RAW value. Runtime resolution is an exact map
+// lookup, so a validator that trimmed or folded first would be more permissive
+// than the thing it certifies.
+func IsCanonicalStorageClassName(name string) bool {
+	return name == strings.TrimSpace(name) &&
+		name == strings.ToLower(name) &&
+		storageClassNamePattern.MatchString(name)
+}
+
+// validateStorageClassIdentity protects the R23a contract that a persisted
+// storage_class is itself the immutable physical namespace identity.
+//
+// It covers both halves of "identity": the declared names must be canonical and
+// unambiguous, and every field that REFERENCES a class must name one that
+// actually resolves. An unresolvable reference is not an identity, and the
+// failure modes differ sharply in how loudly they surface -- a bad default_class
+// breaks the first classless write, while a bad failover_class breaks nothing
+// until the primary is down, which is precisely when it is needed.
+//
+// What it cannot do: detect an operator rebinding an already-deployed name to
+// another namespace, or reusing a decommissioned name for a fresh one. That stays
+// an append-only configuration contract; see docs/GC-X1-CLOSURE-OPTIONS.md R23a.
+func (c *Config) validateStorageClassIdentity() error {
+	if err := validateStorageClassNames(c.Storage); err != nil {
+		return err
+	}
+	for name := range c.Storage.Classes {
+		if !c.configuredStorageClass(name) {
+			return fmt.Errorf("storage.classes.%s is declared but cannot be registered; configure a non-empty bucket", name)
+		}
+	}
+	if err := c.validateStorageClassReference("storage.default_class", c.Storage.DefaultClass); err != nil {
+		return err
+	}
+	for name, classCfg := range c.Storage.Classes {
+		if err := c.validateStorageClassReference("storage.classes."+name+".failover_class", classCfg.FailoverClass); err != nil {
+			return err
+		}
+	}
+	for region, regionConfig := range c.Storage.RegionClasses {
+		if err := c.validateStorageClassReference("storage.region_classes."+region+".hot", regionConfig.Hot); err != nil {
+			return err
+		}
+		if err := c.validateStorageClassReference("storage.region_classes."+region+".cold", regionConfig.Cold); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateStorageClassReference checks one field that names a storage class. A
+// literal empty value means "not configured" and is left to the mode-specific
+// rules that already decide whether that is allowed. Whitespace-only values are
+// non-empty raw references and must fail the canonical-name check.
+func (c *Config) validateStorageClassReference(scope, name string) error {
+	if name == "" {
+		return nil
+	}
+	if !IsCanonicalStorageClassName(name) {
+		return fmt.Errorf("%s references storage class %q, which is not canonical; use lowercase ASCII letters, digits, and hyphens without surrounding whitespace", scope, name)
+	}
+	if !c.configuredStorageClass(name) {
+		return fmt.Errorf("%s references unknown or unconfigured storage class %q", scope, name)
+	}
+	return nil
+}
+
+func validateStorageClassNames(storageConfig StorageConfig) error {
+	seen := make(map[string]string, len(storageConfig.Classes)+len(storageConfig.Backends))
+	validate := func(scope, name string) error {
+		if name == "" {
+			return fmt.Errorf("%s storage class name must not be empty", scope)
+		}
+		if !IsCanonicalStorageClassName(name) {
+			return fmt.Errorf("%s storage class name %q must use lowercase ASCII letters, digits, and hyphens without surrounding whitespace", scope, name)
+		}
+		if previousScope, ok := seen[name]; ok {
+			return fmt.Errorf("%s storage class name %q collides with %s; class and legacy backend names must be unambiguous", scope, name, previousScope)
+		}
+		seen[name] = scope
+		return nil
+	}
+
+	for name := range storageConfig.Classes {
+		if err := validate("storage.classes", name); err != nil {
+			return err
+		}
+	}
+	for name := range storageConfig.Backends {
+		if err := validate("storage.backends", name); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1438,9 +1438,15 @@ func DefaultConfig() *Config {
 		Storage: StorageConfig{
 			Mode:         "",
 			DefaultClass: "hot",
-			// "hot" is the reserved legacy backend name. Modern classes must use a
-			// distinct name so a failed class initialization cannot fall through to
-			// the legacy registration loop and silently bind another namespace.
+			// Nothing reserves the name "hot" globally; what validateStorageClassNames
+			// enforces is that the class and legacy-backend namespaces may not overlap.
+			// This default entry is what makes storage.classes.hot a collision -- and so
+			// a startup failure -- in any configuration that does not explicitly null
+			// "backends:", which is the point: a class whose initialization fails is
+			// skipped with a warning, and the legacy loop would then bind the same name
+			// to a different bucket. A config that DOES null "backends:" may use "hot"
+			// as a modern class, because there is no legacy entry left to fall through
+			// to.
 			Backends: map[string]BackendConfig{
 				"hot": {
 					Type:   "s3",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1442,11 +1442,11 @@ func DefaultConfig() *Config {
 			// enforces is that the class and legacy-backend namespaces may not overlap.
 			// This default entry is what makes storage.classes.hot a collision -- and so
 			// a startup failure -- in any configuration that does not explicitly null
-			// "backends:", which is the point: a class whose initialization fails is
-			// skipped with a warning, and the legacy loop would then bind the same name
-			// to a different bucket. A config that DOES null "backends:" may use "hot"
-			// as a modern class, because there is no legacy entry left to fall through
-			// to.
+			// "backends:", which is the point. Before R23a, a failed class was skipped with
+			// a warning, and the legacy loop could then bind the same name to a different
+			// bucket. Runtime now aborts startup when any declared class fails to
+			// initialize. A config that DOES null "backends:" may use "hot" as a modern
+			// class, because there is no legacy entry left to fall through to.
 			Backends: map[string]BackendConfig{
 				"hot": {
 					Type:   "s3",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2436,3 +2436,173 @@ func TestEnvOverrideSyncBlockInflightCaps(t *testing.T) {
 		t.Fatalf("Validate() with safe overrides: %v", err)
 	}
 }
+
+func TestConfigValidateRequiresCanonicalStorageClassNames(t *testing.T) {
+	newConfig := func() *Config {
+		cfg := DefaultConfig()
+		cfg.Auth.DevMode = true
+		cfg.Storage.Classes = map[string]StorageClassConfig{
+			"hot-v1": {Type: "s3", Bucket: "blocks"},
+		}
+		cfg.Storage.Backends = nil
+		// DefaultConfig points default_class at the legacy "hot" backend that was
+		// just removed; leaving it would fail reference validation for a reason
+		// this test is not about.
+		cfg.Storage.DefaultClass = "hot-v1"
+		return cfg
+	}
+
+	if err := newConfig().Validate(); err != nil {
+		t.Fatalf("Validate() returned error for canonical class: %v", err)
+	}
+
+	for _, name := range []string{"", "Hot-v1", " hot-v1", "hot_v1", "hot/v1"} {
+		t.Run("rejects "+name, func(t *testing.T) {
+			cfg := newConfig()
+			classConfig := cfg.Storage.Classes["hot-v1"]
+			delete(cfg.Storage.Classes, "hot-v1")
+			cfg.Storage.Classes[name] = classConfig
+			cfg.Storage.DefaultClass = ""
+			if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "storage class name") {
+				t.Fatalf("Validate() error = %v, want storage class name error", err)
+			}
+		})
+	}
+}
+
+func TestConfigValidateRejectsClassAndLegacyStorageNameCollision(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Auth.DevMode = true
+	cfg.Storage.Classes = map[string]StorageClassConfig{
+		"hot": {Type: "s3", Bucket: "class-bucket"},
+	}
+	cfg.Storage.Backends = map[string]BackendConfig{
+		"hot": {Type: "s3", Bucket: "legacy-bucket"},
+	}
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "collides") {
+		t.Fatalf("Validate() error = %v, want storage class collision error", err)
+	}
+}
+
+// A reference that does not resolve is not an identity. The failure modes differ
+// in how loudly they surface: default_class breaks the first classless write,
+// while failover_class breaks nothing until the primary is down -- which is
+// exactly when it is needed, so only startup validation can surface it in time.
+func TestConfigValidateRejectsUnresolvableStorageClassReferences(t *testing.T) {
+	newConfig := func() *Config {
+		cfg := DefaultConfig()
+		cfg.Auth.DevMode = true
+		cfg.Storage.Classes = map[string]StorageClassConfig{
+			"hot-v1": {Type: "s3", Bucket: "blocks"},
+			"hot-v2": {Type: "s3", Bucket: "blocks-2"},
+		}
+		cfg.Storage.Backends = nil
+		cfg.Storage.DefaultClass = "hot-v1"
+		return cfg
+	}
+
+	if err := newConfig().Validate(); err != nil {
+		t.Fatalf("Validate() returned error for resolvable references: %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		mutate  func(*Config)
+		wantSub string
+	}{
+		{
+			name:    "unknown default_class",
+			mutate:  func(c *Config) { c.Storage.DefaultClass = "hot-v9" },
+			wantSub: "storage.default_class references unknown or unconfigured storage class",
+		},
+		{
+			name: "modern class without bucket",
+			mutate: func(c *Config) {
+				c.Storage.Classes["hot-v1"] = StorageClassConfig{Type: "s3", Bucket: ""}
+			},
+			wantSub: "storage.classes.hot-v1 is declared but cannot be registered",
+		},
+		{
+			name:    "non-canonical default_class",
+			mutate:  func(c *Config) { c.Storage.DefaultClass = " hot-v1 " },
+			wantSub: "storage.default_class references storage class",
+		},
+		{
+			name:    "whitespace-only default_class",
+			mutate:  func(c *Config) { c.Storage.DefaultClass = "   " },
+			wantSub: "storage.default_class references storage class",
+		},
+		{
+			name: "unknown failover_class",
+			mutate: func(c *Config) {
+				c.Storage.Classes["hot-v1"] = StorageClassConfig{Type: "s3", Bucket: "blocks", FailoverClass: "hot-v9"}
+			},
+			wantSub: "failover_class references unknown or unconfigured storage class",
+		},
+		{
+			name: "non-canonical failover_class",
+			mutate: func(c *Config) {
+				c.Storage.Classes["hot-v1"] = StorageClassConfig{Type: "s3", Bucket: "blocks", FailoverClass: "Hot-V2"}
+			},
+			wantSub: "failover_class references storage class",
+		},
+		{
+			name: "unknown region class",
+			mutate: func(c *Config) {
+				c.Storage.RegionClasses = map[string]RegionClassConfig{"eu": {Hot: "hot-v9"}}
+			},
+			wantSub: "storage.region_classes.eu.hot references unknown or unconfigured storage class",
+		},
+		{
+			// The old check trimmed before resolving while the runtime lookup does
+			// not, so a padded reference certified and then failed at use time.
+			name: "padded region class",
+			mutate: func(c *Config) {
+				c.Storage.RegionClasses = map[string]RegionClassConfig{"eu": {Hot: " hot-v1 "}}
+			},
+			wantSub: "storage.region_classes.eu.hot references storage class",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := newConfig()
+			tc.mutate(cfg)
+			err := cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("Validate() error = %v, want error containing %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+// A resolvable failover_class must stay accepted; the point of the check is to
+// reject typos, not to forbid failover.
+func TestConfigValidateAcceptsResolvableFailoverClass(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Auth.DevMode = true
+	cfg.Storage.Backends = nil
+	cfg.Storage.DefaultClass = "hot-v1"
+	cfg.Storage.Classes = map[string]StorageClassConfig{
+		"hot-v1": {Type: "s3", Bucket: "blocks", FailoverClass: "hot-v2"},
+		"hot-v2": {Type: "s3", Bucket: "blocks-2"},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil for a resolvable failover chain", err)
+	}
+}
+
+func TestIsCanonicalStorageClassName(t *testing.T) {
+	for _, name := range []string{"hot", "hot-v1", "hot-s3-usa", "h0t-2"} {
+		if !IsCanonicalStorageClassName(name) {
+			t.Errorf("IsCanonicalStorageClassName(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"", " hot", "hot ", "Hot", "hot_v1", "hot/v1", "-hot", "hot-", "hot--v1", "hót"} {
+		if IsCanonicalStorageClassName(name) {
+			t.Errorf("IsCanonicalStorageClassName(%q) = true, want false", name)
+		}
+	}
+}

--- a/internal/config/shipped_configs_test.go
+++ b/internal/config/shipped_configs_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -41,6 +42,20 @@ func loadShippedConfig(t *testing.T, path string) *Config {
 		t.Fatalf("parse %s: %v", path, err)
 	}
 	return cfg
+}
+
+// Some shipped production files intentionally leave class buckets empty because
+// deployment injects them through S3_CLASS_<CLASS>_BUCKET. Reference validation
+// below exercises the topology independently; fill those deployment placeholders
+// with deterministic test buckets. Config.Validate still rejects an empty bucket
+// when the deployment did not provide the required environment override.
+func hydrateShippedStoragePlaceholders(cfg *Config) {
+	for name, classCfg := range cfg.Storage.Classes {
+		if strings.TrimSpace(classCfg.Bucket) == "" {
+			classCfg.Bucket = "shipped-test-" + name
+			cfg.Storage.Classes[name] = classCfg
+		}
+	}
 }
 
 func TestShippedConfigsPassDownloadAdmissionValidation(t *testing.T) {
@@ -142,6 +157,32 @@ func TestShippedConfigsKeepProfileCapsUnderTheNodeCeiling(t *testing.T) {
 				if cap > d.MaxActivePerNode {
 					t.Fatalf("%s = %d exceeds max_active_per_node = %d", name, cap, d.MaxActivePerNode)
 				}
+			}
+		})
+	}
+}
+
+func TestShippedConfigsUseCanonicalStorageClassNames(t *testing.T) {
+	for _, path := range shippedConfigPaths(t) {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			cfg := loadShippedConfig(t, path)
+			if err := validateStorageClassNames(cfg.Storage); err != nil {
+				t.Fatalf("shipped configuration has invalid storage class identity: %v", err)
+			}
+		})
+	}
+}
+
+// Every storage class a shipped config REFERENCES must resolve to one it
+// declares. A typo in failover_class is invisible until the primary backend is
+// down, so the repo's own files are the cheapest place to catch it.
+func TestShippedConfigsResolveEveryStorageClassReference(t *testing.T) {
+	for _, path := range shippedConfigPaths(t) {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			cfg := loadShippedConfig(t, path)
+			hydrateShippedStoragePlaceholders(cfg)
+			if err := cfg.validateStorageClassIdentity(); err != nil {
+				t.Fatalf("shipped configuration would refuse to start: %v", err)
 			}
 		})
 	}

--- a/internal/config/shipped_configs_test.go
+++ b/internal/config/shipped_configs_test.go
@@ -162,6 +162,63 @@ func TestShippedConfigsKeepProfileCapsUnderTheNodeCeiling(t *testing.T) {
 	}
 }
 
+// Nothing reserves "hot" globally -- what is enforced is that the class and legacy
+// backend namespaces may not overlap. In practice that still rejects a modern class
+// named "hot", but only because DefaultConfig ships a legacy "hot" backend and YAML
+// decoding MERGES into that map rather than replacing it. That merge is the load
+// bearing and non-obvious part: a `backends: {}` line looks like it clears the
+// default and does not, while a null `backends:` does. The comment in DefaultConfig
+// states the rule; this pins the behavior it rests on.
+func TestModernHotClassCollidesWithTheShippedLegacyBackend(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		doc           string
+		wantCollision bool
+	}{
+		{"backends omitted", `storage:
+  classes:
+    hot:
+      type: s3
+      bucket: b
+`, true},
+		{"empty mapping merges, does not clear", `storage:
+  backends: {}
+  classes:
+    hot:
+      type: s3
+      bucket: b
+`, true},
+		{"nulled leaves no legacy loop to fall through to", `storage:
+  backends:
+  classes:
+    hot:
+      type: s3
+      bucket: b
+`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			if err := yaml.Unmarshal([]byte(tc.doc), cfg); err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if _, legacyHot := cfg.Storage.Backends["hot"]; legacyHot != tc.wantCollision {
+				t.Fatalf("legacy backends[hot] present = %v, want %v", legacyHot, tc.wantCollision)
+			}
+
+			err := validateStorageClassNames(cfg.Storage)
+			if tc.wantCollision {
+				if err == nil || !strings.Contains(err.Error(), "collides") {
+					t.Fatalf("error = %v, want a collision rejection", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("error = %v, want acceptance: with no legacy entry there is no second binding to fall through to", err)
+			}
+		})
+	}
+}
+
 func TestShippedConfigsUseCanonicalStorageClassNames(t *testing.T) {
 	for _, path := range shippedConfigPaths(t) {
 		t.Run(filepath.Base(path), func(t *testing.T) {

--- a/internal/db/block_references.go
+++ b/internal/db/block_references.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Sesame-Disk/sesamefs/internal/config"
 	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
@@ -574,9 +575,15 @@ func (db *DB) UpsertBlockMetadataWithRepresentationAndSHA1(orgID, representation
 	if err := ValidateBlockRepresentationID(representationID); err != nil {
 		return fmt.Errorf("%w: %w", ErrBlockMetadataPermanent, err)
 	}
-	storageClass = strings.TrimSpace(storageClass)
+	// R23a: the persisted storage_class is the physical namespace identity, so this
+	// funnel is the last door a non-canonical value could enter through. Normalizing
+	// here instead would persist an identity the writer never named, and every reader
+	// downstream — GC included — resolves the raw stored value.
 	if storageClass == "" {
 		return fmt.Errorf("%w: missing canonical storage class for block %s", ErrBlockMetadataPermanent, blockID)
+	}
+	if !config.IsCanonicalStorageClassName(storageClass) {
+		return fmt.Errorf("%w: non-canonical storage class %q for block %s", ErrBlockMetadataPermanent, storageClass, blockID)
 	}
 	sha1 = NormalizeBlockID(sha1)
 	if sha1 != "" && !isHexN(sha1, 40) {
@@ -646,11 +653,19 @@ func (db *DB) ensureBlockIdentityRow(orgID, blockID, representationID, sha1 stri
 		// rather than retry into the same corrupt row or mask it.
 		return fmt.Errorf("%w: block %s has malformed GC ownership: %w", ErrBlockMetadataPermanent, blockID, ownershipErr)
 	}
-	if activeClaim || repairClaim || row.CreatedAt == nil || !row.StorageClassPresent || strings.TrimSpace(row.StorageClass) == "" {
+	if activeClaim || repairClaim || row.CreatedAt == nil || !row.StorageClassPresent || row.StorageClass == "" {
 		// Deliberately transient (unmarked): an active/repair claim or a still-stub
 		// row can converge on a re-probe (GC abandons, or a concurrent uploader
 		// completes it), so the caller retries instead of failing the upload.
 		return fmt.Errorf("block %s has incomplete canonical metadata", blockID)
+	}
+	// R23a: validating only the incoming argument is not enough. When the INSERT
+	// loses, the caller INHERITS the identity already on the row, and reporting
+	// success would hand back a physical identity that no reader can resolve --
+	// ProbeBlockReuse and GC both refuse a non-canonical stored class. Permanent,
+	// not transient: unlike a claim or a stub, a corrupt label never converges.
+	if !config.IsCanonicalStorageClassName(row.StorageClass) {
+		return fmt.Errorf("%w: block %s has non-canonical storage class %q", ErrBlockMetadataPermanent, blockID, row.StorageClass)
 	}
 
 	currentRepresentationID := strings.TrimSpace(row.RepresentationID)
@@ -904,11 +919,17 @@ func (db *DB) ProbeBlockReuse(orgID, blockID string) (BlockReuseProbe, error) {
 	probe := BlockReuseProbe{
 		Sha1:         strings.TrimSpace(metadata.Sha1),
 		SizeBytes:    metadata.SizeBytes,
-		StorageClass: strings.TrimSpace(metadata.StorageClass),
+		StorageClass: metadata.StorageClass,
 		StorageKey:   strings.TrimSpace(metadata.StorageKey),
 	}
 	if !metadata.StorageClassPresent || probe.StorageClass == "" {
 		return BlockReuseProbe{Decision: BlockReuseUnknownError}, fmt.Errorf("block %s has empty canonical storage class", blockID)
+	}
+	// A stored class that is not canonical cannot name a physical namespace, and the
+	// probe is what every reuse/repair path resolves through. Reject it here rather
+	// than let a normalized copy of it select a backend.
+	if !config.IsCanonicalStorageClassName(probe.StorageClass) {
+		return BlockReuseProbe{Decision: BlockReuseUnknownError}, fmt.Errorf("block %s has non-canonical storage class %q", blockID, probe.StorageClass)
 	}
 	if activeClaim || repairClaim {
 		probe.Decision = BlockReuseBlockedByGC

--- a/internal/db/block_references_test.go
+++ b/internal/db/block_references_test.go
@@ -254,6 +254,74 @@ func TestUpsertBlockMetadataRejectsEmptyRepresentationBeforeInsert(t *testing.T)
 	}
 }
 
+// R23a: the persisted storage_class is the physical namespace identity, so the
+// write funnel is where a non-canonical value has to be stopped. Normalizing it
+// would store an identity the writer never named; every reader resolves the raw
+// stored value and would fail on it later, far from the cause.
+func TestUpsertBlockMetadataRejectsNonCanonicalStorageClass(t *testing.T) {
+	oldInsert := upsertBlockMetadataInsertWithRepresentationFn
+	t.Cleanup(func() {
+		upsertBlockMetadataInsertWithRepresentationFn = oldInsert
+	})
+	upsertBlockMetadataInsertWithRepresentationFn = func(*DB, string, string, string, string, int, string, string, time.Time) (bool, error) {
+		t.Fatal("insert must not run with a non-canonical storage class")
+		return false, nil
+	}
+
+	for _, storageClass := range []string{" hot", "hot ", "Hot", "hot_tier", "hot--tier", "   "} {
+		err := (&DB{}).UpsertBlockMetadataWithRepresentationAndSHA1("org-1", PlainBlockRepresentationID, "block-1", "", 1, storageClass, "key")
+		if err == nil || !strings.Contains(err.Error(), "non-canonical storage class") {
+			t.Fatalf("UpsertBlockMetadataWithRepresentationAndSHA1(%q) error = %v, want non-canonical rejection", storageClass, err)
+		}
+		if !errors.Is(err, ErrBlockMetadataPermanent) {
+			t.Fatalf("UpsertBlockMetadataWithRepresentationAndSHA1(%q) error is not permanent: %v", storageClass, err)
+		}
+	}
+}
+
+// Validating only the incoming argument leaves the case that actually matters
+// uncovered: when the INSERT loses, the caller inherits whatever identity the
+// existing row already carries. Reporting success there would finish an upload
+// whose metadata ProbeBlockReuse and GC both refuse to resolve.
+func TestUpsertBlockMetadataRejectsNonCanonicalStorageClassOnTheExistingRow(t *testing.T) {
+	oldInsert := upsertBlockMetadataInsertFn
+	oldRead := readBlockIdentityForRepairFn
+	oldBackfill := backfillBlockSHA1Fn
+	t.Cleanup(func() {
+		upsertBlockMetadataInsertFn = oldInsert
+		readBlockIdentityForRepairFn = oldRead
+		backfillBlockSHA1Fn = oldBackfill
+	})
+
+	backfillBlockSHA1Fn = func(*DB, string, string, string, string) (bool, error) {
+		t.Fatal("must not repair identity on a row whose storage class cannot name a namespace")
+		return false, nil
+	}
+
+	for _, storedClass := range []string{" hot", "hot ", "Hot", "hot_tier", "   "} {
+		upsertBlockMetadataInsertFn = func(*DB, string, string, string, int, string, string, time.Time) (bool, error) {
+			return false, nil // the row already exists; converge on it
+		}
+		readBlockIdentityForRepairFn = func(*DB, string, string) (blockIdentityRepairRow, bool, error) {
+			row := completeIdentityRepairRow(PlainBlockRepresentationID, "")
+			row.StorageClass = storedClass
+			return row, true, nil
+		}
+
+		// The ARGUMENT is canonical here; only the stored row is not.
+		err := (&DB{}).UpsertBlockMetadataWithSHA1("org-1", "block-1", strings.Repeat("a", 40), 123, "hot", "key")
+		if err == nil {
+			t.Fatalf("stored class %q: error = nil, want rejection", storedClass)
+		}
+		if !strings.Contains(err.Error(), "non-canonical storage class") {
+			t.Fatalf("stored class %q: error = %v, want non-canonical rejection", storedClass, err)
+		}
+		if !errors.Is(err, ErrBlockMetadataPermanent) {
+			t.Fatalf("stored class %q: error is not permanent (a corrupt label never converges): %v", storedClass, err)
+		}
+	}
+}
+
 func TestUpsertBlockMetadataRepairsReleasedStubAndRetriesInsert(t *testing.T) {
 	database := &DB{}
 	oldInsert := upsertBlockMetadataInsertFn
@@ -1114,7 +1182,7 @@ func TestProbeBlockReuseReturnsUnknownErrorForEmptyStorageClass(t *testing.T) {
 	t.Cleanup(func() { probeBlockReuseMetadataFn = oldMetadata })
 
 	probeBlockReuseMetadataFn = func(database *DB, orgID, blockID string) (blockReuseMetadataRow, bool, error) {
-		row := completeProbeMetadataRow("   ")
+		row := completeProbeMetadataRow("")
 		row.SizeBytes = 123
 		return row, true, nil
 	}
@@ -1125,6 +1193,29 @@ func TestProbeBlockReuseReturnsUnknownErrorForEmptyStorageClass(t *testing.T) {
 	}
 	if probe.Decision != BlockReuseUnknownError {
 		t.Fatalf("decision = %v, want BlockReuseUnknownError", probe.Decision)
+	}
+}
+
+// A stored class that only looks empty after normalization is corruption, not an
+// absent class: the probe must refuse it instead of resolving a trimmed copy.
+func TestProbeBlockReuseReturnsUnknownErrorForNonCanonicalStorageClass(t *testing.T) {
+	oldMetadata := probeBlockReuseMetadataFn
+	t.Cleanup(func() { probeBlockReuseMetadataFn = oldMetadata })
+
+	for _, storageClass := range []string{"   ", " hot-s3-eu", "Hot-S3-EU", "hot_s3_eu"} {
+		probeBlockReuseMetadataFn = func(database *DB, orgID, blockID string) (blockReuseMetadataRow, bool, error) {
+			row := completeProbeMetadataRow(storageClass)
+			row.SizeBytes = 123
+			return row, true, nil
+		}
+
+		probe, err := (&DB{}).ProbeBlockReuse("org-1", "block-1")
+		if err == nil {
+			t.Fatalf("ProbeBlockReuse(%q) error = nil, want error", storageClass)
+		}
+		if probe.Decision != BlockReuseUnknownError {
+			t.Fatalf("ProbeBlockReuse(%q) decision = %v, want BlockReuseUnknownError", storageClass, probe.Decision)
+		}
 	}
 }
 

--- a/internal/db/gc_projection_write_helpers_test.go
+++ b/internal/db/gc_projection_write_helpers_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
@@ -49,5 +50,17 @@ func TestGCProjectionUTCDateNormalizesOtherZones(t *testing.T) {
 	want := time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC)
 	if !got.Equal(want) {
 		t.Fatalf("GCProjectionUTCDate(%v) = %v, want %v", in, got, want)
+	}
+}
+
+func TestAddProvisionalBlockReferenceWithExpiryRejectsNonCanonicalStorageClassBeforeDatabase(t *testing.T) {
+	var database *DB
+	for _, storageClass := range []string{"", " hot", "hot ", "Hot", "hot_v1"} {
+		err := database.AddProvisionalBlockReferenceWithExpiry(
+			"org-1", "block-1", "up:attempt", "lib-1", storageClass, time.Now().Add(time.Hour),
+		)
+		if err == nil || !errors.Is(err, ErrBlockMetadataPermanent) {
+			t.Fatalf("storage class %q: error = %v, want permanent canonical-name error", storageClass, err)
+		}
 	}
 }

--- a/internal/db/provisional_block_ref_expiry.go
+++ b/internal/db/provisional_block_ref_expiry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Sesame-Disk/sesamefs/internal/config"
 	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
@@ -80,6 +81,9 @@ func addProvisionalBlockRefExpiryQueries(batch *gocql.Batch, orgID, blockID, ref
 // A zero/past expiresAt is rejected rather than silently written: an untracked
 // provisional reference is exactly the leak this function exists to prevent.
 func (db *DB) AddProvisionalBlockReferenceWithExpiry(orgID, blockID, referrer, libraryID, storageClass string, expiresAt time.Time) error {
+	if !config.IsCanonicalStorageClassName(storageClass) {
+		return fmt.Errorf("%w: non-canonical storage class %q for provisional block reference", ErrBlockMetadataPermanent, storageClass)
+	}
 	if db == nil {
 		return fmt.Errorf("add provisional block reference for org=%s block=%s referrer=%s: no database", orgID, blockID, referrer)
 	}

--- a/internal/gc/s3_orphan_recovery_test.go
+++ b/internal/gc/s3_orphan_recovery_test.go
@@ -165,7 +165,7 @@ func TestWorker_RecoverS3Orphans_Success(t *testing.T) {
 
 	orgID := uuid.New()
 	// Seed an orphan directly.
-	seedS3Orphan(t, store, orgID, "orph-1", " hot ", "", "earlier failure", time.Now())
+	seedS3Orphan(t, store, orgID, "orph-1", "hot", "", "earlier failure", time.Now())
 
 	recovered, err := w.RecoverS3Orphans(context.Background(), 100)
 	if err != nil {
@@ -180,6 +180,32 @@ func TestWorker_RecoverS3Orphans_Success(t *testing.T) {
 	deletes := sp.ScopedBlockDeletes()
 	if len(deletes) != 1 || deletes[0] != (ScopedBlockDelete{OrgID: orgID.String(), StorageClass: "hot", BlockID: "orph-1"}) {
 		t.Errorf("unexpected scoped S3 deletes: %+v", deletes)
+	}
+}
+
+func TestWorker_RecoverS3Orphans_NonCanonicalStorageClassFailsClosed(t *testing.T) {
+	store := NewMockStore()
+	sp := &MockStorageProvider{}
+	w := NewWorker(store, sp, NewQueue(store), 100, 0, false, &Stats{})
+
+	orgID := uuid.New()
+	seedS3Orphan(t, store, orgID, "orph-padded-class", " hot ", "", "earlier failure", time.Now())
+
+	recovered, err := w.RecoverS3Orphans(context.Background(), 100)
+	if err == nil {
+		t.Fatal("RecoverS3Orphans() error = nil, want non-canonical storage class error")
+	}
+	if recovered != 0 {
+		t.Fatalf("recovered = %d, want 0", recovered)
+	}
+	if store.S3OrphanCount() != 1 {
+		t.Fatal("orphan row must remain for repair/retry")
+	}
+	if got := sp.BlockStoreRequests(); len(got) != 0 {
+		t.Fatalf("storage must not be touched for non-canonical class, got %+v", got)
+	}
+	if got := sp.ScopedBlockDeletes(); len(got) != 0 {
+		t.Fatalf("S3 must not be touched for non-canonical class, got %+v", got)
 	}
 }
 

--- a/internal/gc/worker.go
+++ b/internal/gc/worker.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Sesame-Disk/sesamefs/internal/config"
 	"github.com/Sesame-Disk/sesamefs/internal/db"
 	"github.com/Sesame-Disk/sesamefs/internal/metrics"
 	gocql "github.com/apache/cassandra-gocql-driver/v2"
@@ -1085,7 +1086,7 @@ func (w *Worker) processBlock(ctx context.Context, item QueueItem) error {
 			return w.failClosedIfUnavailable("failed to load re-referenced block info", item.ItemID, infoErr)
 		}
 		if blockInfo.CreatedAt == nil {
-			if strings.TrimSpace(blockInfo.StorageClass) != "" {
+			if blockInfo.StorageClass != "" {
 				return fmt.Errorf("stub block %s has storage class without creation timestamp", item.ItemID)
 			}
 			// The owned claim fences writers. Remove only the metadata-free stub;
@@ -1131,7 +1132,7 @@ func (w *Worker) processBlock(ctx context.Context, item QueueItem) error {
 	if err != nil {
 		return w.failClosedIfUnavailable("failed to load canonical block info", item.ItemID, err)
 	}
-	storageClass := strings.TrimSpace(blockInfo.StorageClass)
+	storageClass := blockInfo.StorageClass
 	if storageClass == "" {
 		if blockInfo.CreatedAt == nil {
 			deleted, deleteErr := w.store.DeleteClaimedBlockStub(item.OrgID, item.ItemID, claimID)
@@ -1159,6 +1160,12 @@ func (w *Worker) processBlock(ctx context.Context, item QueueItem) error {
 			return relErr
 		}
 		return fmt.Errorf("block %s has empty canonical storage class", item.ItemID)
+	}
+	if !config.IsCanonicalStorageClassName(storageClass) {
+		if relErr := w.releaseBlockClaim(item.OrgID, item.ItemID, claimID); relErr != nil {
+			return relErr
+		}
+		return fmt.Errorf("block %s has non-canonical storage class %q", item.ItemID, storageClass)
 	}
 	if item.StorageClass != "" && item.StorageClass != storageClass {
 		log.Printf("[GC Worker] WARNING: block %s queued with storage_class=%s but canonical storage_class=%s; using canonical value", item.ItemID, item.StorageClass, storageClass)
@@ -1564,10 +1571,16 @@ func (w *Worker) RecoverS3Orphans(ctx context.Context, perBucketLimit int) (int,
 					continue
 				}
 
-				storageClass := strings.TrimSpace(canonicalCommit.StorageClass)
+				storageClass := canonicalCommit.StorageClass
 				if storageClass == "" {
 					if phaseErr == nil {
 						phaseErr = fmt.Errorf("S3 orphan recovery row has empty storage class for org=%s block=%s", canonicalCommit.OrgID, canonicalCommit.BlockID)
+					}
+					continue
+				}
+				if !config.IsCanonicalStorageClassName(storageClass) {
+					if phaseErr == nil {
+						phaseErr = fmt.Errorf("S3 orphan recovery row has non-canonical storage class %q for org=%s block=%s", storageClass, canonicalCommit.OrgID, canonicalCommit.BlockID)
 					}
 					continue
 				}
@@ -1653,9 +1666,9 @@ func s3OrphanRecoveryStateEqual(left, right S3OrphanInfo) bool {
 	return left.OrgID == right.OrgID &&
 		left.BlockID == right.BlockID &&
 		normalizeS3OrphanRecoveryTime(left.FirstSeenAt).Equal(normalizeS3OrphanRecoveryTime(right.FirstSeenAt)) &&
-		strings.TrimSpace(left.StorageClass) == strings.TrimSpace(right.StorageClass) &&
-		strings.TrimSpace(left.ExternalSHA1) == strings.TrimSpace(right.ExternalSHA1) &&
-		strings.TrimSpace(left.RecoveryPhase) == strings.TrimSpace(right.RecoveryPhase)
+		left.StorageClass == right.StorageClass &&
+		left.ExternalSHA1 == right.ExternalSHA1 &&
+		left.RecoveryPhase == right.RecoveryPhase
 }
 
 func (w *Worker) loadS3OrphansStartDay(cutoffDay time.Time) (time.Time, error) {

--- a/internal/gc/worker_test.go
+++ b/internal/gc/worker_test.go
@@ -329,7 +329,7 @@ func TestWorker_ProcessBlock_UsesCanonicalStorageClassForDeleteTracking(t *testi
 
 	orgID := uuid.New()
 	store.AddOrganization(orgID)
-	store.AddBlock(orgID, "block-canonical-cold", "cold-tier ", 0)
+	store.AddBlock(orgID, "block-canonical-cold", "cold-tier", 0)
 	queuedAt := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Millisecond)
 	if err := store.EnqueueItem(orgID, queuedAt, ItemBlock, "block-canonical-cold", uuid.Nil, "hot-tier", 0); err != nil {
 		t.Fatalf("EnqueueItem() error = %v", err)
@@ -352,6 +352,41 @@ func TestWorker_ProcessBlock_UsesCanonicalStorageClassForDeleteTracking(t *testi
 	deletes := sp.ScopedBlockDeletes()
 	if len(deletes) != 1 || deletes[0] != (ScopedBlockDelete{OrgID: orgID.String(), StorageClass: "cold-tier", BlockID: "block-canonical-cold"}) {
 		t.Fatalf("delete used queued rather than canonical scope: %+v", deletes)
+	}
+}
+
+// A stored class that is not canonical cannot name a physical namespace. The
+// block must stay put, the claim must come down so the fence does not outlive the
+// pass, and S3 must not be touched on a guess about what the label meant.
+func TestWorker_ProcessBlock_NonCanonicalStorageClassFailsClosed(t *testing.T) {
+	store := NewMockStore()
+	sp := &MockStorageProvider{}
+	w := NewWorker(store, sp, NewQueue(store), 100, 0, false, &Stats{})
+
+	orgID := uuid.New()
+	store.AddOrganization(orgID)
+	store.AddBlock(orgID, "blk-padded-class", " hot-tier", 0)
+	queuedAt := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Millisecond)
+	if err := store.EnqueueItem(orgID, queuedAt, ItemBlock, "blk-padded-class", uuid.Nil, " hot-tier", 0); err != nil {
+		t.Fatalf("EnqueueItem() error = %v", err)
+	}
+
+	if _, err := w.ProcessOnce(context.Background()); err != nil {
+		t.Fatalf("ProcessOnce() error = %v", err)
+	}
+
+	block := store.GetBlock(orgID, "blk-padded-class")
+	if block == nil {
+		t.Fatal("canonical row must survive a non-canonical storage class")
+	}
+	if block.GCState != "" || block.GCClaimID != "" {
+		t.Fatalf("claim must be released, got state=%q claim=%q", block.GCState, block.GCClaimID)
+	}
+	if got := sp.ScopedBlockDeletes(); len(got) != 0 {
+		t.Fatalf("S3 must not be touched for a non-canonical class, got %+v", got)
+	}
+	if got := store.AllS3Orphans(); len(got) != 0 {
+		t.Fatalf("no orphan may be recorded for a class that never resolved, got %+v", got)
 	}
 }
 

--- a/internal/storage/manager_test.go
+++ b/internal/storage/manager_test.go
@@ -3,8 +3,11 @@ package storage
 import (
 	"context"
 	"io"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/Sesame-Disk/sesamefs/internal/config"
 )
 
 // mockStore implements Store interface for testing
@@ -70,6 +73,30 @@ func TestManagerRegisterBackend(t *testing.T) {
 	}
 	if health.FailoverClass != "hot-s3-eu" {
 		t.Errorf("failover class = %s, want hot-s3-eu", health.FailoverClass)
+	}
+}
+
+func TestManagerResolvePhysicalStorageClassUsesTheCanonicalLabel(t *testing.T) {
+	m := NewManager()
+	m.RegisterBackend("hot-v1", &mockStore{accessType: AccessImmediate}, "hot-v2")
+	m.RegisterBackend("hot-v2", &mockStore{accessType: AccessImmediate}, "")
+
+	got, err := m.ResolvePhysicalStorageClass("hot-v1")
+	if err != nil {
+		t.Fatalf("ResolvePhysicalStorageClass returned error: %v", err)
+	}
+	if got != "hot-v1" {
+		t.Fatalf("physical storage class = %q, want %q", got, "hot-v1")
+	}
+
+	if _, err := m.ResolvePhysicalStorageClass(" hot-v1"); err == nil {
+		t.Fatal("ResolvePhysicalStorageClass accepted a non-canonical class with surrounding whitespace")
+	}
+	if _, err := m.ResolvePhysicalStorageClass("Hot-v1"); err == nil {
+		t.Fatal("ResolvePhysicalStorageClass accepted an uppercase class")
+	}
+	if _, err := m.ResolvePhysicalStorageClass("missing"); err == nil {
+		t.Fatal("ResolvePhysicalStorageClass accepted an unknown class")
 	}
 }
 
@@ -262,6 +289,19 @@ func TestManagerGetHealthyBackend(t *testing.T) {
 			t.Error("expected error for nonexistent backend")
 		}
 	})
+}
+
+func TestManagerGetHealthyBackendRejectsFailoverCycle(t *testing.T) {
+	m := NewManager()
+	m.RegisterBackend("hot-s3-usa", &mockStore{accessType: AccessImmediate}, "hot-s3-eu")
+	m.RegisterBackend("hot-s3-eu", &mockStore{accessType: AccessImmediate}, "hot-s3-usa")
+	m.UpdateHealth("hot-s3-usa", HealthUnhealthy, nil)
+	m.UpdateHealth("hot-s3-eu", HealthUnhealthy, nil)
+
+	_, _, err := m.GetHealthyBackend("hot-s3-usa")
+	if err == nil || !strings.Contains(err.Error(), "failover cycle") {
+		t.Fatalf("GetHealthyBackend() error = %v, want failover cycle error", err)
+	}
 }
 
 func TestManagerCheckHealth(t *testing.T) {
@@ -633,5 +673,26 @@ func TestGetHealthyBlockStoreForOrg_FailoverCachesCanonicalStore(t *testing.T) {
 	}
 	if bs1 != bs2 {
 		t.Fatal("repeated healthy lookup should reuse the cached BlockStore")
+	}
+}
+
+// The resolver and configuration validation must apply one canon, so a class
+// name cannot certify at one layer and fail at the other.
+func TestResolvePhysicalStorageClassSharesTheConfigCanon(t *testing.T) {
+	m := NewManager()
+	m.RegisterBackend("hot-v1", &S3Store{}, "")
+	// Registered out of band, bypassing configuration validation.
+	m.RegisterBackend("hot_v1", &S3Store{}, "")
+
+	if got, err := m.ResolvePhysicalStorageClass("hot-v1"); err != nil || got != "hot-v1" {
+		t.Fatalf("ResolvePhysicalStorageClass(canonical) = (%q, %v), want (\"hot-v1\", nil)", got, err)
+	}
+	for _, name := range []string{"hot_v1", " hot-v1", "Hot-V1", ""} {
+		if _, err := m.ResolvePhysicalStorageClass(name); err == nil {
+			t.Errorf("ResolvePhysicalStorageClass(%q) error = nil, want a non-canonical or missing-class rejection", name)
+		}
+	}
+	if config.IsCanonicalStorageClassName("hot_v1") {
+		t.Error("test premise broken: hot_v1 is not supposed to be canonical")
 	}
 }

--- a/internal/storage/manager_test.go
+++ b/internal/storage/manager_test.go
@@ -133,6 +133,7 @@ func TestManagerResolveStorageClass(t *testing.T) {
 		libraryClass string
 		tier         string
 		want         string
+		wantErr      bool
 	}{
 		{
 			name:     "USA endpoint hot",
@@ -172,11 +173,12 @@ func TestManagerResolveStorageClass(t *testing.T) {
 			want:         "hot-s3-eu",
 		},
 		{
-			name:         "Invalid library falls back",
+			name:         "Invalid library returns an error",
 			hostname:     "us.sesamefs.com",
 			libraryClass: "nonexistent",
 			tier:         "hot",
-			want:         "hot-s3-usa",
+			want:         "",
+			wantErr:      true,
 		},
 		{
 			name:     "localhost",
@@ -188,7 +190,16 @@ func TestManagerResolveStorageClass(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := m.ResolveStorageClass(tt.hostname, tt.libraryClass, tt.tier)
+			got, err := m.ResolveStorageClass(tt.hostname, tt.libraryClass, tt.tier)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("ResolveStorageClass accepted an unregistered explicit library class")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveStorageClass returned error: %v", err)
+			}
 			if got != tt.want {
 				t.Errorf("ResolveStorageClass(%s, %s, %s) = %s, want %s",
 					tt.hostname, tt.libraryClass, tt.tier, got, tt.want)
@@ -202,7 +213,10 @@ func TestManagerResolveStorageClass(t *testing.T) {
 			"*": "usa",
 		})
 		m.SetLocalRegion("eu")
-		got := m.ResolveStorageClass("files.sesamefs.com", "", "hot")
+		got, err := m.ResolveStorageClass("files.sesamefs.com", "", "hot")
+		if err != nil {
+			t.Fatalf("ResolveStorageClass returned error: %v", err)
+		}
 		if got != "hot-s3-eu" {
 			t.Fatalf("ResolveStorageClass local fallback = %q, want %q", got, "hot-s3-eu")
 		}
@@ -214,7 +228,10 @@ func TestManagerResolveStorageClass(t *testing.T) {
 			"*.sesamefs.com": "usa",
 			"*":              "usa",
 		})
-		got := m.ResolveStorageClass("files.sesamefs.com", "", "hot")
+		got, err := m.ResolveStorageClass("files.sesamefs.com", "", "hot")
+		if err != nil {
+			t.Fatalf("ResolveStorageClass returned error: %v", err)
+		}
 		if got != "hot-s3-usa" {
 			t.Fatalf("ResolveStorageClass wildcard override = %q, want %q", got, "hot-s3-usa")
 		}
@@ -226,7 +243,10 @@ func TestManagerResolveStorageClass(t *testing.T) {
 			" *.sesamefs.com ": "usa",
 			"*":                "eu",
 		})
-		got := m.ResolveStorageClass("files.sesamefs.com", "", "hot")
+		got, err := m.ResolveStorageClass("files.sesamefs.com", "", "hot")
+		if err != nil {
+			t.Fatalf("ResolveStorageClass returned error: %v", err)
+		}
 		if got != "hot-s3-usa" {
 			t.Fatalf("ResolveStorageClass spaced wildcard = %q, want %q", got, "hot-s3-usa")
 		}
@@ -238,7 +258,10 @@ func TestManagerResolveStorageClass(t *testing.T) {
 			"us.sesamefs.com": "usa",
 			"*":               "usa",
 		})
-		got := m.ResolveStorageClass("us.sesamefs.com", "", "hot")
+		got, err := m.ResolveStorageClass("us.sesamefs.com", "", "hot")
+		if err != nil {
+			t.Fatalf("ResolveStorageClass returned error: %v", err)
+		}
 		if got != "hot-s3-usa" {
 			t.Fatalf("ResolveStorageClass exact override = %q, want %q", got, "hot-s3-usa")
 		}

--- a/internal/storage/manager_test.go
+++ b/internal/storage/manager_test.go
@@ -195,6 +195,9 @@ func TestManagerResolveStorageClass(t *testing.T) {
 				if err == nil {
 					t.Fatal("ResolveStorageClass accepted an unregistered explicit library class")
 				}
+				if got != "" {
+					t.Fatalf("ResolveStorageClass returned invalid class %q with error", got)
+				}
 				return
 			}
 			if err != nil {
@@ -266,6 +269,19 @@ func TestManagerResolveStorageClass(t *testing.T) {
 			t.Fatalf("ResolveStorageClass exact override = %q, want %q", got, "hot-s3-usa")
 		}
 	})
+}
+
+func TestManagerResolveStorageClassRejectsNonCanonicalLastResortBackend(t *testing.T) {
+	m := NewManager()
+	m.RegisterBackend("hot_v1", &mockStore{accessType: AccessImmediate}, "")
+
+	got, err := m.ResolveStorageClass("", "", "hot")
+	if err == nil {
+		t.Fatalf("ResolveStorageClass returned %q for a non-canonical fallback backend", got)
+	}
+	if got != "" {
+		t.Fatalf("ResolveStorageClass returned invalid class %q with error", got)
+	}
 }
 
 func TestManagerGetHealthyBackend(t *testing.T) {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -332,9 +332,9 @@ func (m *Manager) ResolveStorageClass(hostname string, libraryClass string, tier
 		return m.resolveRegisteredStorageClass(m.defaultClass, "default")
 	}
 
-	// 5. Last resort: return first available backend
+	// 5. Last resort: validate the first available backend
 	for name := range m.backends {
-		return name, nil
+		return m.resolveRegisteredStorageClass(name, "fallback")
 	}
 
 	return "", fmt.Errorf("no storage class is registered")
@@ -345,7 +345,7 @@ func (m *Manager) resolveRegisteredStorageClass(className, source string) (strin
 		return "", fmt.Errorf("%s storage class %q is not canonical", source, className)
 	}
 	if _, ok := m.backends[className]; !ok {
-		return className, fmt.Errorf("%s storage class %q is not registered", source, className)
+		return "", fmt.Errorf("%s storage class %q is not registered", source, className)
 	}
 	return className, nil
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -299,15 +299,19 @@ func (m *Manager) GetHealthyBackend(preferredClass string) (Store, string, error
 	return nil, "", fmt.Errorf("no healthy backend available for class %s", preferredClass)
 }
 
-// ResolveStorageClass determines the storage class based on context
-// Priority: library override > endpoint region > default
-func (m *Manager) ResolveStorageClass(hostname string, libraryClass string, tier string) string {
-	// 1. Library override takes precedence
+// ResolveStorageClass determines the storage class based on context.
+// Priority: library override > endpoint region > default. An explicit library
+// class is persisted placement metadata, so it must be registered exactly as
+// stored; only an empty library class may use routing/default selection.
+func (m *Manager) ResolveStorageClass(hostname string, libraryClass string, tier string) (string, error) {
+	if m == nil {
+		return "", fmt.Errorf("storage manager is nil")
+	}
+
+	// 1. Library override takes precedence and never falls back. The raw label
+	// is the physical namespace identity used by R23a.
 	if libraryClass != "" {
-		if _, ok := m.backends[libraryClass]; ok {
-			return libraryClass
-		}
-		log.Printf("Warning: library storage class %s not found, falling back", libraryClass)
+		return m.resolveRegisteredStorageClass(libraryClass, "library")
 	}
 
 	// 2. Resolve region from hostname
@@ -316,24 +320,34 @@ func (m *Manager) ResolveStorageClass(hostname string, libraryClass string, tier
 	// 3. Get class for region and tier
 	if regionConfig, ok := m.regionClasses[region]; ok {
 		if tier == "cold" && regionConfig.Cold != "" {
-			return regionConfig.Cold
+			return m.resolveRegisteredStorageClass(regionConfig.Cold, "region")
 		}
 		if regionConfig.Hot != "" {
-			return regionConfig.Hot
+			return m.resolveRegisteredStorageClass(regionConfig.Hot, "region")
 		}
 	}
 
 	// 4. Fallback to default
 	if m.defaultClass != "" {
-		return m.defaultClass
+		return m.resolveRegisteredStorageClass(m.defaultClass, "default")
 	}
 
 	// 5. Last resort: return first available backend
 	for name := range m.backends {
-		return name
+		return name, nil
 	}
 
-	return ""
+	return "", fmt.Errorf("no storage class is registered")
+}
+
+func (m *Manager) resolveRegisteredStorageClass(className, source string) (string, error) {
+	if !config.IsCanonicalStorageClassName(className) {
+		return "", fmt.Errorf("%s storage class %q is not canonical", source, className)
+	}
+	if _, ok := m.backends[className]; !ok {
+		return className, fmt.Errorf("%s storage class %q is not registered", source, className)
+	}
+	return className, nil
 }
 
 // ResolveEndpointRegion resolves a request hostname to a configured region.

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Sesame-Disk/sesamefs/internal/config"
 )
 
 // AccessType defines whether storage is immediately accessible or requires retrieval
@@ -232,6 +234,26 @@ func (m *Manager) GetBackend(name string) (Store, bool) {
 	return store, ok
 }
 
+// ResolvePhysicalStorageClass validates the canonical class that names a
+// physical namespace. R23a deliberately uses storage_class itself as B, so
+// this resolver never follows failover or rewrites the label. Callers that
+// selected a backend through GetHealthyBackend must pass its returned class.
+func (m *Manager) ResolvePhysicalStorageClass(className string) (string, error) {
+	if className == "" {
+		return "", fmt.Errorf("storage class is empty")
+	}
+	// Same canon as configuration validation, from one definition, so a name
+	// cannot certify at one layer and fail at the other. This resolver also
+	// vets classes read back from persisted rows, not just configured ones.
+	if !config.IsCanonicalStorageClassName(className) {
+		return "", fmt.Errorf("storage class %q is not canonical", className)
+	}
+	if _, ok := m.backends[className]; !ok {
+		return "", fmt.Errorf("storage class %s not found", className)
+	}
+	return className, nil
+}
+
 // GetHealthyBackend returns a healthy backend for the given class, with failover
 func (m *Manager) GetHealthyBackend(preferredClass string) (Store, string, error) {
 	// Fall back to default class if empty
@@ -239,8 +261,22 @@ func (m *Manager) GetHealthyBackend(preferredClass string) (Store, string, error
 		preferredClass = m.defaultClass
 	}
 
-	// Try preferred class first
-	if store, ok := m.backends[preferredClass]; ok {
+	// Failover configurations commonly form a cycle so either region can be
+	// primary. Walk iteratively with a visited set: when every member of that
+	// cycle is unhealthy, return an error instead of exhausting the goroutine
+	// stack while trying the same classes forever.
+	visited := make(map[string]struct{})
+	for {
+		if _, seen := visited[preferredClass]; seen {
+			return nil, "", fmt.Errorf("storage failover cycle detected at class %s", preferredClass)
+		}
+		visited[preferredClass] = struct{}{}
+
+		// Try preferred class first
+		store, ok := m.backends[preferredClass]
+		if !ok {
+			break
+		}
 		m.healthMu.RLock()
 		health := m.health[preferredClass]
 		m.healthMu.RUnlock()
@@ -253,8 +289,10 @@ func (m *Manager) GetHealthyBackend(preferredClass string) (Store, string, error
 		if health.FailoverClass != "" {
 			log.Printf("Storage class %s is %s, trying failover to %s",
 				preferredClass, health.Status, health.FailoverClass)
-			return m.GetHealthyBackend(health.FailoverClass)
+			preferredClass = health.FailoverClass
+			continue
 		}
+		break
 	}
 
 	// No backend found
@@ -480,7 +518,11 @@ func (m *Manager) GetBlockStoreForOrg(orgID, className string) (*BlockStore, err
 	if err != nil {
 		return nil, err
 	}
-	key := blockStoreKey{orgID: normalizedOrgID, class: className}
+	physicalClass, err := m.ResolvePhysicalStorageClass(className)
+	if err != nil {
+		return nil, err
+	}
+	key := blockStoreKey{orgID: normalizedOrgID, class: physicalClass}
 
 	// Check cache first.
 	m.blockStoresMu.RLock()
@@ -490,15 +532,15 @@ func (m *Manager) GetBlockStoreForOrg(orgID, className string) (*BlockStore, err
 	}
 	m.blockStoresMu.RUnlock()
 
-	store, ok := m.backends[className]
+	store, ok := m.backends[physicalClass]
 	if !ok {
-		return nil, fmt.Errorf("storage class %s not found", className)
+		return nil, fmt.Errorf("storage class %s not found", physicalClass)
 	}
 
 	// Cast to S3Store (BlockStore requires S3Store)
 	s3Store, ok := store.(*S3Store)
 	if !ok {
-		return nil, fmt.Errorf("storage class %s is not an S3 backend", className)
+		return nil, fmt.Errorf("storage class %s is not an S3 backend", physicalClass)
 	}
 
 	bs, err := NewOrgBlockStore(s3Store, "blocks/", normalizedOrgID)
@@ -529,19 +571,23 @@ func (m *Manager) GetHealthyBlockStoreForOrg(orgID, preferredClass string) (*Blo
 	if err != nil {
 		return nil, "", err
 	}
+	physicalClass, err := m.ResolvePhysicalStorageClass(actualClass)
+	if err != nil {
+		return nil, "", err
+	}
 
 	// Cast to S3Store
 	s3Store, ok := store.(*S3Store)
 	if !ok {
-		return nil, "", fmt.Errorf("storage class %s is not an S3 backend", actualClass)
+		return nil, "", fmt.Errorf("storage class %s is not an S3 backend", physicalClass)
 	}
 
-	key := blockStoreKey{orgID: normalizedOrgID, class: actualClass}
+	key := blockStoreKey{orgID: normalizedOrgID, class: physicalClass}
 
 	m.blockStoresMu.RLock()
 	if bs, ok := m.blockStoresByOrg[key]; ok {
 		m.blockStoresMu.RUnlock()
-		return bs, actualClass, nil
+		return bs, physicalClass, nil
 	}
 	m.blockStoresMu.RUnlock()
 
@@ -553,9 +599,9 @@ func (m *Manager) GetHealthyBlockStoreForOrg(orgID, preferredClass string) (*Blo
 	m.blockStoresMu.Lock()
 	defer m.blockStoresMu.Unlock()
 	if existing, ok := m.blockStoresByOrg[key]; ok {
-		return existing, actualClass, nil
+		return existing, physicalClass, nil
 	}
 
 	m.blockStoresByOrg[key] = bs
-	return bs, actualClass, nil
+	return bs, physicalClass, nil
 }

--- a/internal/streaming/canonical_block_reader.go
+++ b/internal/streaming/canonical_block_reader.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Sesame-Disk/sesamefs/internal/config"
 	"github.com/Sesame-Disk/sesamefs/internal/db"
 	"github.com/Sesame-Disk/sesamefs/internal/storage"
 	"golang.org/x/sync/errgroup"
@@ -215,6 +216,9 @@ dispatchLocations:
 			storageClass := metadata.StorageClass
 			if storageClass == "" {
 				return fmt.Errorf("canonical storage class is empty for block %s", blockID)
+			}
+			if !config.IsCanonicalStorageClassName(storageClass) {
+				return fmt.Errorf("canonical storage class %q for block %s is not canonical", storageClass, blockID)
 			}
 
 			var store *storage.BlockStore

--- a/internal/streaming/canonical_block_reader.go
+++ b/internal/streaming/canonical_block_reader.go
@@ -203,7 +203,7 @@ dispatchLocations:
 				return fmt.Errorf("canonical block %s has unknown gc state %q", blockID, metadata.GCState)
 			}
 			if metadata.CreatedAt == nil {
-				if !strictRead && strings.TrimSpace(metadata.StorageClass) == "" {
+				if !strictRead && metadata.StorageClass == "" {
 					mu.Lock()
 					reader.locations[blockID] = canonicalBlockLocation{missing: true}
 					mu.Unlock()
@@ -212,7 +212,7 @@ dispatchLocations:
 				return fmt.Errorf("canonical block %s has storage metadata without a creation timestamp", blockID)
 			}
 
-			storageClass := strings.TrimSpace(metadata.StorageClass)
+			storageClass := metadata.StorageClass
 			if storageClass == "" {
 				return fmt.Errorf("canonical storage class is empty for block %s", blockID)
 			}
@@ -224,7 +224,7 @@ dispatchLocations:
 				if err != nil {
 					return fmt.Errorf("resolve canonical storage class %q for block %s: %w", storageClass, blockID, err)
 				}
-			case fallback != nil && storageClass == strings.TrimSpace(fallbackClass):
+			case fallback != nil && fallbackClass != "" && storageClass == fallbackClass:
 				store = fallback
 			default:
 				return fmt.Errorf("canonical storage class %q for block %s is unavailable", storageClass, blockID)

--- a/internal/streaming/canonical_block_reader_test.go
+++ b/internal/streaming/canonical_block_reader_test.go
@@ -679,6 +679,20 @@ func TestCanonicalBlockReaderExactClassAndBackendErrorsFailClosed(t *testing.T) 
 	}
 }
 
+func TestCanonicalBlockReaderRejectsNonCanonicalFallbackIdentity(t *testing.T) {
+	resetCanonicalReaderHooks(t)
+	blockID := canonicalReaderTestID(750)
+	store := canonicalReaderTestStore(t)
+	canonicalBlockLocationLookup = func(context.Context, *db.DB, string, string) (db.BlockStorageLocation, bool, error) {
+		return db.BlockStorageLocation{StorageClass: "CANONICAL", CreatedAt: canonicalReaderTestCreatedAt()}, true, nil
+	}
+
+	reader, err := NewCanonicalBlockReader(context.Background(), nil, nil, canonicalReaderTestOrg, []string{blockID}, store, "CANONICAL")
+	if reader != nil || err == nil || !strings.Contains(err.Error(), "not canonical") {
+		t.Fatalf("non-canonical fallback identity = (%v, %v), want rejection", reader, err)
+	}
+}
+
 func TestCanonicalBlockReaderExistenceBackendErrorFailsClosed(t *testing.T) {
 	resetCanonicalReaderHooks(t)
 	blockID := canonicalReaderTestID(800)


### PR DESCRIPTION
R23a adopts a persisted `storage_class` as the **candidate physical namespace identity `B`** and hardens every layer that declares, admits, persists or resolves a class so the value is preserved exactly.

> **Scope, stated up front:** this is identity *hardening*, not a proven binding. R23a does **not** bind a class name durably to the namespace it was first used with, so `B = storage_class` remains a contract operators assert rather than one the system enforces. R23 is marked **PARTIAL** in the risk matrix; closing it is R23b. See the Scope section below.

`IsCanonicalStorageClassName` is the single definition, shared by configuration validation and the storage runtime. It checks the **RAW** value: runtime resolution is an exact map lookup, so a validator that trimmed or folded first would be more permissive than the thing it certifies.

## Configuration

- Declared class and legacy backend names must be canonical, and a name may not appear in both maps. That collision is not cosmetic: a class whose `initStorageClass` fails is skipped with a warning and the legacy loop then binds the same name to the legacy bucket, so **one transient boot failure rebinds a persisted identity to another namespace**.
- Every field that *references* a class — `default_class`, each `failover_class`, `region_classes.*.hot/cold` — must name one that actually resolves. `failover_class` is the sharp case: a typo there breaks nothing until the primary is down, which is precisely when it is needed.
- A class is "resolvable" only if it can be *registered*, which requires a non-empty bucket, matching `initStorageClass`. This applies to every **declared** class, not only referenced ones.
- Canonical names disallow consecutive hyphens, which would otherwise collapse to one `S3_CLASS_<CLASS>_*` environment prefix and let a single variable configure two supposedly distinct identities.

## Admission

- Library create/change, org storage policy and bootstrap admission apply the same raw rule, and the bootstrap picker no longer offers a class the manager cannot register.
- Admission decides on the **raw** request. Trimming first would accept `" hot-v1 "` at create and persist it as `hot-v1` while `ChangeStorageClass` refuses that same value — two doors onto one field disagreeing about what it means. `storageClassRegion`, whose only caller decides data residency, compares raw too.

## Persistence

- `UpsertBlockMetadataWithRepresentationAndSHA1` rejects a non-canonical class as a **permanent** error instead of normalizing it, and `ProbeBlockReuse` rejects one it reads back. Normalizing would persist an identity the writer never named.
- The argument is not the only thing that must be canonical. When the `IF NOT EXISTS` insert loses, the caller **inherits** the identity already on the row, so `ensureBlockIdentityRow` checks the stored class as well. Otherwise an upsert carrying a canonical class returns `nil` over a row whose class `ProbeBlockReuse` and GC both refuse — finishing an upload whose metadata no reader can resolve. Permanent, not transient: unlike a claim or a stub, a corrupt label never converges.
- **The first writer mints the identity.** `ResolveNeedsPutBlockStore` returns the class that gets persisted, and it certifies rather than normalizes — before the PUT, not after. The object is stored before materialization, so a class rejected downstream would leave bytes in S3 that no row points at.

## Resolution

- `ResolvePhysicalStorageClass` vets the class that names a physical namespace, never following failover and never rewriting the label; the org block-store lookups go through it.
- Readers resolve the raw stored value. The trims in GC, canonical block reading, upload reuse, the sync block-lookup resolvers and `loadZeroRefBlockStorageClasses` are gone: trimming resolves a label the writer never persisted, which is **a silent rebind performed by the reader**. GC's orphan-recovery state comparison is now as strict as the resolver it protects, and the two no-manager fallbacks compare raw on both sides instead of against a trimmed copy of their own label.
- `GetHealthyBackend` walks failover iteratively with a visited set. Shipped multi-region configs form an A↔B failover cycle, so with both backends unhealthy the previous recursion exhausted the stack — a crash during exactly the outage failover exists for.

## ⚠️ Deployment note

**Every class declared under `storage.classes` must now provide a bucket**, not only the ones something references. `configs/config.prod.yaml` declares `hot-s3-na`, `hot-s3-eu` and `hot-s3-asia` with empty buckets that deployment fills through `S3_CLASS_<CLASS>_BUCKET`.

A node that sets only some of them **now refuses to start**, instead of booting without the missing class and failing every request routed to it. Provide a bucket for each declared class, or remove the class the deployment does not use. All three are listed in `.env.prod.example`.

## Scope: what this does not close

An operator rebinding an already-deployed name to another namespace, or reusing a decommissioned one. **Neither is prevented, and both silently retarget a persisted identity.**

An earlier revision of this PR argued that no-rebind was "largely self-enforcing" because repointing a class makes every block unreadable at once — a loud outage. **That argument does not hold** and has been removed. It fails on the most likely rebind: copy bucket A to B, then repoint. Reads keep working; nothing is loud. And "the system will probably make noise" is not a safety property — observability is not revocation of authority, and the rule on a destructive path is *when in doubt, do not delete*.

What actually makes a migration rebind survivable is narrower, and stating it shows where it stops working: `hashToKey` derives `blocks/<org_id>/<h[0:2]>/<h[2:4]>/<hash>` with **no namespace component**, and liveness lives in Cassandra rather than in the bucket. So an object at key `K` for a given org is byte-identical content in whatever namespace it sits, and the garbage verdict that produced a `gc_s3_orphans` row still describes that content after the rebind — a misdirected delete removes the same condemned bytes. That is **an accident of key derivation, not a design property**, and it runs out the moment the new namespace answers to a different liveness authority. Which is exactly the reuse case, and a rebind onto a bucket shared with another cluster.

**R23b** must record a durable per-class namespace fingerprint (never deleted, no TTL), re-checked fail-closed, and persist the exact `storage_key` to form `P = (storage_class, storage_key)`. See `docs/GC-X1-CLOSURE-OPTIONS.md` R23.

No schema migration, storage-key change, or GC protocol change in this PR.

## Verification

| Check | Result |
|---|---|
| `go build ./...` | ✅ |
| `go vet ./...` | ✅ clean |
| `go test -count=1 ./...` | ✅ full suite green |
| `gofmt` (CRLF-normalized copies) | ✅ clean on every changed file |

New tests cover the identity rules rather than the wiring: shipped configs are loaded through the **real** validator (`TestShippedConfigsResolveEveryStorageClassReference` — the only thing that catches a `failover_class` typo), the failover cycle, GC failing closed *and releasing its claim* on a non-canonical class, the write/probe/inherited-row/first-writer refusals, and the YAML-merge behavior that makes a modern `hot` class collide with the shipped legacy backend. Every admission and inheritance test was confirmed to fail without its fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
